### PR TITLE
travis: Fix docker image naming

### DIFF
--- a/ci/travis-image-name.sh
+++ b/ci/travis-image-name.sh
@@ -1,10 +1,2 @@
 #!/bin/sh
-
-# Build docker image name
-img="sociomantictsunami/$(basename $TRAVIS_REPO_SLUG):ci"
-if test "$TRAVIS_PULL_REQUEST" != "false"
-then
-    echo "$img-$TRAVIS_BRANCH"
-else
-    echo "$img-$TRAVIS_PULL_REQUEST"
-fi
+echo "sociomantictsunami/$(basename $TRAVIS_REPO_SLUG):ci-$TRAVIS_BRANCH"


### PR DESCRIPTION
The name for the docker image for PRs was wrongly set as the branch
image, and images for push builds where plain wrong (:ci-false).

This commit fixes that and makes pulling of images smarter for PRs. If
a PR image doesn't exist already, the base branch image will be fetched
instead (and tagged as the PR image). Since docker image building
scripts are very unlikely to change, the base branch image will probably
be the same as the PR image anyway, so it will be used as a cache.