### PR TITLE
Use FreeList-based allocation for TimerExt internals

### DIFF
--- a/relnotes/timeoutallocator.feature.md
+++ b/relnotes/timeoutallocator.feature.md
@@ -1,0 +1,10 @@
+* `ocean.io.select.client.TimerSet`,
+  `ocean.io.select.timeout.TimerEventTimeoutManager`
+
+  These classes are now able to specify the allocation strategy used by the
+  base `TimeoutManager` class.
+
+* `ocean.util.app.ext.TimerExt`
+
+  `TimerExt` now uses FreeList-based allocation strategy for the internals,
+  instead of deferring to GC for this, generating less GC activity.

--- a/src/ocean/io/select/client/TimerSet.d
+++ b/src/ocean/io/select/client/TimerSet.d
@@ -276,11 +276,17 @@ public class TimerSet ( EventData ) : TimerEventTimeoutManager
                 (see `schedule()` / `stopTimeout()`)
             max_events = limit on the number of events which can be managed by
                 the scheduler at one time. (0 = no limit)
+            allocator = use this bucket element allocator for the expiry
+                registration to ISelectClient map. If it is null the default map
+                allocator (BucketElementGCAllocator) is used.
 
     ***************************************************************************/
 
-    public this ( EpollSelectDispatcher epoll = null, uint max_events = 0 )
+    public this ( EpollSelectDispatcher epoll = null, uint max_events = 0,
+        IAllocator allocator = null )
     {
+        super(allocator);
+
         this.epoll = epoll;
 
         this.events = new ObjectPool!(Event);

--- a/src/ocean/io/select/timeout/TimerEventTimeoutManager.d
+++ b/src/ocean/io/select/timeout/TimerEventTimeoutManager.d
@@ -75,6 +75,8 @@ static this ( )
 
 class TimerEventTimeoutManager : TimeoutManager
 {
+    import ocean.util.container.map.model.IAllocator;
+
     /***************************************************************************
 
         TimerEvent for absolute real-time that calls checkTimeouts() when fired.
@@ -138,10 +140,16 @@ class TimerEventTimeoutManager : TimeoutManager
 
         Constructor
 
+        Params:
+            allocator = use this bucket element allocator for the expiry
+                registration to ISelectClient map. If it is null the default map
+                allocator (BucketElementGCAllocator) is used.
+
     ***************************************************************************/
 
-    public this ( )
+    public this ( IAllocator allocator = null )
     {
+        super(allocator);
         this.event = this.new TimerEvent;
     }
 

--- a/src/ocean/time/timeout/TimeoutManager.d
+++ b/src/ocean/time/timeout/TimeoutManager.d
@@ -75,6 +75,15 @@ class TimeoutManager : TimeoutManagerBase
 {
     /***************************************************************************
 
+        Default expected number of elements in expiry registration to
+        ISelectClient map.
+
+    ***************************************************************************/
+
+    private const default_expected_no_elements = 1024;
+
+    /***************************************************************************
+
         Expiry registration class for an object that can time out.
 
     ***************************************************************************/
@@ -121,9 +130,24 @@ class TimeoutManager : TimeoutManagerBase
 
     ***************************************************************************/
 
-    public this ( size_t n = 1024, IAllocator allocator = null )
+    public this ( size_t n = default_expected_no_elements, IAllocator allocator = null )
     {
         super(n, allocator);
+    }
+
+    /***************************************************************************
+
+        Constructor.
+
+        Params:
+            allocator = use this bucket element allocator for the expiry
+                registration to ISelectClient map.
+
+    ***************************************************************************/
+
+    public this ( IAllocator allocator )
+    {
+        super(default_expected_no_elements, allocator);
     }
 
     /***************************************************************************

--- a/src/ocean/util/app/ext/TimerExt.d
+++ b/src/ocean/util/app/ext/TimerExt.d
@@ -107,6 +107,8 @@ public class TimerExt : IApplicationExtension
 
     import ocean.io.select.EpollSelectDispatcher;
     import ocean.io.select.client.TimerSet;
+    import BucketElementFreeList = ocean.util.container.map.model.BucketElementFreeList;
+    import ocean.time.timeout.TimeoutManager;
 
     /***************************************************************************
 
@@ -168,7 +170,8 @@ public class TimerExt : IApplicationExtension
 
     public this ( EpollSelectDispatcher epoll )
     {
-        this.timer_set = new TimerSet!(EventData)(epoll);
+        this.timer_set = new TimerSet!(EventData)(epoll, 0,
+                BucketElementFreeList.instantiateAllocator!(TimeoutManagerBase.ExpiryToClient));
     }
 
     /***************************************************************************


### PR DESCRIPTION
Previously, TimerExt of DaemonApp is based on the TimerSet, which with
few more inheritance layer goes back to TimeoutManager. TimeoutManager
by default uses BucketElementGCAllocator for allocating internals, which
uses GC to allocate.

However, TimeoutManager allows for configuring this, so another
allocation strategies may be used, such malloc/free via
BucketElementMallocAllocator, for example.

In order to minimize GC activity, BucketElementFreeList allocator
is now used for TimerExt internal allocation.

Fixes sociomantic-tsunami/ocean#36