### PR TITLE
Fix license and copyright strings for modules under `test/`

### DIFF
--- a/test/collectd/main.d
+++ b/test/collectd/main.d
@@ -8,7 +8,7 @@
     to, and run it.
 
     Copyright:
-        Copyright (c) 2015-2016 Sociomantic Labs GmbH.
+        Copyright (c) 2015-2017 sociomantic labs GmbH.
         All rights reserved.
 
     License:

--- a/test/filesystemevent/main.d
+++ b/test/filesystemevent/main.d
@@ -2,7 +2,14 @@
 
     Unittest for FileSystemEvent.
 
-    Copyright:      Copyright (c) 2014 sociomantic labs. All rights reserved
+    Copyright:
+        Copyright (c) 2014-2017 sociomantic labs GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+        Alternatively, this file may be distributed under the terms of the Tango
+        3-Clause BSD License (see LICENSE_BSD.txt for details).
 
 *******************************************************************************/
 

--- a/test/loggerstats/main.d
+++ b/test/loggerstats/main.d
@@ -2,7 +2,14 @@
 
     Tests the Log.stats() API
 
-    Copyright:      Copyright (c) 2016 sociomantic labs. All rights reserved
+    Copyright:
+        Copyright (c) 2016-2017 sociomantic labs GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+        Alternatively, this file may be distributed under the terms of the Tango
+        3-Clause BSD License (see LICENSE_BSD.txt for details).
 
 *******************************************************************************/
 

--- a/test/selectlistener/UnixServer.d
+++ b/test/selectlistener/UnixServer.d
@@ -2,7 +2,14 @@
 
     Sample unix socket server, which is based on fiber select listener.
 
-    Copyright:      Copyright (c) 2016 sociomantic labs. All rights reserved
+    Copyright:
+        Copyright (c) 2016-2017 sociomantic labs GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+        Alternatively, this file may be distributed under the terms of the Tango
+        3-Clause BSD License (see LICENSE_BSD.txt for details).
 
 *******************************************************************************/
 

--- a/test/selectlistener/main.d
+++ b/test/selectlistener/main.d
@@ -8,7 +8,14 @@
     various system calls (fork(), waitpid(), epoll_wait(), epoll_ctl(), etc)
     which could, under certain environmental conditions, fail.
 
-    Copyright:      Copyright (c) 2016 sociomantic labs. All rights reserved
+    Copyright:
+        Copyright (c) 2016-2017 sociomantic labs GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+        Alternatively, this file may be distributed under the terms of the Tango
+        3-Clause BSD License (see LICENSE_BSD.txt for details).
 
 *******************************************************************************/
 

--- a/test/signalfd/main.d
+++ b/test/signalfd/main.d
@@ -1,13 +1,20 @@
 /*******************************************************************************
 
-    Copyright:      Copyright (c) 2014 sociomantic labs. All rights reserved
-
     Unittests for SignalFD. The tests involve signals (obviously) and forking
     processes, so are placed in this slowtest module.
 
     FLAKY: the unittests in this module are very flaky, as they rely on making
     various system calls (fork(), waitpid(), epoll_wait(), epoll_ctl(), etc)
     which could, under certain environmental conditions, fail.
+
+    Copyright:
+        Copyright (c) 2014-2017 sociomantic labs GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+        Alternatively, this file may be distributed under the terms of the Tango
+        3-Clause BSD License (see LICENSE_BSD.txt for details).
 
 *******************************************************************************/
 

--- a/test/unixlistener/main.d
+++ b/test/unixlistener/main.d
@@ -3,7 +3,7 @@
     Test suite for the unix socket listener.
 
     Copyright:
-        Copyright (c) 2009-2016 Sociomantic Labs GmbH.
+        Copyright (c) 2009-2017 sociomantic labs GmbH.
         All rights reserved.
 
     License:

--- a/test/unixsocket/main.d
+++ b/test/unixsocket/main.d
@@ -1,7 +1,5 @@
 /*******************************************************************************
 
-    Copyright:      Copyright (c) 2015 sociomantic labs. All rights reserved
-
     Test-suite for UnixSockets.
 
     The tests involve unix sockets and forking
@@ -10,6 +8,15 @@
     FLAKY: the unittests in this module are very flaky, as they rely on making
     various system calls (fork(), waitpid(), epoll_wait(), epoll_ctl(), etc)
     which could, under certain environmental conditions, fail.
+
+    Copyright:
+        Copyright (c) 2015-2017 sociomantic labs GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+        Alternatively, this file may be distributed under the terms of the Tango
+        3-Clause BSD License (see LICENSE_BSD.txt for details).
 
 *******************************************************************************/
 


### PR DESCRIPTION
Copyright & licence in module headers were previously not updated for
modules under `test/`.
