### PR TITLE
Resize BitArray does not update the pad bits if the dimension does not change

### DIFF
--- a/src/ocean/core/BitArray.d
+++ b/src/ocean/core/BitArray.d
@@ -89,12 +89,14 @@ struct BitArray
                 enableStomping(buf);
 
                 ptr = buf.ptr;
-                if( auto pad_bits = (newlen & 31) )
-                {
-                    // Set any pad bits to 0
-                    ptr[newdim - 1] &= ~(~0 << pad_bits);
-                }
             }
+
+            if( auto pad_bits = (newlen & 31) )
+            {
+                // Set any pad bits to 0
+                ptr[newdim - 1] &= ~(~0 << pad_bits);
+            }
+
             len = newlen;
         }
     }
@@ -1179,4 +1181,18 @@ unittest
         else
             t.test!("==")(bit, false);
     }
+
+    // Checks the bits are reset to zero resizing the BitArray without changing
+    // its dimension (the BitArray is large enough to hold the new length).
+    bit_array = [true, true, true, true];
+
+    bit_array.length = 2;
+    t.test!("==")(bit_array[0], true);
+    t.test!("==")(bit_array[1], true);
+
+    bit_array.length = 4;
+    t.test!("==")(bit_array[0], true);
+    t.test!("==")(bit_array[1], true);
+    t.test!("==")(bit_array[2], false);
+    t.test!("==")(bit_array[3], false);
 }


### PR DESCRIPTION
According to the documentation of the function `length()` in the `BitArray`, the new bits will be initialized to zero. Unfortunately if the dimension of the `BitArray` is not changed then the bits remains the same
(they are not set to zero).

https://github.com/sociomantic-tsunami/ocean/blob/v2.x.x/src/ocean/core/BitArray.d#L70-L98

```D
unittest
{
    BitArray bit_array = [1, 1, 1, 1];

    bit_array.length = 2;
    assert(bit_array[0] == 1);
    assert(bit_array[1] == 1);

    bit_array.length = 4;
    assert(bit_array[0] == 1);
    assert(bit_array[1] == 1);
    assert(bit_array[2] == 0); // fails
    assert(bit_array[3] == 0); // fails
}
```

Recently we fixed a bug and added a unit test but unfortunately it doesn't cover the case when the dimension does not change when resizing the number of bits.

To fix this issue we could set the pad bits to zero regardless the dimension is changed or not.
For instance:
```D
    void length( size_t newlen )
    {
        if( newlen != len )
        {
            auto olddim = dim();
            auto newdim = (newlen + 31) / 32;

            if( newdim != olddim )
            {
                // Create a fake array so we can use D's realloc machinery
                uint[] buf = ptr[0 .. olddim];

                buf.length = newdim; // realloc
                enableStomping(buf);

                ptr = buf.ptr;
            }

            if( auto pad_bits = (newlen & 31) )
            {
                // Set any pad bits to 0
                ptr[newdim - 1] &= ~(~0 << pad_bits);
            }

            len = newlen;
        }
    }
```



