### PR TITLE
Fix flaky connect tests

### DIFF
--- a/test/unixlistener/main.d
+++ b/test/unixlistener/main.d
@@ -60,13 +60,8 @@ void writeToClient( cstring socket_path, cstring command )
     auto socket_fd = client.socket();
     enforce(socket_fd >= 0, "socket() call failed!");
 
-    int connect_result = ECONNREFUSED;
-    for (int i = 0; i < 5 && connect_result == ECONNREFUSED; i++)
-    {
-        Thread.sleep(seconds(0.5));
-        connect_result = client.connect(&local_address);
-    }
-    enforce(connect_result == 0, "connect() call failed after 5 tries!");
+    auto connect_result = client.connect(&local_address);
+    enforce(connect_result == 0, "connect() call failed.");
 
     client.write(command);
 }

--- a/test/unixsocket/main.d
+++ b/test/unixsocket/main.d
@@ -57,17 +57,8 @@ int runClient ( sockaddr_un* socket_address )
 
     auto connect_result = client.connect(socket_address);
 
-    // Try to connect at most 5 times, do a simple backoff if the connection
-    // fails to increase the time linearly (the sum of all retries is ~1.5s)
-    int i;
-    for (i = 1; i <= 5 && connect_result == ECONNREFUSED; i++)
-    {
-        Thread.sleep(seconds(0.1 * i));
-        connect_result = client.connect(socket_address);
-    }
-
-    enforce(i <= 5 && connect_result == 0,
-            "connect() call failed after 5 retries!");
+    enforce(connect_result == 0,
+            "connect() call failed");
 
     // send some data
     client.write(CLIENT_STRING);
@@ -113,16 +104,6 @@ int main ( )
 
     auto socket_address = sockaddr_un.create(socket_path);
 
-    pid_t pid = fork();
-
-    enforce(pid != -1);
-
-    if (pid == 0)  // client
-    {
-        in_child = true;
-        return runClient(&socket_address);
-    }
-
     auto server = new UnixSocket();
 
     // close the socket
@@ -134,17 +115,31 @@ int main ( )
     auto bind_result = server.bind(&socket_address);
     enforce(bind_result == 0, "bind() call failed!");
 
+    int backlog = 10;
+
+    auto listen_result = server.listen(backlog);
+    enforce(listen_result == 0, "listen() call failed!");
+
+    // Since the process already called bind and listen,
+    // it is safe to connect from a child process.
+    // NOTE: even though child process inherits the listening socket,
+    // unless it `accept`s, no connect() attempts will be redirected to it
+    pid_t pid = fork();
+
+    enforce(pid != -1);
+
+    if (pid == 0)  // client
+    {
+        in_child = true;
+        return runClient(&socket_address);
+    }
+
     scope (exit)
     {
         auto r = unlink(socket_path.ptr);
         assert(r == 0, "Couldn't remove the socket file " ~ socket_path ~
                 ": " ~ StringC.toDString(strerror(errno)));
     }
-
-    int backlog = 10;
-
-    auto listen_result = server.listen(backlog);
-    enforce(listen_result == 0, "listen() call failed!");
 
     int connection_fd;
 


### PR DESCRIPTION
Previously, the client process was created before the server process
was guaranteed to call bind/listen. Because of this, the tests were
flaky, since the connect() could be called before bind()/listen()
was done. This forks after bind/listen (which is necessary for
setting a backlog on a socket), so the connect() is guaranteed to be
ready to be called.

Note that, although forked process in this case inherits server socket,
unless it `accept`'s, no connect() attempts will be redirected to it.
