### PR TITLE
Formatter: Deprecate the size_t returning delegate

### DIFF
--- a/relnotes/formatter.deprecation.md
+++ b/relnotes/formatter.deprecation.md
@@ -1,0 +1,4 @@
+* `ocean.text.convert.Formatter : ElementSink`
+
+  This alias was accidentally made public on the first release of the formatter.
+  It have been deprecated and should probably not affect any project.

--- a/relnotes/formatter.deprecation.md
+++ b/relnotes/formatter.deprecation.md
@@ -2,3 +2,10 @@
 
   This alias was accidentally made public on the first release of the formatter.
   It have been deprecated and should probably not affect any project.
+
+* `ocean.text.convert.Formatter`
+
+  The return type of the sink alias, which was `size_t`, was changed to `void`
+  as the return value wasn't used.
+  As a result, the `Sink` alias is deprecated in favor of `FormatterSink`,
+  and so is the `sformat` overload accepting a `Sink`.

--- a/src/ocean/io/select/client/model/ISelectClient.d
+++ b/src/ocean/io/select/client/model/ISelectClient.d
@@ -425,7 +425,7 @@ public abstract class ISelectClient : ITimeoutClient, ISelectable, ISelectClient
     public void fmtInfo ( void delegate ( cstring chunk ) sink )
     {
         sformat(
-            (cstring chunk) {sink(chunk); return chunk.length;},
+            (cstring chunk) {sink(chunk); },
             "{} fd={} events=", this.id, this.fileHandle
         );
         foreach ( event, name; epoll_event_t.event_to_name )

--- a/src/ocean/text/convert/Formatter.d
+++ b/src/ocean/text/convert/Formatter.d
@@ -45,6 +45,25 @@ public alias size_t delegate(cstring) Sink;
 
 /*******************************************************************************
 
+    Internal sink type that wraps the user-provided one and takes care
+    of cropping and width
+
+    This sink expects to receive a full element as the first parameter,
+    in other words, the full chunk of text that needs a fixed size.
+    This is why one cannot format a whole aggregate (struct, arrays etc.), but
+    only individual elements.
+
+*******************************************************************************/
+
+private alias size_t delegate(cstring, ref Const!(FormatInfo)) ElemSink;
+
+/// This was accidentally made private so needs to be deprecated
+deprecated("This alias shouldn't be used from outside the Formatter")
+public alias size_t delegate(cstring, ref Const!(FormatInfo)) ElementSink;
+
+
+/*******************************************************************************
+
     Formats an input string into a newly-allocated string and returns it
 
     Params:
@@ -215,21 +234,6 @@ public bool sformat (Args...) (Sink sink, cstring fmt, Args args)
 
 /*******************************************************************************
 
-    Internal sink type that wraps the user-provided one and takes care
-    of cropping and width
-
-    This sink expects to receive a full element as the first parameter,
-    in other words, the full chunk of text that needs a fixed size.
-    This is why one cannot format a whole aggregate (struct, arrays etc.), but
-    only individual elements.
-
-*******************************************************************************/
-
-public alias size_t delegate(cstring, ref Const!(FormatInfo)) ElementSink;
-
-
-/*******************************************************************************
-
     A function that writes to a `Sink` according to the width limits
 
     Params:
@@ -290,7 +294,7 @@ private size_t widthSink (Sink sink, cstring str, ref Const!(FormatInfo) f)
 
 *******************************************************************************/
 
-private void handle (T) (T v, FormatInfo f, Sink sf, ElementSink se)
+private void handle (T) (T v, FormatInfo f, Sink sf, ElemSink se)
 {
     // Handle ref types explicitly
     static if (is (typeof(v is null)))
@@ -810,7 +814,7 @@ private bool readNumber (out size_t f, ref Const!(char)* s)
 
 *******************************************************************************/
 
-private void writePointer (in void* v, ref FormatInfo f, ElementSink se)
+private void writePointer (in void* v, ref FormatInfo f, ElemSink se)
 {
     alias void* T;
 


### PR DESCRIPTION
The return value is not used and the compatibility with Layout_tango is not needed.
Using void as a return type simplifies user code.

Fix #41 
CC @gavin-norman-sociomantic 