### PR TITLE
Formatter: Do not explicitly instantiate the non-deprecated sformat

### DIFF
--- a/src/ocean/text/convert/Formatter.d
+++ b/src/ocean/text/convert/Formatter.d
@@ -237,7 +237,7 @@ public bool sformat (Args...) (FormatterSink sink, cstring fmt, Args args)
 deprecated("Use the overload which accepts a `FormatterSink` instead")
 public bool sformat (Args...) (Sink sink, cstring fmt, Args args)
 {
-    return sformat!(Args)((cstring s) { sink(s); }, fmt, args);
+    return sformat((cstring s) { sink(s); }, fmt, args);
 }
 
 


### PR DESCRIPTION
This triggers an ICE in DMD1:
dmd1: template.c:4644: Identifier* TemplateInstance::genIdent(): Assertion 'i + 1 == args->dim' failed.
It happens because some code in swarm is calling the deprecated overload of sformat,
and the ICE is triggered without showing any deprecation message. It does not happen in D2.
Attempts to craft a test case to reproduce the issue were unsuccessful.

CC @daniel-zullo-sociomantic , could you test to see if it resolves your issue ?