### PR TITLE
Provide the ability to specify custom layouts from the config

### DIFF
--- a/relnotes/makelayout.feature.md
+++ b/relnotes/makelayout.feature.md
@@ -1,0 +1,37 @@
+* `ocean.util.log.Config`
+
+    An extra overload of the `configureLogger` and `configureOldLoggers` functions
+    were introduced, with an additional `makeLayout` parameter.
+    This parameter is used to instantiate a `Layout` from a name, allowing
+    users to have custom layouts usable from their config files.
+    For example, a config entry would be:
+    ```
+    [LOG.myapp.supermodule]
+    level = info
+    file  = log/supermodule.log
+    file_layout = aquatic
+    console_layout = submarine
+    ```
+    And calling `configureOldLoggers` should be done as such:
+    ```
+    void myConfigureLoggers (
+        ClassIterator!(Config, ConfigParser) config,
+        MetaConfig m_config,
+        Appender delegate ( istring file, Layout layout ) file_appender,
+        bool use_insert_appender = false)
+    {
+        Layout makeLayout (cstring name)
+        {
+            if (name == "aquatic")
+                return new AquaticLayout;
+            if (name == "submarine")
+                return new SubmarineLayout;
+            return ocean.util.log.Config.newLayout(name);
+        }
+        ocean.util.log.Config.configureOldLoggers(config, m_config,
+            file_appender, &makeLayout, use_insert_appender);
+    }
+    ```
+    Note that the previous example is kept short for simplicity. `makeLayout` gets the raw name,
+    and as such may make the comparison as loose as wanted
+    (by lowercasing, removing `"layout"` prefix/suffix, etc...).

--- a/relnotes/makelayout.feature.md
+++ b/relnotes/makelayout.feature.md
@@ -35,3 +35,12 @@
     Note that the previous example is kept short for simplicity. `makeLayout` gets the raw name,
     and as such may make the comparison as loose as wanted
     (by lowercasing, removing `"layout"` prefix/suffix, etc...).
+
+* `ocean.util.app.LogExt : LogExt`
+
+    This class has a new constructor, which accepts a delegate with the same signature as `makeLayout`
+    previously described, and will pass it to `configureOldLoggers` accordingly.
+
+* `ocean.util.app.DaemonApp : DaemonApp.OptionalSettings`
+
+    This struct gained a new member, `make_layout`, which is passed to `LogExt` and ultimately `configureOldLoggers`.

--- a/src/ocean/util/app/DaemonApp.d
+++ b/src/ocean/util/app/DaemonApp.d
@@ -218,6 +218,7 @@ public abstract class DaemonApp : Application,
 
     public static struct OptionalSettings
     {
+        import ocean.util.log.Appender;
         import core.sys.posix.signal : SIGHUP;
 
         /***********************************************************************
@@ -287,6 +288,9 @@ public abstract class DaemonApp : Application,
         ***********************************************************************/
 
         int reopen_signal = SIGHUP;
+
+        /// Delegate for LogExt that instantiates a `Appender.Layout` from a name
+        Appender.Layout delegate (cstring name) make_layout;
     }
 
     /***************************************************************************
@@ -363,7 +367,8 @@ public abstract class DaemonApp : Application,
         this.args_ext.registerExtension(this.config_ext);
 
         // Create and register log extension
-        this.log_ext = new LogExt(settings.use_insert_appender);
+        this.log_ext = new LogExt(settings.make_layout,
+                                  settings.use_insert_appender);
         this.config_ext.registerExtension(this.log_ext);
 
         // Create and register version extension

--- a/src/ocean/util/log/Config.d
+++ b/src/ocean/util/log/Config.d
@@ -319,7 +319,7 @@ public Layout newLayout ( cstring layout_str )
             // yields `cstring` instead of `istring`.
             istring msg = "Invalid layout requested : ";
             msg ~= layout_str;
-            throw new Exception(msg);
+            throw new Exception(msg, __FILE__, __LINE__);
     }
 
     return layout;


### PR DESCRIPTION
Issue reported by @daniel-zullo-sociomantic :

> Some configureLoggers() were deprecated in v2.6.0 and the suggested method to use instead configureOldLoggers() does not deal with the template parameters FileLayout and ConsoleLayout.

This provides a more generic approach, less tied to the internals of this function (and that can be done at runtime).

CC @daniel-zullo-sociomantic @hatem-oraby-sociomantic for testing / sanity.