### PR TITLE
Fix documentation for sformat

### DIFF
--- a/src/ocean/text/convert/Formatter.d
+++ b/src/ocean/text/convert/Formatter.d
@@ -73,11 +73,11 @@ public istring format (Args...) (cstring fmt, Args args)
 
 /*******************************************************************************
 
-    Write the processed (formatted) input into a buffer
+    Append the processed (formatted) input onto the end of the provided buffer
 
     Params:
-        buffer  = The buffer to write the formatted string into, will be
-                  extended if needed
+        buffer  = The buffer to which to append the formatted string; its
+                  capacity will be increased if necessary
         fmt     = Format string to use
         args    = Variadic arguments to format according to `fmt`
 


### PR DESCRIPTION
These patches fix the incorrect documentation for the `ocean.text.convert.Formatter.sformat` overload that takes an `mstring buffer` as input, and rename it to `aformat`, leaving behind a deprecated wrapper function for backwards compatibility.  (Note, an alias is not possible because of the second `sformat` overload that takes a `Sink` as input.)

The original `sformat` documentation stated that the formatted string would be written _into_ the provided buffer, when in fact it is appended to it.  The choice of name seems to match better the original documentation than the correct documentation (by analogy to `snformat` in the same module, C's `sprintf`, and D2 phobos' `sformat`, all of which also write _into_ a buffer); the rename to `aformat` ('append format') is chosen to better distinguish the use-case.

Uses in ocean code have been switched to the new name, but a `deprecated unittest` block has been added to `ocean.text.convert.Formatter` to ensure that the behaviour of the old API continues to be validated.