### PR TITLE
Make ocean.core.Traits : isTypedef, StripTypedef useful in D2

### DIFF
--- a/relnotes/typedef-no-more.feature.md
+++ b/relnotes/typedef-no-more.feature.md
@@ -1,0 +1,6 @@
+* `ocean.core.Traits : isTypedef, StripTypedef`
+
+  Those functions now behave the same in D1 and D2.
+  Previously they were no-op in D2 under the assumption that Typedef
+  could be handled generically using type conversion instead of strict type checks,
+  but this proved to not be possible.

--- a/src/ocean/io/serialize/StructSerializer.d
+++ b/src/ocean/io/serialize/StructSerializer.d
@@ -575,12 +575,8 @@ struct StructSerializer ( bool AllowUnions = false )
 
                 static if (isTypedef!(T))
                 {
-                    mixin(`
-                    static if ( is(T B == typedef) )
-                    {
-                        serializer.serialize(data, cast(B)(field), field_name);
-                    }
-                    `);
+                    serializer.serialize(data, cast(StripTypedef!(T))(field),
+                                         field_name);
                 }
                 else static if ( is(T B == enum) )
                 {
@@ -696,12 +692,8 @@ struct StructSerializer ( bool AllowUnions = false )
 
                 static if (isTypedef!(T))
                 {
-                    mixin(`
-                    else static if ( is(T B == typedef) )
-                    {
-                        deserializer.deserialize(cast(B)(*field), field_name);
-                    }
-                    `);
+                    deserializer.deserialize(cast(StripTypedef!(T))(*field),
+                                             field_name);
                 }
                 else static if ( is(T B == enum) )
                 {

--- a/src/ocean/io/serialize/TypeId.d
+++ b/src/ocean/io/serialize/TypeId.d
@@ -346,10 +346,7 @@ template BaseType ( T )
 {
     static if (isTypedef!(T))
     {
-        mixin(`
-            static if (is (T Base == typedef))
-                alias BaseType!(Base) BaseType;
-        `);
+        alias BaseType!(StripTypedef!(T)) BaseType;
     }
     else static if (is (T Base == enum))
     {

--- a/src/ocean/text/convert/Formatter.d
+++ b/src/ocean/text/convert/Formatter.d
@@ -379,8 +379,8 @@ private void handle (T) (T v, FormatInfo f, FormatterSink sf, ElemSink se)
      * but only the means to perform it.
      * This could be solved later with a UDA, but it's at best a workaround.
      */
-    else static if (IsTypedef!(T))
-        handle!(DropTypedef!(T))(v, f, sf, se);
+    else static if (isTypedef!(T))
+        handle!(StripTypedef!(T))(v, f, sf, se);
 
     // toString hook: Give priority to the non-allocating one
     // Note: sink `toString` overload should take a `scope` delegate
@@ -556,56 +556,6 @@ private template IsTypeofNull (T)
     {
         public const bool IsTypeofNull = false;
     }
-}
-
-
-/*******************************************************************************
-
-        Helper template to detect if a given type is a typedef (D1 and D2).
-
-        This bears the same name as the template in `ocean.core.Traits`.
-        However, the definition in `Traits` unconditionally returns `false`
-        in D2.
-        While it might be suitable for most use cases, here we have to
-        explicitly handle `typedef`.
-
-        Params:
-            T   = Type to check
-
-*******************************************************************************/
-
-private template IsTypedef (T)
-{
-    version (D_Version2)
-        const IsTypedef = is(T.IsTypedef);
-    else
-        const IsTypedef = mixin("is(T == typedef)");
-}
-
-/*******************************************************************************
-
-        Helper template to get the underlying type of a typedef (D1 and D2).
-
-        This bears the same name as the template in `ocean.core.Traits`.
-        However, the definition in `Traits` unconditionally returns `T` in D2.
-        While it might be suitable for most use cases, here we have to
-        explicitly handle `typedef`.
-
-        Params:
-            T   = Typedef for which to get the underlying type
-
-*******************************************************************************/
-
-private template DropTypedef (T)
-{
-    static assert(IsTypedef!(T),
-                  "DropTypedef called on non-typedef type " ~ T.stringof);
-
-    version (D_Version2)
-        alias typeof(T.value) DropTypedef;
-    else
-        mixin("static if (is (T V == typedef))
-                alias V DropTypedef;");
 }
 
 

--- a/src/ocean/transition.d
+++ b/src/ocean/transition.d
@@ -101,6 +101,7 @@ template Typedef(T, istring name, T initval)
                 ("static struct " ~ name ~
                 "{ " ~
                 "alias IsTypedef = void;" ~
+                "alias TypedefBaseType = " ~ T.stringof ~ ";" ~
                 T.stringof ~ " value = " ~ initval.stringof ~ ";" ~
                 "alias value this;" ~
                 "this(" ~ T.stringof ~ " rhs) { this.value = rhs; }" ~
@@ -127,6 +128,7 @@ template Typedef(T, istring name)
                 ("static struct " ~ name ~
                 "{ " ~
                 "alias IsTypedef = void;" ~
+                "alias TypedefBaseType = " ~ T.stringof ~ ";" ~
                 T.stringof ~ " value; " ~
                 "alias value this;" ~
                 "this(" ~ T.stringof ~ " rhs) { this.value = rhs; }" ~

--- a/src/ocean/util/Convert.d
+++ b/src/ocean/util/Convert.d
@@ -1137,29 +1137,11 @@ D toFromUDT(D,S)(S value)
 
 D toImpl(D,S)(S value)
 {
-    version (D_Version2)
-    {
-        // has own different static branch
-        const isTypedef = false;
-    }
-    else
-    {
-        mixin("
-            static if (is( S BaseType == typedef ))
-                const isTypedef = true;
-            else
-                const isTypedef = false;
-        ");
-    }
-
     static if( is( D == S ) )
         return value;
 
-    else static if ( isTypedef )
-        return toImpl!(D,BaseType)(value);
-
-    else static if ( is(S.IsTypedef) )
-        return toImpl!(D, typeof(S.value))(value.value);
+    else static if (isTypedef!(S))
+        return toImpl!(D,StripTypedef!(S))(value);
 
     else static if( is( S BaseType == enum ) )
         return toImpl!(D,BaseType)(value);


### PR DESCRIPTION
It's been a common problem during porting that some meta code needed to special-case Typedef but couldn't.
The code was originally trying to ensure that no typedef special casing happened, but it proved impossible in some cases,
which led to libraries / utilities implementing their own StripTypedef / IsTypedef (e.g. the Formatter).
This fixes the problem at the root, by exposing same behavior between D1 and D2.

CC @mihails-strasuns-sociomantic 