### PR TITLE
Report an invalid IP address string via EINVAL, not EAFNOSUPPORT

### DIFF
--- a/relnotes/inetaddress-einval.migration.md
+++ b/relnotes/inetaddress-einval.migration.md
@@ -1,0 +1,9 @@
+* `ocean.sys.socket.InetAddress`, `ocean.sys.socket.AddressIPSocket`
+
+  Functions which accept an IP address string now report an invalid address by
+  setting `errno = EINVAL`. It was `EAFNOSUPPORT` before, which is wrong because
+  `EAFNOSUPPORT` refers to the wrong address family, which is not the case.
+  This affects the following methods:
+  * `ocean.sys.socket.InetAddress.opCall`
+  * `ocean.sys.socket.AddressIPSocket.bind(cstring, ushort)`
+  * `ocean.sys.socket.AddressIPSocket.connect(cstring, ushort)`

--- a/src/ocean/sys/socket/AddressIPSocket.d
+++ b/src/ocean/sys/socket/AddressIPSocket.d
@@ -173,7 +173,7 @@ class AddressIPSocket ( bool IPv6 = false ) : IPSocket!(IPv6), IAddressIPSocketI
             appropriately.
 
         Errors:
-            as the overridden method but also sets errno to EAFNOSUPPORT if the
+            as the overridden method but also sets errno to EINVAL if the
             address does not contain a valid IP address string.
 
      **************************************************************************/
@@ -227,7 +227,7 @@ class AddressIPSocket ( bool IPv6 = false ) : IPSocket!(IPv6), IAddressIPSocketI
             appropriately.
 
         Errors:
-            as the overridden method but also sets errno to EAFNOSUPPORT if the
+            as the overridden method but also sets errno to EINVAL if the
             address does not contain a valid IP address string.
 
      **************************************************************************/
@@ -412,7 +412,7 @@ class AddressIPSocket ( bool IPv6 = false ) : IPSocket!(IPv6), IAddressIPSocketI
 version (UnitTest)
 {
     import ocean.core.Test;
-    import core.stdc.errno: errno, EAFNOSUPPORT, EBADF;
+    import core.stdc.errno: errno, EINVAL, EBADF;
 }
 
 unittest
@@ -431,7 +431,7 @@ unittest
 
         errno = 0;
         test!("==")(s.bind("Hello World!", 6789), -1);
-        test!("==")(errno, EAFNOSUPPORT);
+        test!("==")(errno, EINVAL);
         test!("==")(s.address, "127.0.0.1");
         test!("==")(s.port, 12345);
 
@@ -443,7 +443,7 @@ unittest
 
         errno = 0;
         test!("==")(s.connect("Hello World!", 54321), -1);
-        test!("==")(errno, EAFNOSUPPORT);
+        test!("==")(errno, EINVAL);
         test!("==")(s.address, "127.0.0.2");
         test!("==")(s.port, 9876);
     }
@@ -461,7 +461,7 @@ unittest
 
         errno = 0;
         test!("==")(s.bind("Hello World!", 6789), -1);
-        test!("==")(errno, EAFNOSUPPORT);
+        test!("==")(errno, EINVAL);
         test!("==")(s.address, "::ffff:204.152.189.116");
         test!("==")(s.port, 12345);
 
@@ -473,7 +473,7 @@ unittest
 
         errno = 0;
         test!("==")(s.connect("Hello World!", 54321), -1);
-        test!("==")(errno, EAFNOSUPPORT);
+        test!("==")(errno, EINVAL);
         test!("==")(s.address, "::ffff:204.152.189.117");
         test!("==")(s.port, 9876);
     }

--- a/src/ocean/sys/socket/AddressIPSocket.d
+++ b/src/ocean/sys/socket/AddressIPSocket.d
@@ -173,8 +173,8 @@ class AddressIPSocket ( bool IPv6 = false ) : IPSocket!(IPv6), IAddressIPSocketI
             appropriately.
 
         Errors:
-            as above but also sets errno to EAFNOSUPPORT if the address does not
-            contain a valid IP address string.
+            as the overridden method but also sets errno to EAFNOSUPPORT if the
+            address does not contain a valid IP address string.
 
      **************************************************************************/
 
@@ -227,8 +227,8 @@ class AddressIPSocket ( bool IPv6 = false ) : IPSocket!(IPv6), IAddressIPSocketI
             appropriately.
 
         Errors:
-            as above but also sets errno to EAFNOSUPPORT if the address does not
-            contain a valid IP address string.
+            as the overridden method but also sets errno to EAFNOSUPPORT if the
+            address does not contain a valid IP address string.
 
      **************************************************************************/
 

--- a/src/ocean/sys/socket/InetAddress.d
+++ b/src/ocean/sys/socket/InetAddress.d
@@ -62,7 +62,7 @@ import core.sys.posix.arpa.inet: inet_ntop, inet_pton, ntohs, htons, htonl;
 
 import core.stdc.string: strlen;
 
-import core.stdc.errno: errno, EAFNOSUPPORT;
+import core.stdc.errno: errno, EINVAL;
 
 import ocean.core.TypeConvert;
 
@@ -302,8 +302,8 @@ struct InetAddress ( bool IPv6 = false )
         Returns:
             a sockaddr pointer to this.addr on success.
             If ip_address_str does not contain a valid IP address, null is
-            returned and errno set to EAFNOSUPPORT (this error is reported by
-            this wrapper, not the underlying system function).
+            returned and errno set to EINVAL (this error is reported by this
+            wrapper, not the underlying POSIX function).
 
      **************************************************************************/
 
@@ -316,7 +316,7 @@ struct InetAddress ( bool IPv6 = false )
         }
         else
         {
-            .errno = EAFNOSUPPORT;
+            .errno = EINVAL;
             return null;
         }
     }

--- a/src/ocean/sys/socket/InetAddress.d
+++ b/src/ocean/sys/socket/InetAddress.d
@@ -309,10 +309,9 @@ struct InetAddress ( bool IPv6 = false )
 
     public sockaddr* opCall ( cstring ip_address_str, ushort port = 0 )
     {
-        this.port = port;
-
         if (this.inet_pton(ip_address_str) == 1)
         {
+            this.port = port;
             return cast (sockaddr*) &this.addr;
         }
         else


### PR DESCRIPTION
Based on #71.

`EINVAL` is the appropriate code for this. `EAFNOSUPPORT` is wrong because it means a wrong address family was used, which is not the case here.
For functions that call `bind(2)`/`connect(2)` after `inet_ntop` this is in line with bind/connect error codes: Both return `EINVAL` for an invalid address argument as well.