### PR TITLE
Fix several Serializer and Deserializer bugs, especially const

### DIFF
--- a/src/ocean/core/Traits.d
+++ b/src/ocean/core/Traits.d
@@ -1009,16 +1009,19 @@ template ContainsDynamicArray ( T ... )
         }
         else
         {
-            static if (is (T[0] Element == Element[])) // array
+            static if (is (T[0] Element : Element[])) // array
             {
-                const ContainsDynamicArray = true;
-            }
-            else static if (is (T[0] Element : Element[]))
-            {
-                // Static array, recurse into base type.
+                static if (is (Element[] == Unqual!(T[0])))
+                {
+                    const ContainsDynamicArray = true;
+                }
+                else
+                {
+                    // Static array, recurse into base type.
 
-                const ContainsDynamicArray = ContainsDynamicArray!(Element) ||
-                                             ContainsDynamicArray!(T[1 .. $]);
+                    const ContainsDynamicArray = ContainsDynamicArray!(Element) ||
+                                                 ContainsDynamicArray!(T[1 .. $]);
+                }
             }
             else
             {
@@ -1046,6 +1049,14 @@ unittest
     }
 
     static assert ( ContainsDynamicArray!(Const!(S)));
+
+    static struct S2
+    {
+        struct Arr { Const!(int[]) x; }
+        Arr[3][4] arr;
+    }
+
+    static assert(ContainsDynamicArray!(Immut!(S2)));
 }
 
 

--- a/src/ocean/util/serialize/contiguous/Contiguous.d
+++ b/src/ocean/util/serialize/contiguous/Contiguous.d
@@ -262,13 +262,13 @@ unittest
     mixin(Typedef!(int, "MyInt"));
 
     // prepare structures
-    struct S1
+    static struct S1
     {
         void[] arr;
         MyInt[2][2] static_arr;
     }
 
-    struct S2
+    static struct S2
     {
         int a, b, c;
         S1 subs;

--- a/src/ocean/util/serialize/contiguous/Contiguous.d
+++ b/src/ocean/util/serialize/contiguous/Contiguous.d
@@ -215,7 +215,7 @@ private void enforceContiguous (S) ( ref S input, in void[] allowed_range )
             {
                 // static + dynamic arrays
 
-                static if (is(Member == U[]))
+                static if (is(Unqual!(Member) == U[]))
                 {
                     if (member.ptr)
                     {
@@ -257,6 +257,9 @@ private void enforceContiguous (S) ( ref S input, in void[] allowed_range )
     }
 }
 
+version (UnitTest)
+    import core.stdc.string: memset;
+
 unittest
 {
     mixin(Typedef!(int, "MyInt"));
@@ -287,4 +290,15 @@ unittest
 
     tested.subs.arr = new void[2];
     testThrown!(Exception)(enforceContiguous(*tested, buffer));
+
+    static struct S4
+    {
+        Const!(char[])[] str = ["Hello", "World"];
+    }
+
+    auto tested2 = cast(S4*) memset(buffer.ptr, 0, buffer.length);
+
+    *tested2 = S4.init;
+    test!("==")(tested2.str.length, 2);
+    testThrown!(Exception)(enforceContiguous(*tested2, buffer));
 }

--- a/src/ocean/util/serialize/contiguous/Serializer.d
+++ b/src/ocean/util/serialize/contiguous/Serializer.d
@@ -417,7 +417,16 @@ struct Serializer
 
             foreach (subelement; element)
             {
-                len += This.countElementSize(subelement);
+                static if (is(Unqual!(Base) Sub == Sub[]))
+                {
+                    // subelement is a dynamic array
+                    len += This.countArraySize(subelement);
+                }
+                else
+                {
+                    // subelement is a value containing dynamic arrays
+                    len += This.countElementSize(subelement);
+                }
             }
 
             return len;
@@ -707,7 +716,7 @@ struct Serializer
 
             foreach (ref element; array)
             {
-                data = This.dumpElement(element, data);
+                data = This.dumpStaticArray(element[], data);
                 This.resetArrayReferences(element);
             }
         }

--- a/src/ocean/util/serialize/contiguous/Serializer.d
+++ b/src/ocean/util/serialize/contiguous/Serializer.d
@@ -289,11 +289,7 @@ struct Serializer
                     {
                         // Recurse into static array elements which contain a
                         // dynamic array.
-
-                        foreach (element; s.tupleof[i])
-                        {
-                            len += This.countArraySize(field);
-                        }
+                        len += This.countElementSize(field);
                     }
                 }
                 else static if (is (T == union))

--- a/src/ocean/util/serialize/contiguous/Serializer.d
+++ b/src/ocean/util/serialize/contiguous/Serializer.d
@@ -622,6 +622,7 @@ struct Serializer
                 {
                     // element is a dynamic array
                     data = This.dumpArray(element, data);
+                    *(cast(T*)&element) = null;
                 }
                 else
                 {

--- a/src/ocean/util/serialize/contiguous/Serializer.d
+++ b/src/ocean/util/serialize/contiguous/Serializer.d
@@ -696,7 +696,7 @@ struct Serializer
         }
         else static if (is (T Base : Base[]))
         {
-            static assert (!is (Base[] == T),
+            static assert (!is (Base[] == Unqual!(T)),
                "expected static, not dynamic array of " ~ T.stringof);
 
             debug (SerializationTrace)

--- a/src/ocean/util/serialize/contiguous/Serializer.d
+++ b/src/ocean/util/serialize/contiguous/Serializer.d
@@ -816,8 +816,6 @@ struct Serializer
     }
     body
     {
-        static assert (ContainsDynamicArray!(T), "nothing to do for " ~ S.stringof);
-
         debug (SerializationTrace)
         {
             Stdout.formatln("> resetArrayReferences!({})({})", T.stringof, array.ptr);

--- a/src/ocean/util/serialize/contiguous/package_.d
+++ b/src/ocean/util/serialize/contiguous/package_.d
@@ -195,6 +195,8 @@ struct S
 
     char[][3] static_of_dynamic;
 
+    char[][2][3][] dynamic_of_static_of_static_of_dynamic;
+
     union
     {
         int union_a;
@@ -268,6 +270,11 @@ S defaultS()
 
     s.static_of_dynamic[] = [ "a".dup, "b".dup, "c".dup ];
 
+    s.dynamic_of_static_of_static_of_dynamic = [
+        [["Die".dup, "Katze".dup], ["tritt".dup, "die".dup], ["Treppe".dup, "krumm.".dup]],
+        [["abc".dup, "def".dup], ["ghi".dup, "jkl".dup], ["mno".dup, "pqr".dup]]
+    ];
+
     s.union_a = 42;
 
     return s;
@@ -310,6 +317,9 @@ void testS(NamedTest t, ref S checked)
 
         test!("==")(checked.static_of_dynamic[],
                     defaultS().static_of_dynamic[]);
+
+        test!("==")(checked.dynamic_of_static_of_static_of_dynamic,
+                    defaultS().dynamic_of_static_of_static_of_dynamic);
 
         test!("==")(checked.union_a, defaultS().union_b);
     }


### PR DESCRIPTION
Fix #79 and a few more bugs I found on the way, also clean up the code a bit.
I made it so that the elements of a `const(T[])[]` array (which are of type `const(T[])`) will reside in the slices buffer which by itself is _not_ `const` but should never directly be written to anyway.