### PR TITLE
Rename constructor parameter of the IOException to error_num

### DIFF
--- a/src/ocean/core/Exception_tango.d
+++ b/src/ocean/core/Exception_tango.d
@@ -161,7 +161,7 @@ class IOException : PlatformException
 
     *******************************************************************/
 
-    public this ( istring msg, int error_code, istring func_name,
+    public this ( istring msg, int error_num, istring func_name,
         istring file = __FILE__, long line = __LINE__ )
     {
         super(msg, file, line);


### PR DESCRIPTION
IOException has the member `error_num`, and it does the assignment
of it in the constructor: `this.error_num = error_num`. However, the
argument is called `error_code`, so the `this.error_num = error_num`
does nothing.