### PR TITLE
Extend support for monitoring directories using FileSystemEvent

### DIFF
--- a/relnotes/filesystemdir.feature.md
+++ b/relnotes/filesystemdir.feature.md
@@ -1,0 +1,7 @@
+* `ocean.io.select.client.FileSystemEvent`
+
+  `FileSystemEvent`'s constructor and `setHandler` now accepts
+  `FileSystemEvent.Notifier` which accepts `SmartUnion` of structs
+  `(path, events)` or `(path, name, events)` where the later member is
+  used when the changes are performed on the files inside monitored directory,
+  where the `name` will be the name of the file that triggered this event.

--- a/relnotes/filesystemevent.deprecation.md
+++ b/relnotes/filesystemevent.deprecation.md
@@ -1,0 +1,5 @@
+* `ocean.io.select.client.FileSystemEvent`
+
+  `FileSystemEvent`'s constructor and `setHandler` methods accepting
+  `FileSystemEvent.Handler` are now deprecated in favour of the same methods
+  accepting the handler that accepts `SmartUnion` describing the raised event.

--- a/relnotes/sandbox1.feature.md
+++ b/relnotes/sandbox1.feature.md
@@ -1,0 +1,4 @@
+* `ocean.util.test.DirectorySandbox`
+
+  `DirectorySandbox` now doesn't need to accept the list of the subdirectories,
+  which is useful if no subdirectories are needed.

--- a/relnotes/sandbox2.feature.md
+++ b/relnotes/sandbox2.feature.md
@@ -1,0 +1,3 @@
+* `ocean.util.test.DirectorySandbox`
+
+  `DirectorySandbox` now provides its path via `path()` method.

--- a/src/ocean/util/test/DirectorySandbox.d
+++ b/src/ocean/util/test/DirectorySandbox.d
@@ -54,7 +54,7 @@ class DirectorySandbox
 
     ***************************************************************************/
 
