### PR TITLE
Deprecate contiguous serializer traits

### DIFF
--- a/relnotes/serializer-traits.deprecation.md
+++ b/relnotes/serializer-traits.deprecation.md
@@ -1,0 +1,9 @@
+* `ocean.util.serializer.model.Traits`
+
+  The traits that check serializer/deserializer interface via structural typing
+  have been deprecated and current serializer/decorator implementation adapted
+  to not use them.
+
+  Those originated in over-generalized assumption that new framework will
+  be use to adjust all over serializers but it proved to be impactical for
+  the time. This has proven to not be the case and only complicated development.

--- a/src/ocean/util/serialize/contiguous/Deserializer.d
+++ b/src/ocean/util/serialize/contiguous/Deserializer.d
@@ -25,7 +25,6 @@ module ocean.util.serialize.contiguous.Deserializer;
 import ocean.transition;
 
 import ocean.util.serialize.contiguous.Contiguous;
-import ocean.util.serialize.model.Traits;
 
 import ocean.core.Enforce;
 import ocean.core.Traits;
@@ -1117,11 +1116,6 @@ struct Deserializer
             }
         alias T RejectQualifier;
     }
-}
-
-unittest
-{
-    static assert (isDeserializer!(Deserializer));
 }
 
 unittest

--- a/src/ocean/util/serialize/contiguous/MultiVersionDecorator.d
+++ b/src/ocean/util/serialize/contiguous/MultiVersionDecorator.d
@@ -33,7 +33,6 @@ import ocean.core.Enforce,
        ocean.core.StructConverter : structConvert;
 
 import ocean.util.serialize.Version,
-       ocean.util.serialize.model.Traits,
        ocean.util.serialize.model.VersionDecoratorMixins;
 
 import ocean.util.serialize.contiguous.Serializer,
@@ -73,22 +72,8 @@ class VersionDecorator
     public alias VersionDecorator This;
 
 
-    /***************************************************************************
-
-        Aliases for used Serializer / Deserializer implementations as demanded
-        by `isDecorator` trait.
-
-    ***************************************************************************/
-
-    public alias .Serializer  Serializer;
-
-    /***************************************************************************
-
-        ditto
-
-    ***************************************************************************/
-
-    public alias .Deserializer Deserializer;
+    deprecated public alias .Serializer  Serializer;
+    deprecated public alias .Deserializer Deserializer;
 
     /***************************************************************************
 
@@ -131,10 +116,10 @@ class VersionDecorator
 
     ***************************************************************************/
 
-    mixin StoreMethod!(Serializer);
-    mixin LoadMethod!(Deserializer, This.e);
+    mixin StoreMethod!(.Serializer);
+    mixin LoadMethod!(.Deserializer, This.e);
     mixin LoadCopyMethod!(This.e);
-    mixin ConvertMethod!(Serializer, Deserializer);
+    mixin ConvertMethod!(.Serializer, .Deserializer);
 
     /***************************************************************************
 
@@ -174,7 +159,7 @@ class VersionDecorator
         if (input_version == VInfo.number)
         {
             // no conversion is necessary
-            return Deserializer.deserialize!(S)(buffer);
+            return .Deserializer.deserialize!(S)(buffer);
         }
 
         if (input_version > VInfo.number)
@@ -207,11 +192,6 @@ class VersionDecorator
 
         assert(0);
     }
-}
-
-unittest
-{
-    static assert (isDecorator!(VersionDecorator));
 }
 
 version(UnitTest)

--- a/src/ocean/util/serialize/contiguous/Serializer.d
+++ b/src/ocean/util/serialize/contiguous/Serializer.d
@@ -24,7 +24,6 @@ module ocean.util.serialize.contiguous.Serializer;
 
 import ocean.transition;
 
-import ocean.util.serialize.model.Traits;
 import ocean.util.serialize.contiguous.Contiguous;
 
 import ocean.core.Traits : ContainsDynamicArray;
@@ -57,15 +56,6 @@ struct Serializer
     **************************************************************************/
 
     alias typeof(*this) This;
-
-    /**************************************************************************
-
-        NB! This will suppress any compilation errors, comment out during
-        development and enable only when commiting.
-
-    **************************************************************************/
-
-    static assert (isSerializer!(This));
 
     /***************************************************************************
 

--- a/src/ocean/util/serialize/model/Traits.d
+++ b/src/ocean/util/serialize/model/Traits.d
@@ -47,7 +47,7 @@ private struct _Dummy
 
 *******************************************************************************/
 
