### PR TITLE
travis: Don't push docker images when building tags

### DIFF
--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -11,7 +11,7 @@ docker build --pull -t "$img" .
 
 # And pushing will also be very fast (done only if there are valid credentials)
 set +x # No peeking of password!
-if test -n "$DOCKER_PASSWORD"
+if test -n "$DOCKER_PASSWORD" -a -z "$TRAVIS_TAG" # Don't push tags
 then
     docker login -u"$DOCKER_USERNAME" -p"$DOCKER_PASSWORD"
     set -x


### PR DESCRIPTION
There is no easy way to identify which branch a tag belongs to (and it
might not belong to any), and saving images of tags as a cache makes no
sense at all, so just avoid pushing images of tag builds.

This was already added to v2.6.x, but we need it in previous branches
for patch releases.