-    public static DirectorySandbox create (in cstring[] subdirectories,
+    public static DirectorySandbox create (in cstring[] subdirectories = null,
             mstring path_template = "/tmp/Dunittest-XXXXXXXX".dup)
     {
         auto sandbox = new DirectorySandbox;

--- a/src/ocean/util/test/DirectorySandbox.d
+++ b/src/ocean/util/test/DirectorySandbox.d
@@ -88,6 +88,18 @@ class DirectorySandbox
 
     /***************************************************************************
 
+        Returns:
+            path of the sandbox
+
+    ***************************************************************************/
+
+    public cstring path ()
+    {
+        return this.sandbox_path;
+    }
+
+    /***************************************************************************
+
         Changes the directory to the old directory and removes the
         sandbox directory.
 

--- a/test/filesystemevent/main.d
+++ b/test/filesystemevent/main.d
@@ -15,6 +15,7 @@
 
 module test.filesystemevent.main;
 
+import ocean.text.convert.Formatter;
 
 
 /*******************************************************************************
@@ -24,6 +25,10 @@ module test.filesystemevent.main;
 *******************************************************************************/
 
 import ocean.transition;
+
+import ocean.core.Enforce;
+
+import ocean.io.device.File;
 
 import ocean.io.device.TempFile;
 
@@ -39,43 +44,14 @@ import ocean.io.FilePath_tango;
 
 import ocean.core.Test;
 
+import ocean.util.test.DirectorySandbox;
 
+import ocean.task.Task;
 
-/*******************************************************************************
+import ocean.task.Scheduler;
 
-    Class to perform a single test on FileSystemEvent
-
-*******************************************************************************/
-
-private class FileSystemEventTest
+class FileModificationTestTask: Task
 {
-    /***************************************************************************
-
-        Epoll where the inotifier instance will be registered
-
-    ***************************************************************************/
-
-    private EpollSelectDispatcher epoll;
-
-
-    /***************************************************************************
-
-        Temporary file used to generate file system events
-
-    ***************************************************************************/
-
-    private TempFile temp_file;
-
-
-    /***************************************************************************
-
-        Filepath of the temporary file
-
-    ***************************************************************************/
-
-    private FilePath temp_path;
-
-
     /***************************************************************************
 
         File operations to be checked
@@ -86,6 +62,21 @@ private class FileSystemEventTest
     private bool deleted  = false;
     private bool closed   = false;
 
+    /***************************************************************************
+
+        Name of the created file.
+
+    ***************************************************************************/
+
+    private cstring created_name;
+
+    /***************************************************************************
+
+        Path to the monitored file.
+
+    ***************************************************************************/
+
+    private FilePath temp_path;
 
     /***************************************************************************
 
@@ -95,71 +86,54 @@ private class FileSystemEventTest
 
     private int operation_order = 0;
 
-
     /***************************************************************************
 
-        Constructor
-
-        Also register a timer event to time-out the test after 1s, in case the
-        file event notification fails.
+        Tested FileSystemEvent instance.
 
     ***************************************************************************/
 
-    this ( )
-    {
-        this.epoll = new EpollSelectDispatcher;
-
-        this.temp_file = new TempFile(TempFile.Permanent);
-        this.temp_path = FilePath(this.temp_file.toString());
-
-        TimerEvent timer = new TimerEvent(&this.timerHandler);
-        this.epoll.register(timer);
-        timer.set(1, 0, 0, 0);
-
-        this.run();
-    }
-
+    private FileSystemEvent inotifier;
 
     /***************************************************************************
 
-        Run the test:
-            Creates a watch to a temporary file which is written, closed and
-            deleted.
-            The epoll is blocked until the FileSystem handler shutdown the epoll,
-            or the timer (worst case/failed test).
+        Test entry point. Prepares environment and tests the FileSystemEvent.
 
     ***************************************************************************/
 
-    public void run ( )
+    override public void run ( )
     {
-        auto inotifier  = new FileSystemEvent(&this.fileSystemHandler);
-        inotifier.watch(cast(char[]) this.temp_file.toString(),
-                           FileEventsEnum.IN_MODIFY | FileEventsEnum.IN_DELETE_SELF
-                         | FileEventsEnum.IN_CLOSE_WRITE );
+        auto temp_file = new TempFile(TempFile.Permanent);
+        this.temp_path = FilePath(temp_file.toString());
 
-        this.epoll.register(inotifier);
+        this.inotifier  = new FileSystemEvent(&this.fileSystemHandler);
+        inotifier.watch(cast(char[]) temp_file.toString(),
+                       FileEventsEnum.IN_MODIFY | FileEventsEnum.IN_DELETE_SELF
+                     | FileEventsEnum.IN_CLOSE_WRITE );
 
-        this.temp_file.write("something");
-        this.temp_file.close;
-        this.temp_path.remove();
+        theScheduler.epoll.register(inotifier);
 
-        this.epoll.eventLoop();
+        temp_file.write("something");
+        temp_file.close;
+        temp_path.remove();
+
+        this.suspend();
+
+        theScheduler.epoll.unregister(inotifier);
 
         test(this.modified);
         test(this.closed);
         test(this.deleted);
     }
 
-
-    /***************************************************************************
+    /**********************************************************************
 
         File System handler: called anytime a File System event occurs.
 
         Params:
-            path   = Path of the file
+            path   = monitored path
             event  = Inotify event (see FileEventsEnum)
 
-    ****************************************************************************/
+    **********************************************************************/
 
     private void fileSystemHandler ( char[] path, uint event )
     {
@@ -190,39 +164,19 @@ private class FileSystemEventTest
                     if ( this.operation_order == 3 )
                     {
                         this.deleted = true;
+                        if (this.suspended())
+                            this.resume();
                     }
                     break;
 
+                case FileEventsEnum.IN_IGNORED:
+                    enforce(this.deleted);
+                    break;
 
                 default:
-                    test(false, "Unexpected file system event notification.");
+                    test(false, format("Unexpected file system event notification. {}", event));
             }
         }
-
-        if ( this.modified && this.closed && this.deleted )
-        {
-            this.epoll.shutdown();
-        }
-    }
-
-
-    /***************************************************************************
-
-        Timer Handler: Called when the timer is fired.
-
-        Note: The timer is needed to assure epoll does not get blocked
-              indefinitely.
-
-        Returns:
-            Always false - Timer will not be re-set.
-
-    ***************************************************************************/
-
-    private bool timerHandler ( )
-    {
-        this.epoll.shutdown();
-
-        return false;
     }
 }
 
@@ -245,5 +199,13 @@ void main ( )
 
 unittest
 {
-    new FileSystemEventTest();
+    initScheduler(SchedulerConfiguration.init);
+    theScheduler.exception_handler = (Task t, Exception e) {
+        throw e;
+    };
+
+    auto test_task = new FileModificationTestTask;
+    theScheduler.schedule(test_task);
+
+    theScheduler.eventLoop();
 }

--- a/test/filesystemevent/main.d
+++ b/test/filesystemevent/main.d
@@ -15,8 +15,6 @@
 
 module test.filesystemevent.main;
 