-template isSerializer(T)
+deprecated template isSerializer(T)
 {
     public const isSerializer =
         is(typeof({
@@ -59,7 +59,7 @@ template isSerializer(T)
         }));
 }
 
-unittest
+deprecated unittest
 {
     static assert( isSerializer!(DummySerializer));
     static assert(!isSerializer!(_Dummy));
@@ -102,7 +102,7 @@ version(UnitTest)
 
 *******************************************************************************/
 
-template isDeserializer(T)
+deprecated template isDeserializer(T)
 {
     public const isDeserializer =
         is(typeof({
@@ -118,7 +118,7 @@ template isDeserializer(T)
         }));
 }
 
-unittest
+deprecated unittest
 {
     static assert( isDeserializer!(DummyDeserializer));
     static assert(!isDeserializer!(_Dummy));
@@ -171,7 +171,7 @@ version(UnitTest)
 
 *******************************************************************************/
 
-template isDecorator(T)
+deprecated template isDecorator(T)
 {
     static if (
            is(typeof({ alias T.Serializer Alias; }))
@@ -200,7 +200,7 @@ template isDecorator(T)
     }
 }
 
-unittest
+deprecated unittest
 {
     static assert( isDecorator!(DummyDecorator));
     static assert(!isDecorator!(_Dummy));
@@ -245,7 +245,7 @@ version(UnitTest)
 
 *******************************************************************************/
 
-template DeserializerReturnType(D, S)
+deprecated template DeserializerReturnType(D, S)
 {
     static assert (isDeserializer!(D));
 
@@ -260,7 +260,7 @@ template DeserializerReturnType(D, S)
         DeserializerReturnType;
 }
 
-unittest
+deprecated unittest
 {
     static assert (is(DeserializerReturnType!(DummyDeserializer, _Dummy) == _Dummy));
 }

--- a/src/ocean/util/serialize/model/VersionDecoratorMixins.d
+++ b/src/ocean/util/serialize/model/VersionDecoratorMixins.d
@@ -29,8 +29,8 @@ import ocean.core.Enforce,
        ocean.util.container.ConcatBuffer,
        ocean.core.StructConverter;
 
-import ocean.util.serialize.Version,
-       ocean.util.serialize.model.Traits;
+import ocean.util.serialize.Version;
+import ocean.util.serialize.contiguous.Contiguous;
 
 import ocean.stdc.string;
 
@@ -127,7 +127,7 @@ template LoadMethod (Deserializer, alias exception_field)
 
     ***************************************************************************/
 
-    public DeserializerReturnType!(Deserializer, S) load(S)(ref void[] buffer)
+    public Contiguous!(S) load(S)(ref void[] buffer)
     {
         static assert (
             Version.Info!(S).exists,
@@ -186,7 +186,7 @@ template HandleVersionMethod(Deserializer, alias exception_field)
 
     ***************************************************************************/
 
-    private DeserializerReturnType!(Deserializer, S) handleVersion(S)
+    private Contiguous!(S) handleVersion(S)
         (ref void[] buffer, Version.Type input_version)
     body
     {
@@ -261,7 +261,7 @@ template ConvertMethod(Serializer, Deserializer)
 
     ***************************************************************************/
 
-    private DeserializerReturnType!(Deserializer, S) convert(S, Source)
+    private Contiguous!(S) convert(S, Source)
         (ref void[] buffer)
     {
         scope(exit)
@@ -375,14 +375,14 @@ version(UnitTest)
 {
     struct DummyDeserializer
     {
-        static void[] deserialize(S)(void[] buffer)
+        static Contiguous!(S) deserialize(S)(void[] buffer)
         {
-            return null;
+            return Contiguous!(S).init;
         }
 
-        static void[] deserialize(S)(void[] buffer, void[] copy_buffer)
+        static Contiguous!(S) deserialize(S)(void[] buffer, void[] copy_buffer)
         {
-            return null;
+            return Contiguous!(S).init;
         }
 
         static size_t countRequiredSize(S)(void[] buffer)


### PR DESCRIPTION
Those originated in over-generalized assumption that new framework will
be use to adjust all over serializers but it proved to be impactical for
the time.

At the same time extra compile-time reflection complicated code
structure consierably and resulted in suppression of relevant compiler
messages. It is better to deprecate/remove it for now and reconsider if
standardization of serializer is to happen again.