### PR TITLE
StopWatch: Use the monotonic clock, fix minor bugs

### DIFF
--- a/src/ocean/time/StopWatch.d
+++ b/src/ocean/time/StopWatch.d
@@ -43,13 +43,23 @@ extern (C) private
         // ...
 
         double i = elapsed.stop;
+        ulong us = elapsed.microsec;
         ---
 
-        The measured interval is in units of seconds, using floating-
-        point to represent fractions. This approach is more flexible
-        than integer arithmetic since it migrates trivially to more
-        capable timer hardware (there no implicit granularity to the
-        measurable intervals, except the limits of fp representation)
+        The measured interval is either an integer value in units of
+        microseconds -- returned by `microsec` -- or a floating-point value in
+        units of seconds with fractions -- returned by `stop`.
+        The integer value has always a precision of 1µs and is recommended if
+        you want to compare it with reference values such as checking if it's
+        below or above 1ms (e.g. `elapsed.microsec <= 1000`).
+        Although floating-point representation seems often more convenient, bear
+        in mind that
+          - The precision is relative to the value (i.e. the greater the values
+            the lower the absolute precision).
+          - Comparing fractions can yield unexpected results due to rounding and
+            because decimal fractions have no exact binary floating-point
+            representation. To avoid surprises like this using the integer
+            represenation of time spans is in general recommended.
 
         There is some minor overhead in using StopWatch, so take that into
         account

--- a/src/ocean/time/StopWatch.d
+++ b/src/ocean/time/StopWatch.d
@@ -95,7 +95,7 @@ public struct StopWatch
 
         double stop ()
         {
-                return multiplier * (timer - started);
+                return multiplier * this.microsec;
         }
 
         /***********************************************************************
@@ -106,7 +106,7 @@ public struct StopWatch
 
         ulong microsec ()
         {
-                 return (timer - started);
+                 return (timer >= started)? (timer - started) : 0;
         }
 
         /***********************************************************************

--- a/src/ocean/time/StopWatch.d
+++ b/src/ocean/time/StopWatch.d
@@ -53,7 +53,7 @@ public struct StopWatch
         import ocean.core.Exception_tango: PlatformException;
 
         private ulong  started;
-        private static double multiplier = 1.0 / 1_000_000.0;
+        private const double multiplier = 1.0 / 1_000_000.0;
 
         /***********************************************************************
 

--- a/src/ocean/time/StopWatch.d
+++ b/src/ocean/time/StopWatch.d
@@ -17,17 +17,6 @@
 
 module ocean.time.StopWatch;
 
-import ocean.core.Exception_tango;
-
-/*******************************************************************************
-
-*******************************************************************************/
-
-version (Posix)
-{
-        import ocean.stdc.posix.sys.time;
-}
-
 /*******************************************************************************
 
         Timer for measuring small intervals, such as the duration of a
@@ -60,6 +49,9 @@ version (Posix)
 
 public struct StopWatch
 {
+        import ocean.stdc.posix.sys.time;
+        import ocean.core.Exception_tango: PlatformException;
+
         private ulong  started;
         private static double multiplier = 1.0 / 1_000_000.0;
 
@@ -93,8 +85,7 @@ public struct StopWatch
 
         ulong microsec ()
         {
-                version (Posix)
-                         return (timer - started);
+                 return (timer - started);
         }
 
         /***********************************************************************
@@ -105,14 +96,11 @@ public struct StopWatch
 
         private static ulong timer ()
         {
-                version (Posix)
-                {
-                        timeval tv;
-                        if (gettimeofday (&tv, null))
-                            throw new PlatformException ("Timer :: linux timer is not available");
+                timeval tv;
+                if (gettimeofday (&tv, null))
+                    throw new PlatformException ("Timer :: linux timer is not available");
 
-                        return (cast(ulong) tv.tv_sec * 1_000_000) + tv.tv_usec;
-                }
+                return (cast(ulong) tv.tv_sec * 1_000_000) + tv.tv_usec;
         }
 }
 


### PR DESCRIPTION
- Use the monotonic timer rather than the wall clock time to avoid incorrect results if the clock is adjusted.
- Avoid huge time differences resulting from integer overflow if the clock is inconsistent.
- Remove `version(Posix)`, tidy up imports, correct documentation.