### PR TITLE
Add ability to pass a makeLayout delegate to new loggers

### DIFF
--- a/src/ocean/util/app/ext/LogExt.d
+++ b/src/ocean/util/app/ext/LogExt.d
@@ -177,7 +177,7 @@ class LogExt : IConfigExtExtension
             this.layout_maker, this.use_insert_appender);
 
         LogUtil.configureNewLoggers(log_config, log_meta_config, &appender,
-            this.use_insert_appender);
+            this.layout_maker, this.use_insert_appender);
 
         foreach (ext; this.extensions)
         {


### PR DESCRIPTION
This was implemented in v2.x.x by #34 but we need to apply this change to new loggers as well.