### PR TITLE
Fix implicit string concatenation in StructConverter and Contiguous

### DIFF
--- a/src/ocean/core/StructConverter.d
+++ b/src/ocean/core/StructConverter.d
@@ -488,9 +488,9 @@ private void callBestOverload ( From, To, istring function_name )
             static assert ( false,
               "Function ` ~
              To.stringof ~ `.` ~ function_name ~
-             ` (" ~ convFuncTypeString ~ ") doesn't `
-             `have any of the accepted types `
-             `'void function ( ref "~From.stringof~", ref "~To.stringof~", void[] delegate ( size_t ) )' or `
+             ` (" ~ convFuncTypeString ~ ") doesn't ` ~
+             `have any of the accepted types ` ~
+             `'void function ( ref "~From.stringof~", ref "~To.stringof~", void[] delegate ( size_t ) )' or ` ~
              `'void function ( ref "~From.stringof~", ref "~To.stringof~" )'");
         }`);
 }

--- a/src/ocean/util/serialize/contiguous/Contiguous.d
+++ b/src/ocean/util/serialize/contiguous/Contiguous.d
@@ -295,7 +295,7 @@ package template ensureValueTypeMember ( S, size_t i, T )
     {
         static assert (!ContainsDynamicArray!(T),
                        M.stringof ~ " " ~ S.tupleof[i].stringof ~
-                       " - unions containing dynamic arrays are not "
+                       " - unions containing dynamic arrays are not " ~
                        "allowed, sorry");
     }
 


### PR DESCRIPTION
Implicit concatenation is deprecated in D2, so replacing these with explicit concatenations will save us some compiler warnings in the future.