### PR TITLE
Deprecate ocean.util.stringz : fromStringz

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -92,6 +92,7 @@ TEST_FILTER_OUT += \
 	$C/src/ocean/stdc/stdint.d \
 	$C/src/ocean/stdc/stdio.d \
 	$C/src/ocean/stdc/stdlib.d \
+	$C/src/ocean/stdc/stringz.d \
 	$C/src/ocean/stdc/tgmath.d \
 	$C/src/ocean/stdc/time.d \
 	$C/src/ocean/stdc/wctype.d \

--- a/relnotes/stringz.deprecation.md
+++ b/relnotes/stringz.deprecation.md
@@ -1,0 +1,17 @@
+* `ocean.stdc.stringz`
+
+  This module and all functions inside of it have been deprecated,
+  as they duplicates already existing functionalities in ocean.text.util.StringC,
+  which is more idiomatic and actively maintained.
+  In place of using static buffer, it is recommended to use a dynamic buffer,
+  `copy` and `StringC.toCString` instead. Example:
+  ```D
+  char[64] buffer;
+  open(toStringz("/etc/limits.conf", buffer));
+  ```
+  turns into:
+  ```D
+  static mstring buffer;
+  buffer.copy("/etc/limits.conf");
+  open(StringC.toCString(buffer));
+  ```

--- a/src/ocean/core/Exception_tango.d
+++ b/src/ocean/core/Exception_tango.d
@@ -128,7 +128,6 @@ class SyncException : PlatformException
  */
 class IOException : PlatformException
 {
-    import ocean.stdc.stringz;
     import ocean.stdc.string;
     import core.stdc.errno;
 

--- a/src/ocean/io/device/File.d
+++ b/src/ocean/io/device/File.d
@@ -24,13 +24,13 @@
 
 module ocean.io.device.File;
 
+import ArrayMut = ocean.core.array.Mutation;
 import ocean.transition;
 
 import ocean.sys.Common;
-
+import ocean.text.util.StringC;
 import ocean.io.device.Device;
 
-import ocean.stdc.stringz;
 import core.stdc.string;
 import core.stdc.errno;
 
@@ -189,8 +189,8 @@ class File : Device, Device.Seek, Device.Truncate
                 if (msg.length == 0)
                 {
                     char[256] buf;
-                    auto errmsg = fromStringz(strerror_r(this.error_num, buf.ptr,
-                                buf.length));
+                    auto errmsg = StringC.toDString(
+                        strerror_r(this.error_num, buf.ptr, buf.length));
 
                     this.ReusableImpl.append(errmsg);
                 }
@@ -527,8 +527,9 @@ class File : Device, Device.Seek, Device.Truncate
             style_ = style;
 
             // zero terminate and convert to utf16
-            char[512] zero = void;
-            auto name = toStringz (path, zero);
+            static mstring buffer;
+            ArrayMut.copy(buffer, path);
+            auto name = StringC.toCString(buffer);
             auto mode = Access[style.access] | Create[style.open];
 
             handle = posix.open (name, mode | setCloExec(addflags, O_CLOEXEC), access);

--- a/src/ocean/io/device/SerialPort.d
+++ b/src/ocean/io/device/SerialPort.d
@@ -21,7 +21,6 @@ import ocean.core.Array : sort;
 
 import ocean.core.Exception_tango,
                 ocean.io.device.Device,
-                ocean.stdc.stringz,
                 ocean.sys.Common;
 
 import ocean.io.FilePath_tango;
@@ -262,7 +261,7 @@ deprecated class SerialPort : Device
             else
                 str = "SerialPort@" ~ file;
 
-            handle = posix.open(file.toStringz(), O_RDWR | O_NOCTTY | O_NONBLOCK);
+            handle = posix.open((file ~ "\0").ptr, O_RDWR | O_NOCTTY | O_NONBLOCK);
             if(handle == -1) {
                 error();
             }

--- a/src/ocean/io/device/TempFile.d
+++ b/src/ocean/io/device/TempFile.d
@@ -29,7 +29,7 @@ import Path = ocean.io.Path;
 import ocean.math.random.Kiss : Kiss;
 import ocean.io.device.Device : Device;
 import ocean.io.device.File;
-import ocean.stdc.stringz : toStringz;
+import ocean.text.util.StringC;
 
 /******************************************************************************
  ******************************************************************************/
@@ -383,7 +383,9 @@ class TempFile : File
         {
             // Check suitability
             {
-                auto parentz = toStringz(Path.parse(path.dup).path);
+                mstring path_mut = Path.parse(path.dup).path;
+                enableStomping(path_mut);
+                auto parentz = StringC.toCString(path_mut);
 
                 // Make sure we have write access
                 if( access(parentz, W_OK) == -1 )
@@ -427,7 +429,7 @@ class TempFile : File
                     // NOTE: This should be an exception and not simply
                     // returning false, since this is a violation of our
                     // guarantees.
-                    if( unlink(toStringz(path)) == -1 )
+                    if( unlink((path ~ "\0").ptr) == -1 )
                         error("could not remove transient file");
                 }
 

--- a/src/ocean/io/device/TempFile.d
+++ b/src/ocean/io/device/TempFile.d
@@ -535,5 +535,3 @@ You might want to delete the permanent one afterwards, too. :)")
 
     Stdout("\nDone.").newline;
 }
