### PR TITLE
BitArray: Optimize opSliceAssign()

### DIFF
--- a/src/ocean/core/BitArray.d
+++ b/src/ocean/core/BitArray.d
@@ -180,22 +180,22 @@ struct BitArray
      *  assert(ba2[0] == false);
      *  -------------------
      */
-     BitArray opSliceAssign(BitArray rhs)
-     in
-     {
-         assert(rhs.len == len);
-     }
-     body
-     {
-         size_t mDim=len/32;
-         ptr[0..mDim] = rhs.ptr[0..mDim];
-         int rest=cast(int)(len & cast(size_t)31u);
-         if (rest){
-             uint mask=(~0u)<<rest;
-             ptr[mDim]=(rhs.ptr[mDim] & (~mask))|(ptr[mDim] & mask);
-         }
-         return *this;
-     }
+    BitArray opSliceAssign(BitArray rhs)
+    in
+    {
+        assert(rhs.len == len);
+    }
+    body
+    {
+        size_t mDim=len/32;
+        ptr[0..mDim] = rhs.ptr[0..mDim];
+        int rest=cast(int)(len & cast(size_t)31u);
+        if (rest){
+            uint mask=(~0u)<<rest;
+            ptr[mDim]=(rhs.ptr[mDim] & (~mask))|(ptr[mDim] & mask);
+        }
+        return *this;
+    }
 
 
     /**

--- a/src/ocean/core/BitArray.d
+++ b/src/ocean/core/BitArray.d
@@ -165,8 +165,7 @@ struct BitArray
      * copy.
      *
      * Params:
-     *  rhs = A BitArray with at least the same number of bits as this bit
-     *  array.
+     *  rhs = A BitArray with the same number of bits as this bit array.
      *
      * Returns:
      *  A shallow copy of this array.

--- a/src/ocean/core/BitArray.d
+++ b/src/ocean/core/BitArray.d
@@ -186,13 +186,8 @@ struct BitArray
     }
     body
     {
-        size_t mDim=len/32;
-        ptr[0..mDim] = rhs.ptr[0..mDim];
-        int rest=cast(int)(len & cast(size_t)31u);
-        if (rest){
-            uint mask=(~0u)<<rest;
-            ptr[mDim]=(rhs.ptr[mDim] & (~mask))|(ptr[mDim] & mask);
-        }
+        auto dimension = this.dim();
+        this.ptr[0..dimension] = rhs.ptr[0..dimension];
         return *this;
     }
 

--- a/src/ocean/core/BitArray.d
+++ b/src/ocean/core/BitArray.d
@@ -1115,3 +1115,47 @@ struct BitArray
         assert( c == a );
     }
 }
+
+version (UnitTest)
+{
+    import ocean.core.Test : NamedTest;
+}
+
+unittest
+{
+    auto t = new NamedTest("Copy the bits from another array");
+
+    const num_bits = 80;
+
+    // Creates a BitArray and sets the bits only for even position.
+    BitArray src_bit_array;
+    src_bit_array.length = num_bits;
+
+    foreach (pos, ref bool_value; src_bit_array)
+    {
+        if (pos % 2 == 0)
+            bool_value = true;
+    }
+
+    BitArray dst_bit_array;
+    dst_bit_array.length = src_bit_array.length;
+
+    // test self-verification
+    t.test!("==")(dst_bit_array.length, num_bits);
+    foreach (pos, bit_value; dst_bit_array)
+        t.test!("==")(bit_value, false);
+
+    dst_bit_array[] = src_bit_array; // performs the copy
+
+    foreach (pos, bit_value; dst_bit_array)
+    {
+        if (pos % 2 == 0)
+            t.test!("==")(bit_value, true);
+        else
+            t.test!("==")(bit_value, false);
+    }
+
+    // Ensures both arrays do not share the same memory storage
+    src_bit_array[0] = false;
+    t.test!("==")(dst_bit_array[0], true);
+}


### PR DESCRIPTION
This patch uses D array functionality to copy all the content from another `BitArray` instead of applying multiple bit operations.

This patch copies all the bytes in the `BitArray` without resetting the padding bits as they will be reset anyway if the array is extended.

*description updated