### PR TITLE
[WIP] (Re)Configurable loggers

### DIFF
--- a/src/ocean/util/app/DaemonApp.d
+++ b/src/ocean/util/app/DaemonApp.d
@@ -397,9 +397,11 @@ public abstract class DaemonApp : Application,
         this.config_ext.registerExtension(this.pidlock_ext);
         this.registerExtension(this.pidlock_ext);
 
+        // Unix socket extension and default commands
         this.unix_socket_ext = new UnixSocketExt();
         this.config_ext.registerExtension(this.unix_socket_ext);
         this.registerExtension(this.unix_socket_ext);
+        this.unix_socket_ext.addHandler("SetLogger", &this.log_ext.unixSocketHandler);
 
         if (settings.use_task_ext)
         {

--- a/src/ocean/util/app/ext/LogExt.d
+++ b/src/ocean/util/app/ext/LogExt.d
@@ -17,6 +17,9 @@ module ocean.util.app.ext.LogExt;
 
 import ocean.core.TypeConvert;
 import ocean.io.device.File;
+import ocean.stdc.string;
+import ocean.text.convert.Formatter;
+import ocean.text.util.SplitIterator;
 import ocean.transition;
 import ocean.util.app.Application;
 import ocean.util.app.ext.ConfigExt;
@@ -28,6 +31,8 @@ import ConfigFiller = ocean.util.config.ConfigFiller;
 import ocean.util.config.ConfigParser;
 import ocean.util.log.Appender;
 import LogUtil = ocean.util.log.Config;
+import ocean.util.log.Logger;
+import ocean.util.log.model.ILogger;
 
 
 /*******************************************************************************
@@ -229,5 +234,145 @@ class LogExt : IConfigExtExtension
     private Appender.Layout makeLayoutDefault ( cstring name )
     {
         return LogUtil.newLayout(name);
+    }
+
+    /***************************************************************************
+
+        Support for dynamic configuration of `Logger` through `UnixSocketExt`
+
+        Entry point (handler) which is passed to `UnixSocketExt`.
+        From there, forwards to `unixSocketCommand`.
+
+        Params:
+            args = Arguments passed via the unix socket, split on space
+            send = Delegate to use to answer
+
+    ***************************************************************************/
+
+    public void unixSocketHandler ( cstring[] args, UnixSocketSink send )
+    {
+        if (!args.length || args[0] == "help")
+            return sendUsage(send);
+
+        if (args[0] == "set")
+        {
+            // Need at least: 'set', 'LoggerName', 'k=v'
+            if (args.length < 3)
+                return sendUsage(send);
+
+            auto logger = icmp(args[1], "root") ? Log.root : Log.lookup(args[1]);
+            // We do not want to half-reconfigure a logger, it should be all or
+            // nothing, which is why we have this recursive logic instead of
+            // a loop.
+            if (this.unixSocketCommand(send, logger.additive(), logger,
+                                       args[2 .. $]))
+                return send("OK\n");
+            else
+                return send("Error happened while processing command 'set'\n");
+        }
+
+        send("Invalid command: ");
+        send(args[0]);
+        send("\n\n");
+        return sendUsage(send);
+    }
+
+    /// Type of sink for the UnixSocketHandler
+    private alias void delegate (cstring msg) UnixSocketSink;
+
+    /// Perform a case-insensitive string comparison
+    private static bool icmp (cstring a, cstring b)
+    {
+        return a.length == b.length && !strncasecmp(a.ptr, b.ptr, a.length);
+    }
+
+    /***************************************************************************
+
+        Write usage information to the provided delegate
+
+        Params:
+            send = Delegate to write the usage information to
+
+    ***************************************************************************/
+
+    private static void sendUsage ( UnixSocketSink send )
+    {
+        send(`SetLogger is a command to change the configuration of a logger
+The modification is temporary and will not be in effect after restart
+
+Usage: SetLogger help
+       SetLogger set Name [ARGS...]
+
+    - help  = Print this usage message;
+    - set   = Set the provided arguments for logger 'Name', keep existing values intact
+
+Arguments to 'set' are key-value pairs, e.g. 'level=trace' or 'file=log/newfile.log'.
+Note that the order in which arguments are processed is not guaranteed,
+except for 'additive' which will affect subsequent arguments.
+As a result, if 'additive' is provided, it should be before 'level',
+or it won't be taken into account.
+`);
+    }
+
+
+    /***************************************************************************
+
+        Reconfigure a logger according to the commands
+
+        Recurses to ensure all modifications happen, or none at all.
+
+        Params:
+            send      = Delegate to use to respond to the user
+            propagate = Whether the user want the modification to propagate to
+                        child loggers. By default, use the `additive` property
+                        of the Logger (which is `true` by default).
+            logger    = Logger to reconfigure
+            remaining = Remaining arguments to process
+
+        Returns:
+            Whether reconfiguring succeeded (`true`) or not (`false`).
+
+    ***************************************************************************/
+
+    private bool unixSocketCommand ( UnixSocketSink send, bool additive,
+                                     Logger logger, in cstring[] remaining )
+    {
+        if (!remaining.length)
+            return true;
+
+        scope it = new ChrSplitIterator('=');
+        it.reset(remaining[0]);
+        cstring opt = it.next();
+        cstring value = it.remaining();
+
+        if (icmp(opt, "additive"))
+        {
+            if (icmp(value, "true") || icmp(value, "1"))
+                additive = true;
+            else if (icmp(value, "false") || icmp(value, "0"))
+                additive = false;
+            else
+            {
+                sformat(send, "Error: '{}' is not a recognized boolean value. "
+                        ~ "Use 'true', 'false', '1' or '0'\n", value);
+                return false;
+            }
+
+            return this.unixSocketCommand(send, additive, logger, remaining[1 .. $]);
+        }
+
+        if (icmp(opt, "level"))
+        {
+            auto lvl = ILogger.convert(value, logger.level());
+            if (this.unixSocketCommand(send, additive, logger, remaining[1 .. $]))
+            {
+                logger.level(lvl, additive);
+                return true;
+            }
+            return false;
+        }
+
+        sformat(send, "Changing property {} is not implemented\n", opt);
+        return false;
     }
 }

