### PR TITLE
BitArray: Fix padding bits in length()

### DIFF
--- a/src/ocean/core/BitArray.d
+++ b/src/ocean/core/BitArray.d
@@ -1123,3 +1123,60 @@ struct BitArray
         assert( c == a );
     }
 }
+
+version (UnitTest)
+{
+    import ocean.core.Test : NamedTest;
+}
+
+unittest
+{
+    auto t = new NamedTest("Test increase and decrease length of the BitArray");
+
+    const size_of_uint = uint.sizeof * 8;
+    const num_bits = (size_of_uint * 5) + 15;
+
+    // Creates a BitArray and sets all the bits.
+    scope bool_array = new bool[num_bits];
+    bool_array[] = true;
+
+    BitArray bit_array;
+    bit_array = bool_array;
+
+    // Self-verification of the BitArray.
+    assert(bit_array.length == bool_array.length);
+    foreach (bit; bit_array)
+        t.test!("==")(bit, true);
+
+    // Increases the length of the BitArray and checks the former bits remain
+    // set and the new ones are not.
+    const greater_length = size_of_uint * 7;
+    static assert(greater_length > num_bits);
+    bit_array.length = greater_length;
+    foreach (pos, bit; bit_array)
+    {
+        if (pos < num_bits)
+            t.test!("==")(bit, true);
+        else
+            t.test!("==")(bit, false);
+    }
+
+    // Decreases the length of the BitArray to a shorter length than the
+    // initial one and checks all bits remain set.
+    const lower_length = size_of_uint * 5;
+    static assert(lower_length < num_bits);
+    bit_array.length = lower_length;
+    foreach (bit; bit_array)
+        t.test!("==")(bit, true);
+
+    // Resizes back to the initial length of the BitArray to check the bits
+    // reassigned after decreasing the length of the BitArray are not set.
+    bit_array.length = num_bits;
+    foreach (pos, bit; bit_array)
+    {
+        if (pos < lower_length)
+            t.test!("==")(bit, true);
+        else
+            t.test!("==")(bit, false);
+    }
+}

--- a/src/ocean/core/BitArray.d
+++ b/src/ocean/core/BitArray.d
@@ -89,10 +89,10 @@ struct BitArray
                 enableStomping(buf);
 
                 ptr = buf.ptr;
-                if( newdim & 31 )
+                if( auto pad_bits = (newlen & 31) )
                 {
                     // Set any pad bits to 0
-                    ptr[newdim - 1] &= ~(~0 << (newdim & 31));
+                    ptr[newdim - 1] &= ~(~0 << pad_bits);
                 }
             }
             len = newlen;

--- a/src/ocean/core/BitArray.d
+++ b/src/ocean/core/BitArray.d
@@ -86,6 +86,8 @@ struct BitArray
                 uint[] buf = ptr[0 .. olddim];
 
                 buf.length = newdim; // realloc
+                enableStomping(buf);
+
                 ptr = buf.ptr;
                 if( newdim & 31 )
                 {


### PR DESCRIPTION
The function `length()` incorrectly changes the padding bits of the `BitArray` when decreasing the `length`.

Also add a unit test to check the correctness of the state of the bits when increasing or decreasing the length of the `BitArray`.