### PR TITLE
Accept `Const!(void)[]` as a content in `File.set()`

### DIFF
--- a/src/ocean/io/device/File.d
+++ b/src/ocean/io/device/File.d
@@ -463,7 +463,7 @@ class File : Device, Device.Seek, Device.Truncate
 
         ***********************************************************************/
 
-        static void set (cstring path, void[] content)
+        static void set (cstring path, Const!(void)[] content)
         {
                 scope file = new File (path, ReadWriteCreate);
                 file.write (content);


### PR DESCRIPTION
This allows more liberty in passing the argument to `File.set`.