### PR TITLE
Remove travis build status badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,3 @@
-.. image:: https://travis-ci.org/sociomantic-tsunami/ocean.svg?branch=v2.x.x
-  :alt: Build status
-  :target: https://travis-ci.org/sociomantic-tsunami/ocean
-
 Description
 ===========
 


### PR DESCRIPTION
The same information is already available from the branch overview page and
maintaining correct branch reference is problematic maintenance-wise.