### PR TITLE
Add close-on-exec option for sockets, timers and events

### DIFF
--- a/relnotes/cloexec.feature.md
+++ b/relnotes/cloexec.feature.md
@@ -1,0 +1,80 @@
+* `ocean.sys.CloseOnExec`
+
+    * `open_with_close_on_exec` has been added. It is a global configuration
+      variable to define whether the close-on-exec option should be set on
+      system calls that create a file descriptor in ocean modules.
+
+    * `setCloExec` is a helper function to set the close-on-exec bit in a bit
+      mask which specifies option flags for a system call that obtains a new
+      file descriptor, such as `open(2)`. On recent Linux all such
+      system/library functions support enabling the close-on-exec option; this
+      is a Linux extension to POSIX.
+
+    On a POSIX system, if a program calls `exec(2)` (or an equivalent function
+    from the `exec` family) to execute another program, then the devices
+    referred to by the file descriptors held by the original program stay open,
+    and the executed program inherits all of them.
+    This has the consequence that, if the executed program is unaware of the
+    original program's file descriptors so it doesn't close those it doesn't
+    need, then all devices will stay open until the process exits.
+
+    Most of the time an `exec` call is preceded by a `fork` call to execute a
+    program in a new process. As with `exec` the child process created by `fork`
+    inherits all file descriptors from its parent process that called `fork`.
+    However, each device referred to by one of these file descriptors stays open
+    until _both_ the parent and child process close them or exit. This means
+    that the parent process has no way of closing its devices any more unless
+    the child process cooperates and does so as well, which is in practice very
+    unlikely.
+
+    This can cause the following situation:
+     - A program opens a device (file, socket, timer or event fd).
+     - The program registers the device with `epoll`.
+     - The program uses a third-party library which starts a task in a separate
+       process using `fork` + `exec`.
+     - The original program (parent process) closes the device.
+     - The executed program (child process) is, as libraries are, unaware of
+       its parent's business so it doesn't close any of the inherited file
+       descriptors; it doesn't even know which it inherited. So the device stays
+       opened.
+     - Because the device is opened it stays registered with `epoll`. The parent
+       process cannot unregister it any more because it has closed the file
+       descriptor.
+     - Until the child process exits `epoll_wait(2)` keeps reporting events for
+       the device in the parent process.
+
+    This is a problem because it can cause sporadic erratic behaviour in a
+    program. The error may be hard to reproduce and track down.
+
+    To prevent this from happening POSIX provides a close-on-exec option for
+    each file descriptor. By default it is disabled. If enabled, `exec` will
+    close the file descriptor so that the executed program won't inherit it. But
+    it works only if the parent process explicitly enables this option for every
+    single file descriptor it obtains from the system.
+
+    The global `open_with_close_on_exec` variable in this module is read by all
+    functions and class constructors in ocean that obtain a file descriptor from
+    the system. If it is `true` then they set the close-on-exec option.
+
+    This does not affect `stdin`, `stdout` and `stderr`, which are opened before
+    the start of the program.
+
+    Currently the flag is `false` to keep the system's default behaviour. In
+    general it is recommended to set it to `true` to avoid the aforementioned
+    problem unless file descriptor inheriting is needed. Since there appears to
+    be no use case for it for us the default value of `open_with_close_on_exec`
+    will change to `true` in the next major ocean release.
+
+    IF YOU HAVE A USE CASE FOR INHERITING FILE DESCRIPTORS, PLEASE CONTACT THE
+    OCEAN MAINTAINERS.
+
+    The following ocean functions obtain a file descriptor and use this flag:
+
+    - `ocean.sys.Epoll`: `Epoll.create`
+    - `ocean.sys.EventFD`: `EventFD` constructor
+    - `ocean.sys.Inotify`: `Inotify` constructor
+    - `ocean.sys.SignalFD`: `SignalFD.register`
+    - `ocean.sys.TimerFD`: `TimerFD` constructor
+    - `ocean.sys.socket`: The `socket` and `accept` methods in all `*Socket`
+        classes
+    - `ocean.io.device.File`: `File.open`