--- a/src/ocean/util/app/ext/LogExt.d
+++ b/src/ocean/util/app/ext/LogExt.d
@@ -15,28 +15,19 @@
 
 module ocean.util.app.ext.LogExt;
 
-
-
-
 import ocean.core.TypeConvert;
-
-import ocean.util.app.model.ExtensibleClassMixin;
+import ocean.io.device.File;
+import ocean.transition;
 import ocean.util.app.Application;
+import ocean.util.app.ext.ConfigExt;
 import ocean.util.app.ext.model.IConfigExtExtension;
 import ocean.util.app.ext.model.ILogExtExtension;
-import ocean.util.app.ext.ConfigExt;
-
 import ocean.util.app.ext.ReopenableFilesExt;
-
-import ocean.util.config.ConfigFiller;
-import ocean.util.config.ConfigParser;
-import LogUtil = ocean.util.log.Config;
+import ocean.util.app.model.ExtensibleClassMixin;
 import ConfigFiller = ocean.util.config.ConfigFiller;
-
-import ocean.transition;
-import ocean.io.device.File;
-
+import ocean.util.config.ConfigParser;
 import ocean.util.log.Appender;
+import LogUtil = ocean.util.log.Config;
 
 
 /*******************************************************************************
@@ -163,7 +154,7 @@ class LogExt : IConfigExtExtension
             return new AppendStream(stream, true, layout);
         }
 
-        enable_loose_parsing(conf_ext.loose_config_parsing);
+        ConfigFiller.enable_loose_parsing(conf_ext.loose_config_parsing);
 
         LogUtil.configureNewLoggers(log_config, log_meta_config, &appender,
             this.layout_maker, this.use_insert_appender);

--- a/test/logger_unixsocketext/main.d
+++ b/test/logger_unixsocketext/main.d
@@ -1,0 +1,221 @@
+/*******************************************************************************
+
+    Test-suite for UnixSocketExt's logger (re)configuration.
+
+    Copyright:
+        Copyright (c) 2017 sociomantic labs GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+        Alternatively, this file may be distributed under the terms of the Tango
+        3-Clause BSD License (see LICENSE_BSD.txt for details).
+
+*******************************************************************************/
+
+module test.logger_unixsocketext.main;
+
+import ocean.core.Enforce;
+import Ocean = ocean.core.Test;
+import ocean.io.select.EpollSelectDispatcher;
+import ocean.io.Stdout;
+import ocean.io.stream.TextFile;
+import ocean.stdc.posix.sys.socket;
+import ocean.stdc.posix.sys.un;
+import ocean.sys.socket.UnixSocket;
+import ocean.task.Scheduler;
+import ocean.task.Task;
+import ocean.task.util.Timer;
+import ocean.text.convert.Formatter;
+import ocean.transition;
+import ocean.util.app.DaemonApp;
+import ocean.util.log.model.ILogger;
+import ocean.util.log.Logger;
+import ocean.util.test.DirectorySandbox;
+
+
+/// Logger instances
+private Logger new_ns1;
+private Logger new_ns2;
+
+static this ()
+{
+    new_ns1 = Log.lookup("UnixSocketExtTest.NS1.Foo");
+    new_ns2 = Log.lookup("UnixSocketExtTest.NS2.Foo");
+}
+
+///
+public final class TestedApp : DaemonApp
+{
+    public this ()
+    {
+        super("UnixSocketExt",
+              "Test for DaemonApp's UnixSocketExt logger configuration",
+              null);
+    }
+
+    public override int run (Arguments args, ConfigParser config)
+    {
+        SchedulerConfiguration sconfig;
+        initScheduler(sconfig);
+
+        scope task = new TestTask;
+        theScheduler.schedule(task);
+
+        this.startEventHandling(theScheduler.epoll);
+        theScheduler.eventLoop();
+
+        return task.error ? 1 : 0;
+    }
+}
+
+private final class TestTask : Task
+{
+    public bool error = true;
+    private UnixSocket client;
+
+    private const istring HelpMsg = `SetLogger is a command to change the configuration of a logger
+The modification is temporary and will not be in effect after restart
+
+Usage: SetLogger help
+       SetLogger set Name [ARGS...]
+
+    - help  = Print this usage message;
+    - set   = Set the provided arguments for logger 'Name', keep existing values intact
+
+Arguments to 'set' are key-value pairs, e.g. 'level=trace' or 'file=log/newfile.log'.
+Note that the order in which arguments are processed is not guaranteed,
+except for 'additive' which will affect subsequent arguments.
+As a result, if 'additive' is provided, it should be before 'level',
+or it won't be taken into account.
+`;
+
+    public override void run ()
+    {
+        // We need this for `connect` to succeed
+        wait(1_000);
+
+        this.client = new UnixSocket();
+        scope(exit)
+        {
+            this.client.close();
+            this.client = null;
+        }
+
+        auto addr = sockaddr_un.create(`mytest.socket`);
+        this.client.socket(SOCK_STREAM | SOCK_NONBLOCK);
+        auto connect_result = this.client.connect(&addr);
+        assert(connect_result == 0, "connect() call failed");
+
+        try
+        {
+            this.doTest();
+            this.error = false;
+        }
+        catch (Exception e)
+        {
+            this.error = true;
+            Stderr.formatln("Test failed (at {}:{}):", e.file, e.line);
+            Stderr(getMsg(e)).nl;
+        }
+
+        theScheduler.shutdown();
+    }
+
+    private void doTest ()
+    {
+        cstring response;
+
+        // Ensure argumentless SetLogger returns us the help message
+        response = this.send("SetLogger\n");
+        Ocean.test!("==")(response, HelpMsg);
+
+        // And the help command should work as well
+        response = this.send("SetLogger help\n");
+        Ocean.test!("==")(response, HelpMsg);
+
+        // Sanity checks that the config was applied
+        Ocean.test!("==")(new_ns1.level, ILogger.Level.Error);
+        Ocean.test!("==")(new_ns2.level, ILogger.Level.Error);
+
+        // Reconfiguring a single logger
+        response = this.send("SetLogger set UnixSocketExtTest.NS1.Foo level=Info\n");
+        Ocean.test!("==")(response, "OK\n");
+        Ocean.test!("==")(new_ns1.level, ILogger.Level.Info);
+        Ocean.test!("==")(new_ns2.level, ILogger.Level.Error);
+
+        // Reconfiguring a single logger through a parent
+
+        response = this.send("SetLogger set UnixSocketExtTest.NS2 additive=true level=Warn\n");
+        Ocean.test!("==")(response, "OK\n");
+        Ocean.test!("==")(new_ns1.level, ILogger.Level.Info);
+        Ocean.test!("==")(new_ns2.level, ILogger.Level.Warn);
+
+        // Reconfiguring both loggers through a parent
+        response = this.send("SetLogger set UnixSocketExtTest additive=true level=Error\n");
+        Ocean.test!("==")(response, "OK\n");
+        Ocean.test!("==")(new_ns1.level, ILogger.Level.Error);
+        Ocean.test!("==")(new_ns2.level, ILogger.Level.Error);
+
+        // Configuring Root logger
+        response = this.send("SetLogger set Root additive=true level=Fatal\n");
+        Ocean.test!("==")(response, "OK\n");
+
+        Ocean.test!("==")(Log.root.level, ILogger.Level.Fatal);
+        Ocean.test!("==")(new_ns1.level, ILogger.Level.Fatal);
+        Ocean.test!("==")(new_ns2.level, ILogger.Level.Fatal);
+
+        // Configuring Root logger without additive
+        response = this.send("SetLogger set Root level=Trace\n");
+        Ocean.test!("==")(response, "OK\n");
+
+        Ocean.test!("==")(Log.root.level, ILogger.Level.Trace);
+        Ocean.test!("==")(new_ns1.level, ILogger.Level.Fatal);
+        Ocean.test!("==")(new_ns2.level, ILogger.Level.Fatal);
+    }
+
+    private cstring send (cstring query)
+    {
+        static mstring buffer;
+
+        if (buffer is null)
+            buffer = new mstring(1020);
+
+        this.client.write(query);
+        wait(1_000);
+        ssize_t read_size = client.recv(buffer, 0);
+        assert(read_size > 0, query);
+        return buffer[0 .. read_size];
+    }
+}
+
+
+/// Entry point
+int main (istring[] args)
+{
+    scope sandbox = DirectorySandbox.create(["etc", "log"]);
+    scope (success) sandbox.remove();
+    scope (failure) sandbox.exitSandbox();
+
+    scope config = new TextFileOutput("etc/config.ini");
+    config.print(`[UNIX_SOCKET]
+path=./mytest.socket
+
+[LOG.Root]
+level = error
+propagate = true
+console = false
+file = log/root.log
+file_layout = simple
+
+[LOG.UnixSocketExtTest.NS1.Foo]
+file = log/ns1.log
+
+[LOG.UnixSocketExtTest.NS2.Foo]
+file = log/ns2.log
+`);
+    config.flush();
+
+    scope app = new TestedApp();
+    return app.main(args);
+}


### PR DESCRIPTION
```
This commit add a default handler for the UnixSocket extension,
which allow one to reconfigure the loggers without restarting the app.
Connecting to the unix socket (through e.g. `nc`), one can send
commands such as `SetLogger set fully.qualified.name level=[Info,Fatal,...]`.

Potential enhancements being considered:
- Currently we only support 'propagate' and 'level'.
  What other properties would be interesting ? 'file' / 'layout' ?
- Currently we only support the 'set' command.
  One of the original idea is to also support 'reset'.
  But this would require to store the original config within the logger (arguably doesn't scale).
  Another option would be to add the ability to re-parse the config file(s).

Fixes #37
```

Just here so we don't loose track of it. The integration test passes (also tested with ocean v3, found a bug that I'll file separately). Will test with a real app soon :tm: 