### PR TITLE
Temporarily disable test that check const fields

### DIFF
--- a/src/ocean/util/serialize/contiguous/package_.d
+++ b/src/ocean/util/serialize/contiguous/package_.d
@@ -782,10 +782,14 @@ version (D_Version2) unittest
     //Deserializer.deserialize!(IS)(buffer1);
     //Deserializer.deserialize!(II)(buffer2);
 
-    static assert(!is(typeof({Deserializer.deserialize!(IS)(buffer1);})),
-                  "Serializer should reject a struct with 'istring'");
-    static assert(!is(typeof({Deserializer.deserialize!(II)(buffer2);})),
-                  "Deserializer should reject a struct with 'immutable' element");
+    version (none)
+    {
+        // TODO: re-enable in v4.x.x
+        static assert(!is(typeof({Deserializer.deserialize!(IS)(buffer1);})),
+                      "Serializer should reject a struct with 'istring'");
+        static assert(!is(typeof({Deserializer.deserialize!(II)(buffer2);})),
+                      "Deserializer should reject a struct with 'immutable' element");
+    }
 }
 
 /******************************************************************************
@@ -870,8 +874,11 @@ unittest
     // Make sure ConstS cannot be deserialised; its const fields should be
     // rejected.
     version(D_Version2)
-        static assert(!mixin(
-            "__traits(compiles, Deserializer.deserialize!(ConstS)(buffer))"));
+    {
+        // TODO: re-enable in v4.x.x
+        version (none)
+            static assert(!is(typeof(Deserializer.deserialize!(ConstS)(buffer))));
+    }
 
     auto cont_S = Deserializer.deserialize!(UnqualConstS)(buffer);
     cont_S.enforceIntegrity();

--- a/src/ocean/util/serialize/contiguous/package_.d
+++ b/src/ocean/util/serialize/contiguous/package_.d
@@ -734,10 +734,10 @@ unittest
 {
     static struct CS
     {
-        cstring s;
+        mstring s;
     }
 
-    CS cs = CS("Hello world");
+    auto cs = Const!(CS)("Hello world");
     void[] buffer;
 
     Serializer.serialize(cs, buffer);


### PR DESCRIPTION
Because of deficiency in DMD implementation, combination of `pragma(msg)` and
`is(typeof())` will result in message printed even if instantiation is
speculative. As it is not possible to turn them into asserts yet, all tests that
trigger warning are disabled for now.