-import ocean.text.convert.Formatter;
-
 
 /*******************************************************************************
 
@@ -50,7 +48,7 @@ import ocean.task.Task;
 
 import ocean.task.Scheduler;
 
-class FileModificationTestTask: Task
+deprecated class FileModificationTestTask: Task
 {
     /***************************************************************************
 
@@ -174,8 +172,222 @@ class FileModificationTestTask: Task
                     break;
 
                 default:
-                    test(false, format("Unexpected file system event notification. {}", event));
+                    test(false, "Unexpected file system event notification.");
             }
+        }
+    }
+}
+
+class FileCreationTestTask: Task
+{
+    /***************************************************************************
+
+        File operations to be checked
+
+    ***************************************************************************/
+
+    private bool created;
+    private bool modified = false;
+    private bool deleted  = false;
+    private bool closed   = false;
+
+    /***************************************************************************
+
+        Name of the created file.
+
+    ***************************************************************************/
+
+    private cstring created_name;
+
+    /***************************************************************************
+
+        Path to the monitored file.
+
+    ***************************************************************************/
+
+    private FilePath temp_path;
+
+    /***************************************************************************
+
+        Variable to control/test the order of the file operations
+
+    ***************************************************************************/
+
+    private int operation_order = 0;
+
+    /***************************************************************************
+
+        Path to the monitored directory.
+
+    ***************************************************************************/
+
+    private cstring watched_path;
+
+    /***************************************************************************
+
+        Tested FileSystemEvent instance.
+
+    ***************************************************************************/
+
+    private FileSystemEvent inotifier;
+
+    /***************************************************************************
+
+        Test that tests monitoring a directory and watching for the file
+        creation.
+
+    ***************************************************************************/
+
+    private void testFileCreation ( )
+    {
+        inotifier.watch(this.watched_path.dup,
+               FileEventsEnum.IN_CREATE);
+
+        theScheduler.epoll.register(inotifier);
+
+        auto file_name = "test_file";
+        File.set(file_name, "".dup);
+
+        this.suspend();
+
+        theScheduler.epoll.unregister(inotifier);
+
+        test(this.created);
+        test!("==")(this.created_name, file_name);
+    }
+
+    /***************************************************************************
+
+        Test that tests modifications/closing/deleting performed on individual
+        file (not a directory)
+
+    ***************************************************************************/
+
+    private void testFileModification ( )
+    {
+        auto temp_file = new TempFile(TempFile.Permanent);
+        this.temp_path = FilePath(temp_file.toString());
+
+        inotifier.watch(cast(char[]) temp_file.toString(),
+                       FileEventsEnum.IN_MODIFY | FileEventsEnum.IN_DELETE_SELF
+                     | FileEventsEnum.IN_CLOSE_WRITE );
+
+        theScheduler.epoll.register(inotifier);
+
+        temp_file.write("something");
+        temp_file.close;
+        temp_path.remove();
+
+        this.suspend();
+
+        theScheduler.epoll.unregister(inotifier);
+
+        test(this.modified);
+        test(this.closed);
+        test(this.deleted);
+    }
+
+    /***************************************************************************
+
+        Test entry point. Prepares environment and tests the FileSystemEvent.
+
+    ***************************************************************************/
+
+    override public void run ( )
+    {
+        auto sandbox = DirectorySandbox.create();
+        scope (exit)
+            sandbox.exitSandbox();
+
+        this.watched_path = sandbox.path;
+
+        this.inotifier  = new FileSystemEvent(&this.fileSystemHandler);
+
+        this.testFileCreation();
+        this.testFileModification();
+    }
+
+    /**********************************************************************
+
+        File System handler: called anytime a File System event occurs.
+
+        Params:
+            path   = monitored path
+            name = name of the file
+            event  = Inotify event (see FileEventsEnum)
+
+    **********************************************************************/
+
+    private void fileSystemHandler ( FileSystemEvent.RaisedEvent raised_event )
+    {
+        with (raised_event.Active) switch (raised_event.active)
+        {
+        case directory_file_event:
+            auto event = raised_event.directory_file_event;
+
+            if ( this.watched_path == event.path )
+            {
+                switch ( event.event )
+                {
+                    case FileEventsEnum.IN_CREATE:
+                        this.created = true;
+                        this.created_name = event.name.dup;
+                        if (this.suspended())
+                            this.resume();
+                        break;
+                    default:
+                        test(false, "Unexpected file system event notification.");
+                }
+            }
+            break;
+
+        case file_event:
+            auto event = raised_event.file_event;
+
+            if ( this.temp_path == event.path )
+            {
+                this.operation_order++;
+
+                switch ( event.event )
+                {
+                    case FileEventsEnum.IN_MODIFY:
+
+                        if ( this.operation_order == 1 )
+                        {
+                            this.modified = true;
+                        }
+                        break;
+
+                    case FileEventsEnum.IN_CLOSE_WRITE:
+
+                        if ( this.operation_order == 2 )
+                        {
+                            this.closed = true;
+                        }
+                        break;
+
+                    case FileEventsEnum.IN_DELETE_SELF:
+
+                        if ( this.operation_order == 3 )
+                        {
+                            this.deleted = true;
+                            if (this.suspended())
+                                this.resume();
+                        }
+                        break;
+
+                    case FileEventsEnum.IN_IGNORED:
+                        enforce(this.deleted);
+                        break;
+
+                    default:
+                        test(false, "Unexpected file system event notification.");
+                }
+            }
+            break;
+
+        default:
+            assert(false);
         }
     }
 }
@@ -204,8 +416,19 @@ unittest
         throw e;
     };
 
+    auto dir_test_task = new FileCreationTestTask;
+    theScheduler.schedule(dir_test_task);
+    theScheduler.eventLoop();
+}
+
+deprecated unittest
+{
+    initScheduler(SchedulerConfiguration.init);
+    theScheduler.exception_handler = (Task t, Exception e) {
+        throw e;
+    };
+
     auto test_task = new FileModificationTestTask;
     theScheduler.schedule(test_task);
-
     theScheduler.eventLoop();
 }


### PR DESCRIPTION
Previously, although user was able to monitor the directory, there was no way to get file name of the files that triggered the event. This is now supported through the new handler which also accepts name of the
file.