-
-

--- a/src/ocean/io/stream/Zlib_internal.d
+++ b/src/ocean/io/stream/Zlib_internal.d
@@ -33,8 +33,6 @@ import ocean.transition;
 
 import ocean.util.compress.c.zlib;
 
-import ocean.stdc.stringz : fromStringz;
-
 import ocean.core.Exception_tango : IOException;
 
 import ocean.io.device.Conduit : InputFilter, OutputFilter;
@@ -42,6 +40,7 @@ import ocean.io.device.Conduit : InputFilter, OutputFilter;
 import ocean.io.model.IConduit : InputStream, OutputStream, IConduit;
 
 import ocean.text.convert.Integer_tango : toString;
+import ocean.text.util.StringC;
 
 
 /* This constant controls the size of the input/output buffers we use
@@ -831,7 +830,9 @@ class ZlibException : IOException
      */
     this(int code, char* msg)
     {
-        super(codeName(code)~": "~idup(fromStringz(msg)));
+        istring m = codeName(code) ~ ": ";
+        m ~= StringC.toDString(msg);
+        super(m);
     }
 
     protected istring codeName(int code)

--- a/src/ocean/net/device/Berkeley.d
+++ b/src/ocean/net/device/Berkeley.d
@@ -2076,5 +2076,3 @@ deprecated public class SocketSet
                 return select (checkRead, checkWrite, checkError, null);
         }
 }
-
-

--- a/src/ocean/stdc/stringz.d
+++ b/src/ocean/stdc/stringz.d
@@ -15,7 +15,7 @@
 
 *******************************************************************************/
 
-module ocean.stdc.stringz;
+deprecated module ocean.stdc.stringz;
 
 import ocean.transition;
 
@@ -25,6 +25,7 @@ import ocean.transition;
  * appropriate.
  */
 
+deprecated("Use ocean.text.util.StringC : StringC.toCString instead")
 Const!(char)* toStringz (cstring s, char[] tmp = null)
 {
     mixin(global(`static char[] empty = "\0".dup`));
@@ -57,7 +58,7 @@ version (UnitTest)
     import ocean.stdc.string;
 }
 
