### PR TITLE
Move error-suppressing static asserts to unittest

### DIFF
--- a/src/ocean/util/serialize/contiguous/Deserializer.d
+++ b/src/ocean/util/serialize/contiguous/Deserializer.d
@@ -181,14 +181,6 @@ struct Deserializer
 
     alias hasMultiDimensionalDynamicArrays canDeserializeInPlace;
 
-    /**************************************************************************
-
-        NB! This will suppress any compilation errors, comment out during
-        development and enable only when commiting.
-
-    **************************************************************************/
-
-    static assert (isDeserializer!(This));
 
     /***************************************************************************
 
@@ -1125,6 +1117,11 @@ struct Deserializer
             }
         alias T RejectQualifier;
     }
+}
+
+unittest
+{
+    static assert (isDeserializer!(Deserializer));
 }
 
 unittest

--- a/src/ocean/util/serialize/contiguous/MultiVersionDecorator.d
+++ b/src/ocean/util/serialize/contiguous/MultiVersionDecorator.d
@@ -72,14 +72,6 @@ class VersionDecorator
 
     public alias VersionDecorator This;
 
-    /**************************************************************************
-
-        NB! This will suppress any compilation errors, comment out during
-        development and enable only when commiting.
-
-    **************************************************************************/
-
-    static assert (isDecorator!(This));
 
     /***************************************************************************
 
@@ -215,6 +207,11 @@ class VersionDecorator
 
         assert(0);
     }
+}
+
+unittest
+{
+    static assert (isDecorator!(VersionDecorator));
 }
 
 version(UnitTest)


### PR DESCRIPTION
The is no advantage in having them within the body, are unittests for ocean (and other applications) are always run.
However it does suppress error during development and lead to extra steps while debugging some core code (e.g. formatter).