### PR TITLE
Disable flaky integration test

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -52,6 +52,11 @@ TEST_FILTER_OUT += \
 # This is an integration test that depends on Collectd -- Don't run it
 TEST_FILTER_OUT += $C/test/collectd/main.d
 
+# integration test which is temporarily disabled due to flakiness
+# to be fixed and re-enabled
+TEST_FILTER_OUT += \
+	$C/test/signalfd/main.d 
+
 $O/test-filesystemevent: override LDFLAGS += -lrt
 
 $O/test-selectlistener: override LDFLAGS += -lebtree


### PR DESCRIPTION
To be fixed and re-enabled (see #25).