-unittest
+deprecated unittest
 {
     cstring        input;
     Const!(char)*  sptr;
@@ -92,6 +93,7 @@ unittest
  * Returns a populated slice of dst
  */
 
+deprecated("Use ocean.text.util.StringC : StringC.toCString instead")
 Const!(char)*[] toStringz (char[] tmp, Const!(char)*[] dst, cstring[] strings...)
 {
     assert (dst.length >= strings.length);
@@ -110,7 +112,7 @@ Const!(char)*[] toStringz (char[] tmp, Const!(char)*[] dst, cstring[] strings...
     return dst [0 .. strings.length];
 }
 
-unittest
+deprecated unittest
 {
     char[] buf;
     Const!(char)*[2] dst;
@@ -125,7 +127,7 @@ unittest
 /*********************************
  * Convert a C-style 0 terminated string to an array of char
  */
-
+deprecated("Use ocean.text.util.StringC : StringC.toDString instead")
 Const!(char)[] fromStringz (Const!(char)* s)
 {
     return s ? s[0 .. strlenz(s)] : null;
@@ -134,7 +136,7 @@ Const!(char)[] fromStringz (Const!(char)* s)
 /*********************************
  * Convert array of wchars s[] to a C-style 0 terminated string.
  */
-
+deprecated("Use ocean.text.util.StringC : StringC.toCString instead")
 wchar* toString16z (wchar[] s)
 {
     if (s.ptr)
@@ -146,7 +148,7 @@ wchar* toString16z (wchar[] s)
 /*********************************
  * Convert a C-style 0 terminated string to an array of wchar
  */
-
+deprecated("Use ocean.text.util.StringC : StringC.toDString instead")
 Const!(wchar)[] fromString16z (Const!(wchar)* s)
 {
     return s ? s[0 .. strlenz(s)] : null;
@@ -155,7 +157,7 @@ Const!(wchar)[] fromString16z (Const!(wchar)* s)
 /*********************************
  * Convert array of dchars s[] to a C-style 0 terminated string.
  */
-
+deprecated("Use ocean.text.util.StringC : StringC.toCString instead")
 dchar* toString32z (dchar[] s)
 {
     if (s.ptr)
@@ -167,7 +169,7 @@ dchar* toString32z (dchar[] s)
 /*********************************
  * Convert a C-style 0 terminated string to an array of dchar
  */
-
+deprecated("Use ocean.text.util.StringC : StringC.toDString instead")
 Const!(dchar)[] fromString32z (Const!(dchar)* s)
 {
     return s ? s[0 .. strlenz(s)] : null;
@@ -176,7 +178,7 @@ Const!(dchar)[] fromString32z (Const!(dchar)* s)
 /*********************************
  * portable strlen
  */
-
+deprecated("Use ocean.stdc.string: strlen or wcslen")
 size_t strlenz(T) (T* s)
 {
     size_t i;
@@ -189,7 +191,7 @@ size_t strlenz(T) (T* s)
 
 
 
-unittest
+deprecated unittest
 {
     auto p = toStringz("foo");
     assert(strlenz(p) == 3);

--- a/src/ocean/sys/ErrnoException.d
+++ b/src/ocean/sys/ErrnoException.d
@@ -37,12 +37,11 @@ version (UnitTest)
 
 public class ErrnoException : Exception
 {
+    import ocean.core.Exception : ReusableExceptionImplementation;
+    import ocean.core.Traits : ReturnTypeOf, identifier;
     import ocean.stdc.string;
     import ocean.stdc.stringz;
-    import ocean.core.Traits : ReturnTypeOf;
 
-    import ocean.core.Exception : ReusableExceptionImplementation;
-    import ocean.core.Traits : identifier;
 
     /**************************************************************************
 

--- a/src/ocean/sys/ErrnoException.d
+++ b/src/ocean/sys/ErrnoException.d
@@ -40,7 +40,7 @@ public class ErrnoException : Exception
     import ocean.core.Exception : ReusableExceptionImplementation;
     import ocean.core.Traits : ReturnTypeOf, identifier;
     import ocean.stdc.string;
-    import ocean.stdc.stringz;
+    import ocean.text.util.StringC;
 
 
     /**************************************************************************
@@ -334,7 +334,7 @@ public class ErrnoException : Exception
             return this.append("Expected non-zero errno after failure");
 
         char[256] buf;
-        auto errmsg = fromStringz(strerror_r(err_num, buf.ptr, buf.length));
+        auto errmsg = StringC.toDString(strerror_r(err_num, buf.ptr, buf.length));
         return this.ReusableImpl.append(errmsg);
     }
 

--- a/src/ocean/sys/Process.d
+++ b/src/ocean/sys/Process.d
@@ -28,7 +28,6 @@ import Integer = ocean.text.convert.Integer_tango;
 
 import core.stdc.stdlib;
 import core.stdc.string;
-import ocean.stdc.stringz;
 
 version (Posix)
 {
@@ -1049,7 +1048,7 @@ class Process
                         // Switch to the working directory if it has been set.
                         if (_workDir.length > 0)
                         {
-                            chdir(toStringz(_workDir));
+                            chdir((_workDir ~ "\0").ptr);
                         }
 
                         // Replace the child fork with a new process. We always use the
@@ -1502,11 +1501,13 @@ class Process
                 {
                     --i;
                     // Add a terminating null character to each string
-                    auto cstr = toStringz(src[i]);
-                    if (cstr is src[i].ptr) // no new array was allocated
-                        dest[i] = src[i].dup.ptr;
+                    auto cstr = src[i];
+                    if (cstr.length == 0)
+                        dest[i] = "\0".dup.ptr;
+                    else if (cstr[$ - 1] == '\0')
+                        dest[i] = cstr.dup.ptr;
                     else
-                        dest[i] = cast(char*) cstr;
+                        dest[i] = (cstr ~ "\0").ptr;
                 }
                 return dest;
             }

--- a/src/ocean/text/convert/DateTime_tango.d
+++ b/src/ocean/text/convert/DateTime_tango.d
@@ -30,27 +30,16 @@
 
 module ocean.text.convert.DateTime_tango;
 
+import ocean.core.Exception_tango;
+import ocean.stdc.posix.langinfo;
+import ocean.stdc.stringz;
+import Integer = ocean.text.convert.Integer_tango;
+import Utf = ocean.text.convert.Utf;
+import ocean.time.chrono.Calendar;
+import ocean.time.chrono.Gregorian;
 import ocean.transition;
 
-import ocean.core.Exception_tango;
-
-import ocean.time.chrono.Calendar,
-       ocean.time.chrono.Gregorian;
-
-import Utf = ocean.text.convert.Utf;
-
-import Integer = ocean.text.convert.Integer_tango;
-
 import core.sys.posix.time; // timezone
-
-/******************************************************************************
-
-        O/S specifics
-
-******************************************************************************/
-
-import ocean.stdc.stringz;
-import ocean.stdc.posix.langinfo;
 
 /******************************************************************************
 

--- a/src/ocean/text/convert/DateTime_tango.d
+++ b/src/ocean/text/convert/DateTime_tango.d
@@ -32,9 +32,9 @@ module ocean.text.convert.DateTime_tango;
 
 import ocean.core.Exception_tango;
 import ocean.stdc.posix.langinfo;
-import ocean.stdc.stringz;
 import Integer = ocean.text.convert.Integer_tango;
 import Utf = ocean.text.convert.Utf;
+import ocean.text.util.StringC;
 import ocean.time.chrono.Calendar;
 import ocean.time.chrono.Gregorian;
 import ocean.transition;
@@ -308,7 +308,7 @@ struct DateTimeLocale
             static cstring getString(nl_item id, cstring def = null)
             {
                 char* p = nl_langinfo(id);
-                return p ? fromStringz(p).dup : def;
+                return p ? StringC.toDString(p).dup : def;
             }
 
             static cstring getFormatString(nl_item id, cstring def = null)

--- a/src/ocean/text/locale/Posix.d
+++ b/src/ocean/text/locale/Posix.d
@@ -25,9 +25,9 @@ version (Posix)
 
     import ocean.core.Exception_tango;
     import ocean.text.locale.Data;
+    import ocean.text.util.StringC;
     import core.stdc.ctype;
     import core.stdc.string;
-    import core.stdc.stringz;
     import core.stdc.locale;
     import core.sys.posix.stdlib;
 
@@ -49,7 +49,7 @@ version (Posix)
         cstring s;
         if (env)
         {
-            auto s_mut = fromStringz(env).dup;
+            auto s_mut = StringC.toDString(env).dup;
             foreach (ref char c; s_mut)
             {
                 if (c == '.')

--- a/src/ocean/text/locale/Posix.d
+++ b/src/ocean/text/locale/Posix.d
@@ -26,10 +26,10 @@ version (Posix)
     import ocean.core.Exception_tango;
     import ocean.text.locale.Data;
     import core.stdc.ctype;
-    import core.sys.posix.stdlib;
     import core.stdc.string;
-    import ocean.stdc.stringz;
+    import core.stdc.stringz;
     import core.stdc.locale;
+    import core.sys.posix.stdlib;
 
     /*private extern(C) char* setlocale(int type, char* locale);
       private extern(C) void putenv(char*);

--- a/src/ocean/util/app/ext/DropPrivilegesExt.d
+++ b/src/ocean/util/app/ext/DropPrivilegesExt.d
@@ -15,18 +15,19 @@
 
 module ocean.util.app.ext.DropPrivilegesExt;
 
-import ocean.util.app.model.IApplicationExtension;
+
+import ocean.stdc.stringz;
+import ocean.transition;
 import ConfigFiller = ocean.util.config.ConfigFiller;
 import ocean.util.app.ext.model.IConfigExtExtension;
+import ocean.util.app.model.IApplicationExtension;
 
-import ocean.transition;
-import core.sys.posix.unistd : setuid, setgid;
-import core.sys.posix.pwd;
-import core.stdc.string;
-import ocean.stdc.stringz;
-import core.sys.posix.grp;
-import core.sys.posix.unistd;
 import core.stdc.errno;
+import core.stdc.string;
+import core.sys.posix.grp;
+import core.sys.posix.pwd;
+import core.sys.posix.unistd;
+
 
 /*******************************************************************************
 

--- a/src/ocean/util/app/ext/DropPrivilegesExt.d
+++ b/src/ocean/util/app/ext/DropPrivilegesExt.d
@@ -16,8 +16,9 @@
 module ocean.util.app.ext.DropPrivilegesExt;
 
 
-import ocean.stdc.stringz;
+import ocean.core.array.Mutation;
 import ocean.transition;
+import ocean.text.util.StringC;
 import ConfigFiller = ocean.util.config.ConfigFiller;
 import ocean.util.app.ext.model.IConfigExtExtension;
 import ocean.util.app.model.IApplicationExtension;
@@ -121,12 +122,11 @@ class DropPrivilegesExt : IConfigExtExtension
     {
         passwd* result;
         passwd passwd_buf;
-        char[50] user_buf;
+        static mstring user_buf;
         char[2048] buf;
 
-        auto cuser = toStringz(usr, user_buf);
-
-        auto res = getpwnam_r(cuser, &passwd_buf,
+        user_buf.copy(usr);
+        auto res = getpwnam_r(StringC.toCString(user_buf), &passwd_buf,
                               buf.ptr, buf.length, &result);
 
         if ( result == null )
@@ -139,7 +139,7 @@ class DropPrivilegesExt : IConfigExtExtension
             {
                 char* err = strerror(res);
                 auto msg = "Error while getting user " ~ usr ~
-                    ": " ~ fromStringz(err);
+                    ": " ~ StringC.toDString(err);
                 throw new Exception(assumeUnique(msg));
             }
         }
@@ -152,7 +152,7 @@ class DropPrivilegesExt : IConfigExtExtension
         {
             char* err = strerror(errno());
             auto msg = "Failed to set process user id to " ~ usr
-                ~ ": " ~ fromStringz(err);
+                ~ ": " ~ StringC.toDString(err);
             throw new Exception(assumeUnique(msg));
         }
     }
@@ -171,12 +171,12 @@ class DropPrivilegesExt : IConfigExtExtension
     {
         group* result;
         group group_buf;
-        char[50] grp_buf;
+        static mstring grp_buf;
         char[2048] buf;
 
-        auto cgroup = toStringz(grp, grp_buf);
-
-        auto res = getgrnam_r(cgroup, &group_buf, buf.ptr, buf.length, &result);
+        grp_buf.copy(grp);
+        auto res = getgrnam_r(StringC.toCString(grp_buf), &group_buf,
+                              buf.ptr, buf.length, &result);
 
         if ( result == null )
         {
@@ -188,7 +188,7 @@ class DropPrivilegesExt : IConfigExtExtension
             {
                 char* err = strerror(res);
                 auto msg = "Error while getting group " ~ grp ~
-                    ": " ~ fromStringz(err);
+                    ": " ~ StringC.toDString(err);
                 throw new Exception(assumeUnique(msg));
             }
         }
@@ -201,7 +201,7 @@ class DropPrivilegesExt : IConfigExtExtension
         {
             char* err = strerror(errno());
             auto msg = "Failed to set process user group to " ~ grp
-                ~ ": " ~ fromStringz(err);
+                ~ ": " ~ StringC.toDString(err);
             throw new Exception(assumeUnique(msg));
         }
     }

--- a/src/ocean/util/cipher/gcrypt/core/Gcrypt.d
+++ b/src/ocean/util/cipher/gcrypt/core/Gcrypt.d
@@ -67,8 +67,8 @@ public alias gcry_cipher_modes Mode;
 public class GcryptException : Exception
 {
     import ocean.core.Exception;
+    import ocean.text.util.StringC;
     import ocean.util.cipher.gcrypt.c.gcrypt;
-    import ocean.stdc.stringz;
 
     /***************************************************************************
 
@@ -180,9 +180,9 @@ public class GcryptException : Exception
                                      int line = __LINE__  )
     {
         this.set(`Error: "`, file, line)
-            .append(fromStringz(gcry_strerror(error)))
+            .append(StringC.toDString(gcry_strerror(error)))
             .append(`" Source: "`)
-            .append(fromStringz(gcry_strsource(error)))
+            .append(StringC.toDString(gcry_strsource(error)))
             .append(`"`);
     }
 }


### PR DESCRIPTION
While porting one of our app, I came accross this code and had a [deja vu](https://github.com/sociomantic-tsunami/ocean/pull/42).