### PR TITLE
Prevent clock drift in TimerExt by accounting for user delegate time.

### DIFF
--- a/relnotes/timerext.feature.md
+++ b/relnotes/timerext.feature.md
@@ -1,0 +1,7 @@
+* `ocean.util.app.ext.TimerExt`
+
+  `TimerExt` now accounts for the amount of time the user delegate took to
+  complete when scheduling the next timer call. If the user delegate takes
+  longer to complete than the interval, the next call will occur at an even
+  multiple of the specified period. (e.g. if the period is 5s and a call to
+  the delegate takes 7s, then the timer will fire 3s later.)


### PR DESCRIPTION
Previously the timer would be registered using the interval without accounting for how long the user delegate took to complete. The extension now looks at how much time was taken to complete the user delegate and then adjusts the registration timer accordingly to get more consistant interval calls.

The current tests for the TimerExt are all disabled at the moment so i will look at seeing what i can do to re-enable them but adding the PR now.