### PR TITLE
Formatter: toString overloads are not recognized anymore

### DIFF
--- a/src/ocean/text/convert/Formatter.d
+++ b/src/ocean/text/convert/Formatter.d
@@ -385,7 +385,14 @@ private void handle (T) (T v, FormatInfo f, FormatterSink sf, ElemSink se)
     // toString hook: Give priority to the non-allocating one
     // Note: sink `toString` overload should take a `scope` delegate
     else static if (is(typeof(v.toString(sf))))
-        v.toString((cstring e) { return se(e, f); });
+        v.toString((cstring e) { se(e, f); });
+    else static if (is(typeof(v.toString((size_t delegate(cstring)).init))))
+    {
+        pragma(msg, "Deprecation: Please change toString to accept ",
+               "`scope FormatterSink` instead of `size_t delegate(cstring)` in ",
+               T.stringof);
+        v.toString((cstring e) { se(e, f); return e.length; });
+    }
     else static if (is(typeof(v.toString()) : cstring))
         se(v.toString(), f);
     else static if (is(T == interface))

--- a/src/ocean/text/convert/Formatter_test.d
+++ b/src/ocean/text/convert/Formatter_test.d
@@ -1,0 +1,53 @@
+/*******************************************************************************
+
+    Test module for ocean.text.convert.Formatter
+
+    Copyright:
+        Copyright (c) 2009-2016 Sociomantic Labs GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+        Alternatively, this file may be distributed under the terms of the Tango
+        3-Clause BSD License (see LICENSE_BSD.txt for details).
+
+*******************************************************************************/
+
+module ocean.text.convert.Formatter_test;
+
+import ocean.core.Test;
+import ocean.text.convert.Formatter;
+import ocean.transition;
+
+/// Tests for #120
+unittest
+{
+    static struct Foo
+    {
+        int i = 0x2A;
+        void toString (size_t delegate (cstring) sink)
+        {
+            sink("Hello size_t");
+        }
+    }
+
+    Foo f;
+    test!("==")(format("{}", f), "Hello size_t");
+
+    static struct Bar
+    {
+        int i = 0x2A;
+         void toString (size_t delegate (cstring) sink)
+        {
+            sink("Hello size_t");
+        }
+        // This one takes precedence
+        void toString (void delegate (cstring) sink)
+        {
+            sink("Hello void");
+        }
+    }
+
+    Bar b;
+    test!("==")(format("{}", b), "Hello void");
+}

--- a/src/ocean/time/Time.d
+++ b/src/ocean/time/Time.d
@@ -709,10 +709,20 @@ struct Time
 
     /// Support for `ocean.text.convert.Formatter`: Print the string in a
     /// user-friendly way
+    deprecated("Use the overload accepting a FormatterSink")
     public void toString (size_t delegate(cstring) sink)
     {
         // Layout defaults to 'G'
         DateTimeDefault.format(sink, *this, "");
+    }
+
+    /// Support for `ocean.text.convert.Formatter`: Print the string in a
+    /// user-friendly way
+    public void toString (void delegate(cstring) sink)
+    {
+        // Layout defaults to 'G'
+        scope dg = (cstring s) { sink(s); return s.length; };
+        DateTimeDefault.format(dg, *this, "");
     }
 }
 


### PR DESCRIPTION
This regression was introduced in #112. While changing the type internally used by the formatter,
it affected which toString overload can be used.
We now correctly recognize both toString overloads and issue a 'deprecation' message when size_t is encountered.