### PR TITLE
Don't require running scheduler state for await

### DIFF
--- a/src/ocean/task/Scheduler.d
+++ b/src/ocean/task/Scheduler.d
@@ -452,7 +452,7 @@ final class Scheduler
 
     public void await ( Task task, void delegate (Task) finished_dg = null )
     {
-        assert (this.state == State.Running && Task.getThis() !is null);
+        assert (Task.getThis() !is null);
 
         auto context = Task.getThis();
         assert (context !is null);


### PR DESCRIPTION
Further investigation has shown that this restriction is not necessary and is
either an artifact of earlier implementation or manifestation of defensive
programming.

Fixes #58