### PR TITLE
Don't call exception_handler for EpollException

### DIFF
--- a/src/ocean/io/select/EpollSelectDispatcher.d
+++ b/src/ocean/io/select/EpollSelectDispatcher.d
@@ -137,7 +137,10 @@ public class EpollSelectDispatcher : IEpollSelectDispatcherInfo
 
     /***************************************************************************
 
-        Optional hook to be called on unhandled exceptions from events
+        Optional hook to be called on unhandled exceptions from event callbacks.
+
+        NB: it won't be called on actual event errors thrown as EpollException
+        as those are expected to be handled on select client level exclusively.
 
     ***************************************************************************/
 
@@ -720,7 +723,7 @@ public class EpollSelectDispatcher : IEpollSelectDispatcherInfo
                 if (unhandled_exception_hook !is null)
                     unhandled_exception_hook(e);
                 else
-                    throw e;              
+                    throw e;
             }
 
             if (select_cycle_hook !is null)

--- a/src/ocean/io/select/selector/SelectedKeysHandler.d
+++ b/src/ocean/io/select/selector/SelectedKeysHandler.d
@@ -166,7 +166,8 @@ class SelectedKeysHandler: ISelectedKeysHandler
                 this.clientError(client, key.events, e);
                 error = true;
 
-                if (unhandled_exception_hook !is null)
+                if (   unhandled_exception_hook !is null
+                    && cast(EpollException)e is null)
                 {
                     unhandled_exception_hook(e);
                 }


### PR DESCRIPTION
EpollException will be thrown for variety of socket/client errors thrown from
`checkKeyError` method. Trying out `exception_handler` in live projects has
shown that silent consumption of such exception is strictly required for some
of existing library code to work.