--- a/src/ocean/io/device/File.d
+++ b/src/ocean/io/device/File.d
@@ -140,6 +140,8 @@ import core.sys.posix.unistd;
 class File : Device, Device.Seek, Device.Truncate
 {
         import TangoException = ocean.core.Exception_tango;
+        import ocean.sys.CloseOnExec;
+        const O_CLOEXEC = 0x80000;
 
         public alias Device.read  read;
         public alias Device.write write;
@@ -529,7 +531,7 @@ class File : Device, Device.Seek, Device.Truncate
             auto name = toStringz (path, zero);
             auto mode = Access[style.access] | Create[style.open];
 
-            handle = posix.open (name, mode | addflags, access);
+            handle = posix.open (name, mode | setCloExec(addflags, O_CLOEXEC), access);
             if (handle is -1)
                 return false;
 

--- a/src/ocean/sys/CloseOnExec.d
+++ b/src/ocean/sys/CloseOnExec.d
@@ -1,0 +1,125 @@
+/*******************************************************************************
+
+    Global configuration variable to define whether the close-on-exec option
+    should be set on system calls that create a file descriptor in ocean
+    modules.
+
+    On a POSIX system, if a program calls `exec(2)` (or an equivalent function
+    from the `exec` family) to execute another program, then the devices
+    referred to by the file descriptors held by the original program stay open,
+    and the executed program inherits all of them.
+    This has the consequence that, if the executed program is unaware of the
+    original program's file descriptors so it doesn't close those it doesn't
+    need, then all devices will stay open until the process exits.
+
+    Most of the time an `exec` call is preceded by a `fork` call to execute a
+    program in a new process. As with `exec` the child process created by `fork`
+    inherits all file descriptors from its parent process that called `fork`.
+    However, each device referred to by one of these file descriptors stays open
+    until _both_ the parent and child process close them or exit. This means
+    that the parent process has no way of closing its devices any more unless
+    the child process cooperates and does so as well, which is in practice very
+    unlikely.
+
+    This can cause the following situation:
+     - A program opens a device (file, socket, timer or event fd).
+     - The program registers the device with `epoll`.
+     - The program uses a third-party library which starts a task in a separate
+       process using `fork` + `exec`.
+     - The original program (parent process) closes the device.
+     - The executed program (child process) is, as libraries are, unaware of
+       its parent's business so it doesn't close any of the inherited file
+       descriptors; it doesn't even know which it inherited. So the device stays
+       opened.
+     - Because the device is opened it stays registered with `epoll`. The parent
+       process cannot unregister it any more because it has closed the file
+       descriptor.
+     - Until the child process exits `epoll_wait(2)` keeps reporting events for
+       the device in the parent process.
+
+    This is a problem because it can cause sporadic erratic behaviour in a
+    program. The error may be hard to reproduce and track down.
+
+    To prevent this from happening POSIX provides a close-on-exec option for
+    each file descriptor. By default it is disabled. If enabled, `exec` will
+    close the file descriptor so that the executed program won't inherit it. But
+    it works only if the parent process explicitly enables this option for every
+    single file descriptor it obtains from the system.
+
+    The global `open_with_close_on_exec` variable in this module is read by all
+    functions and class constructors in ocean that obtain a file descriptor from
+    the system. If it is `true` then they set the close-on-exec option.
+
+    This does not affect `stdin`, `stdout` and `stderr`, which are opened before
+    the start of the program.
+
+    Currently the flag is `false` to keep the system's default behaviour. In
+    general it is recommended to set it to `true` to avoid the aforementioned
+    problem unless file descriptor inheriting is needed. Since there appears to
+    be no use case for it for us the default value of `open_with_close_on_exec`
+    will change to `true` in the next major ocean release.
+
+    IF YOU HAVE A USE CASE FOR INHERITING FILE DESCRIPTORS, PLEASE CONTACT THE
+    OCEAN MAINTAINERS.
+
+    The following ocean functions obtain a file descriptor and use this flag:
+
+    - `ocean.sys.Epoll`: `Epoll.create`
+    - `ocean.sys.EventFD`: `EventFD` constructor
+    - `ocean.sys.Inotify`: `Inotify` constructor
+    - `ocean.sys.SignalFD`: `SignalFD.register`
+    - `ocean.sys.TimerFD`: `TimerFD` constructor
+    - `ocean.sys.socket`: The `socket` and `accept` methods in all `*Socket`
+        classes
+    - `ocean.io.device.File`: `File.open`
+
+    Copyright:
+        Copyright (c) 2017 Sociomantic Labs GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+        Alternatively, this file may be distributed under the terms of the Tango
+        3-Clause BSD License (see LICENSE_BSD.txt for details).
+
+*******************************************************************************/
+
+module ocean.sys.CloseOnExec;
+
+import ocean.transition;
+
+/*******************************************************************************
+
+    If true then all ocean functions obtaining a file descriptor from the system
+    set the close-on-exec option; if false they don't. Changing the value of
+    this variable does not change the state of previously obtained file
+    descriptors.
+
+*******************************************************************************/
+
+mixin(global("bool open_with_close_on_exec = false"));
+
+/*******************************************************************************
+
+    Helper function to set the close-on-exec bit in a bit mask which specifies
+    option flags for a system call that obtains a new file descriptor, such as
+    `open(2)`. On recent Linux all such system/library functions support
+    enabling the close-on-exec option; this is a Linux extension to POSIX. Some
+    of these flag accepting functions were added more recently with a name
+    extension, for example `accept4(2)` or `inotify_init1(2)`.
+
+    Params:
+        flags = the flags where the close-on-exec bit should be set if
+                `open_with_close_on_exec` is `true`
+        close_on_exec_flag = a bitmask with only the close-on-exec bit set
+
+    Returns:
+        `flags | close_on_exec_flag` if `open_with_close_on_exec` is `true`,
+        otherwise `flags`.
+
+*******************************************************************************/
+
+T setCloExec ( T, U ) ( T flags, U close_on_exec_flag )
+{
+    return open_with_close_on_exec? (flags | close_on_exec_flag) : flags;
+}

--- a/src/ocean/sys/Epoll.d
+++ b/src/ocean/sys/Epoll.d
@@ -492,6 +492,8 @@ extern (C)
 
 struct Epoll
 {
+    import ocean.sys.CloseOnExec;
+
     /**************************************************************************
 
         Convenience aliases
@@ -536,7 +538,9 @@ struct Epoll
 
     public int create ( CreateFlags flags = CreateFlags.None )
     {
-        return this.fd = epoll_create1(flags);
+        return this.fd = epoll_create1(
+            setCloExec(flags, EpollCreateFlags.EPOLL_CLOEXEC)
+        );
     }
 
     /**************************************************************************

--- a/src/ocean/sys/EventFD.d
+++ b/src/ocean/sys/EventFD.d
@@ -118,7 +118,11 @@ import core.sys.posix.unistd: read, write, close;
 
 *******************************************************************************/
 
-private extern ( C ) int eventfd ( uint initval, int flags );
+private extern ( C )
+{
+    int eventfd ( uint initval, int flags );
+    const EFD_CLOEXEC = 0x80000;
+}
 
 
 
@@ -130,6 +134,8 @@ private extern ( C ) int eventfd ( uint initval, int flags );
 
 public class EventFD : ISelectable
 {
+    import ocean.sys.CloseOnExec;
+
     /***************************************************************************
 
         Integer file descriptor provided by the operating system and used to
@@ -148,7 +154,7 @@ public class EventFD : ISelectable
 
     public this ( )
     {
-        this.fd = .eventfd(0, 0);
+        this.fd = .eventfd(0, setCloExec(0, EFD_CLOEXEC));
     }
 
 

--- a/src/ocean/sys/Inotify.d
+++ b/src/ocean/sys/Inotify.d
@@ -29,7 +29,6 @@ import ocean.text.util.StringC;
 import ocean.sys.ErrnoException;
 
 import core.sys.linux.sys.inotify;
-import core.sys.posix.fcntl;
 
 import ocean.io.model.IConduit: ISelectable;
 
@@ -165,18 +164,7 @@ public class Inotify : ISelectable
     public this ( InotifyException e )
     {
         this.e = e;
-        this.fd = this.e.enforceRet!(inotify_init)(&verify).call();
-
-        int flags  =  fcntl(this.fd, F_GETFL, 0);
-
-        if ( fcntl(this.fd, F_SETFL, flags | O_NONBLOCK) < 0 )
-        {
-            scope (exit) errno = 0;
-
-            int errnum = errno;
-
-            throw this.e.set(errnum, identifier!(.fcntl));
-        }
+        this.fd = this.e.enforceRet!(inotify_init1)(&verify).call(IN_NONBLOCK);
     }
 
 

--- a/src/ocean/sys/Inotify.d
+++ b/src/ocean/sys/Inotify.d
@@ -46,6 +46,8 @@ import core.stdc.errno: EAGAIN, EWOULDBLOCK, errno;
 
 public class Inotify : ISelectable
 {
+    import ocean.sys.CloseOnExec;
+
     /***************************************************************************
 
         Exception class, thrown on errors with inotify functions
@@ -164,7 +166,9 @@ public class Inotify : ISelectable
     public this ( InotifyException e )
     {
         this.e = e;
-        this.fd = this.e.enforceRet!(inotify_init1)(&verify).call(IN_NONBLOCK);
+
+        this.fd = this.e.enforceRet!(inotify_init1)(&verify)
+            .call(setCloExec(IN_NONBLOCK, IN_CLOEXEC));
     }
 
 

--- a/src/ocean/sys/SignalFD.d
+++ b/src/ocean/sys/SignalFD.d
@@ -129,6 +129,7 @@ debug import ocean.io.Stdout;
 public class SignalFD : ISelectable
 {
     import core.sys.linux.sys.signalfd;
+    import ocean.sys.CloseOnExec;
 
     /***************************************************************************
 
@@ -267,7 +268,9 @@ public class SignalFD : ISelectable
         sigset.add(this.signals);
         auto c_sigset = cast(sigset_t) sigset;
 
-        this.fd = signalfd(this.fd, &c_sigset, SFD_NONBLOCK);
+        this.fd = signalfd(
+            this.fd, &c_sigset, setCloExec(SFD_NONBLOCK, SFD_CLOEXEC)
+        );
         if ( this.fd == -1 )
         {
             scope ( exit ) .errno = 0;

--- a/src/ocean/sys/SignalFD.d
+++ b/src/ocean/sys/SignalFD.d
@@ -109,63 +109,16 @@ import ocean.core.Traits;
 import ocean.io.model.IConduit;
 
 import core.sys.posix.signal;
+
 import core.sys.posix.unistd : read, close;
 
 import core.stdc.errno : EAGAIN, EWOULDBLOCK, errno;
-
-import core.sys.posix.fcntl : O_NONBLOCK;
 
 import ocean.core.Array : contains;
 
 import ocean.transition;
 
 debug import ocean.io.Stdout;
-
-
-extern ( C )
-{
-    /***************************************************************************
-
-        Definition of external functions required to manage signal events.
-
-    ***************************************************************************/
-
-    public int signalfd ( int fd, sigset_t* mask, int flags );
-
-
-
-    /***************************************************************************
-
-        Struct used by signal notification.
-
-    ***************************************************************************/
-
-    public struct signalfd_siginfo
-    {
-        uint ssi_signo;    /* Signal number */
-        int  ssi_errno;    /* Error number (unused) */
-        int  ssi_code;     /* Signal code */
-        uint ssi_pid;      /* PID of sender */
-        uint ssi_uid;      /* Real UID of sender */
-        int  ssi_fd;       /* File descriptor (SIGIO) */
-        uint ssi_tid;      /* Kernel timer ID (POSIX timers) */
-        uint ssi_band;     /* Band event (SIGIO) */
-        uint ssi_overrun;  /* POSIX timer overrun count */
-        uint ssi_trapno;   /* Trap number that caused signal */
-        int  ssi_status;   /* Exit status or signal (SIGCHLD) */
-        int  ssi_int;      /* Integer sent by sigqueue(2) */
-        ulong ssi_ptr;     /* Pointer sent by sigqueue(2) */
-        ulong ssi_utime;   /* User CPU time consumed (SIGCHLD) */
-        ulong ssi_stime;   /* System CPU time consumed (SIGCHLD) */
-        ulong ssi_addr;    /* Address that generated signal
-                              (for hardware-generated signals) */
-        ubyte[48] pad;     /* Pad size to 128 bytes (allow for
-                              additional fields in the future) */
-
-        static assert(signalfd_siginfo.sizeof == 128);
-    }
-}
-
 
 /*******************************************************************************
 
@@ -175,6 +128,8 @@ extern ( C )
 
 public class SignalFD : ISelectable
 {
+    import core.sys.linux.sys.signalfd;
+
     /***************************************************************************
 
         errno exception type for signal events.
@@ -202,16 +157,7 @@ public class SignalFD : ISelectable
 
     ***************************************************************************/
 
-    public alias .signalfd_siginfo SignalInfo;
-
-
-    /***************************************************************************
-
-        SFD_NONBLOCK flags used by signalfd() function.
-
-    ***************************************************************************/
-
-    private alias O_NONBLOCK SFD_NONBLOCK;
+    public alias signalfd_siginfo SignalInfo;
 
 
     /***************************************************************************
@@ -321,12 +267,12 @@ public class SignalFD : ISelectable
         sigset.add(this.signals);
         auto c_sigset = cast(sigset_t) sigset;
 
-        this.fd = .signalfd(this.fd, &c_sigset, SFD_NONBLOCK);
+        this.fd = signalfd(this.fd, &c_sigset, SFD_NONBLOCK);
         if ( this.fd == -1 )
         {
             scope ( exit ) .errno = 0;
             auto errnum = .errno;
-            throw this.errno_exception.set(errnum, identifier!(.signalfd));
+            throw this.errno_exception.set(errnum, identifier!(signalfd));
         }
 
         if ( mask )

--- a/src/ocean/sys/TimerFD.d
+++ b/src/ocean/sys/TimerFD.d
@@ -210,6 +210,8 @@ extern (C)
 
 public class TimerFD : ISelectable
 {
+    import ocean.sys.CloseOnExec;
+
     /***************************************************************************
 
         Set to true to use an absolute or false for a relative timer. On default
@@ -288,8 +290,10 @@ public class TimerFD : ISelectable
     {
         this.e = e;
         static bool verify (int fd) { return fd >= 0; }
-        this.fd = this.e.enforceRet!(.timerfd_create)(&verify)
-            .call(realtime ? CLOCK_REALTIME : CLOCK_MONOTONIC, TFD_NONBLOCK);
+        this.fd = this.e.enforceRet!(.timerfd_create)(&verify).call(
+            realtime ? CLOCK_REALTIME : CLOCK_MONOTONIC,
+            setCloExec(TFD_NONBLOCK, TFD_CLOEXEC)
+        );
     }
 
     /***************************************************************************

--- a/src/ocean/sys/socket/IPSocket.d
+++ b/src/ocean/sys/socket/IPSocket.d
@@ -89,6 +89,8 @@ public enum TcpOptions
 
 abstract class IIPSocket : ISocket
 {
+    import ocean.sys.CloseOnExec;
+
     version (D_Version2)
     {
         // add to overload set explicitly
@@ -240,7 +242,10 @@ abstract class IIPSocket : ISocket
 
     public int socket ( int type, int protocol = 0 )
     {
-        this.fd = .socket(this.is_ipv6? AF_INET6 : AF_INET, type, protocol);
+        this.fd = .socket(
+            this.is_ipv6? AF_INET6 : AF_INET,
+            setCloExec(type, SocketFlags.SOCK_CLOEXEC), protocol
+        );
 
         this.close_in_destructor = (this.fd >= 0);
 

--- a/src/ocean/sys/socket/UnixSocket.d
+++ b/src/ocean/sys/socket/UnixSocket.d
@@ -43,6 +43,7 @@ import ocean.stdc.posix.sys.un;
 
 public class UnixSocket : ISocket
 {
+    import ocean.sys.CloseOnExec;
 
     /***************************************************************************
 
@@ -104,7 +105,9 @@ public class UnixSocket : ISocket
 
     public int socket ( int type = SOCK_STREAM )
     {
-        return super.socket(AF_UNIX, type, 0);
+        return super.socket(
+            AF_UNIX, setCloExec(type, SocketFlags.SOCK_CLOEXEC), 0
+        );
     }
 
 

--- a/src/ocean/sys/socket/model/ISocket.d
+++ b/src/ocean/sys/socket/model/ISocket.d
@@ -66,6 +66,8 @@ public enum SocketFlags
 
 public abstract class ISocket : IODevice
 {
+    import ocean.sys.CloseOnExec;
+
     /**************************************************************************
 
         Flags supported by accept4().
@@ -311,7 +313,9 @@ public abstract class ISocket : IODevice
 
     public int socket ( int domain, int type, int protocol = 0 )
     {
-        this.fd = .socket(domain, type, protocol);
+        this.fd = .socket(
+            domain, setCloExec(type, SocketFlags.SOCK_CLOEXEC), protocol
+        );
 
         this.close_in_destructor = (this.fd >= 0);
 
@@ -467,7 +471,10 @@ public abstract class ISocket : IODevice
     {
         addrlen = this.in_addrlen;
 
-        this.fd = .accept4(listening_socket.fileHandle, remote_address, &addrlen, flags);
+        this.fd = .accept4(
+            listening_socket.fileHandle, remote_address, &addrlen,
+            setCloExec(flags, SocketFlags.SOCK_CLOEXEC)
+        );
 
         this.close_in_destructor = (this.fd >= 0);
 
@@ -494,7 +501,10 @@ public abstract class ISocket : IODevice
 
     public int accept ( ISelectable listening_socket, SocketFlags flags = SocketFlags.None )
     {
-        this.fd = .accept4(listening_socket.fileHandle, null, null, flags);
+        this.fd = .accept4(
+            listening_socket.fileHandle, null, null,
+            setCloExec(flags, SocketFlags.SOCK_CLOEXEC)
+        );
 
         this.close_in_destructor = (this.fd >= 0);
 


### PR DESCRIPTION
Some of our applications spawn new processes, which inherit all file descriptors by default but neither use nor close them until they terminate. Consequently the parent process cannot close any device associated with a file descriptor because the child process keeps it open. One consequence, which caused a bug that was hard to reproduce and track down, is that file descriptors in epoll are not automatically unregistered when closing them.
The solution is to enable the close-on-exec option for every single file descriptor, which prevents the child process from inheriting it. Fortunately on Linux all functions that create a file descriptor accept an option to enable close-on-exec. Add this option to the ocean facilities that create file descriptors which are usually registered with epoll.
There are still two open points:
1. To avoid a breaking change the close-on-exec option is disabled by default so it is up to user code to enable it. I think it should really be enabled by default because it protects from sporadic errors that can be severe and hard to debug -- or do we have an application that spawns a process which needs to use the parent's socket, timer, event or epoll file descriptors?
2. `EpollProcess` is affected as well, in particular the `SIGCHLD` select event in its `GlobalProcessMonitor`. Since a global singleton instance of this class is used I am not sure how to add close-on-exec without a breaking change.