### PR TITLE
Revisit typedef handling approach in ocean

### DIFF
--- a/relnotes/typedef.deprecation.md
+++ b/relnotes/typedef.deprecation.md
@@ -1,0 +1,7 @@
+* `ocean.core.Traits`
+
+  `StripTypedef` and `isTypedef` templates are deprecated with intention to
+  revisit every place where those have been used and evaluate if such custom
+  handling is still needed in D2 builds. New `ocean.transition.isD1Typedef`
+  and `ocean.transition.TypedefBaseType` templates were added to clearly
+  differentiate such places after decision will be made.

--- a/src/ocean/io/select/protocol/task/TaskSelectClient.d
+++ b/src/ocean/io/select/protocol/task/TaskSelectClient.d
@@ -26,7 +26,6 @@ class TaskSelectClient: ISelectClient
     import ocean.task.Task: Task;
     import ocean.task.Scheduler: theScheduler;
     import ocean.io.select.protocol.task.TimeoutException;
-    import ocean.core.Traits: StripTypedef;
     import ocean.util.log.Log;
     import ocean.transition;
 

--- a/src/ocean/io/serialize/StructSerializer.d
+++ b/src/ocean/io/serialize/StructSerializer.d
@@ -573,14 +573,10 @@ struct StructSerializer ( bool AllowUnions = false )
             {
                 mixin AssertSupportedType!(T, S, i);
 
-                static if (isTypedef!(T))
+                static if (isD1Typedef!(T))
                 {
-                    mixin(`
-                    static if ( is(T B == typedef) )
-                    {
-                        serializer.serialize(data, cast(B)(field), field_name);
-                    }
-                    `);
+                    serializer.serialize(data, cast(TypedefBaseType!(T)) field,
+                            field_name);
                 }
                 else static if ( is(T B == enum) )
                 {
@@ -694,14 +690,10 @@ struct StructSerializer ( bool AllowUnions = false )
             {
                 mixin AssertSupportedType!(T, S, i);
 
-                static if (isTypedef!(T))
+                static if (isD1Typedef!(T))
                 {
-                    mixin(`
-                    else static if ( is(T B == typedef) )
-                    {
-                        deserializer.deserialize(cast(B)(*field), field_name);
-                    }
-                    `);
+                    deserializer.deserialize(cast(TypedefBaseType!(T))(*field),
+                        field_name);
                 }
                 else static if ( is(T B == enum) )
                 {

--- a/src/ocean/io/serialize/TypeId.d
+++ b/src/ocean/io/serialize/TypeId.d
@@ -344,12 +344,13 @@ template CheckedBaseType ( T )
 
 template BaseType ( T )
 {
-    static if (isTypedef!(T))
+    static if (is(TypedefBaseType!(T)))
     {
-        mixin(`
-            static if (is (T Base == typedef))
-                alias BaseType!(Base) BaseType;
-        `);
+        // this code would work correctly without removing typedef in D2 version
+        // but the module is used as part of MapSerializer which requires stored
+        // data to be loadable between D1 and D2 builds
+
+        alias BaseType!(TypedefBaseType!(T)) BaseType;
     }
     else static if (is (T Base == enum))
     {

--- a/src/ocean/util/Convert.d
+++ b/src/ocean/util/Convert.d
@@ -1137,29 +1137,11 @@ D toFromUDT(D,S)(S value)
 
 D toImpl(D,S)(S value)
 {
-    version (D_Version2)
-    {
-        // has own different static branch
-        const isTypedef = false;
-    }
-    else
-    {
-        mixin("
-            static if (is( S BaseType == typedef ))
-                const isTypedef = true;
-            else
-                const isTypedef = false;
-        ");
-    }
-
     static if( is( D == S ) )
         return value;
 
-    else static if ( isTypedef )
-        return toImpl!(D,BaseType)(value);
-
-    else static if ( is(S.IsTypedef) )
-        return toImpl!(D, typeof(S.value))(value.value);
+    else static if ( is(TypedefBaseType!(S)) )
+        return toImpl!(D, TypedefBaseType!(S))(value);
 
     else static if( is( S BaseType == enum ) )
         return toImpl!(D,BaseType)(value);

--- a/src/ocean/util/container/pool/FreeList.d
+++ b/src/ocean/util/container/pool/FreeList.d
@@ -41,7 +41,7 @@ import ocean.util.container.pool.model.IFreeList;
 
 import ocean.core.Array : pop;
 
-import ocean.core.Traits;
+import ocean.meta.traits.Basic;
 
 import ocean.transition;
 
@@ -56,9 +56,11 @@ import ocean.transition;
 
 private template ItemType_ ( T )
 {
-    static if ( isReferenceType!(StripTypedef!(T)) ||
-                isDynamicArrayType!(StripTypedef!(T)) ||
-                isAssocArrayType!(StripTypedef!(T)) )
+    static if (isD1Typedef!(T))
+    {
+        alias ItemType_!(TypedefBaseType!(T)) ItemType_;
+    }
+    else static if (isReferenceType!(T))
     {
         alias T ItemType_;
     }
@@ -88,8 +90,11 @@ public class FreeList ( T ) : IFreeList!(ItemType_!(T))
 
     ***************************************************************************/
 
-    static assert(!isStaticArrayType!(T), "Cannot use static array type '"
-        ~ T.stringof ~ "' as base type for FreeList");
+    static assert(
+        isArrayType!(T) != ArrayKind.Static,
+        "Cannot use static array type '" ~ T.stringof ~
+            "' as base type for FreeList"
+    );
 
     static assert(!isPrimitiveType!(T), "Cannot use primitive type '" ~ T.stringof ~
         "' as base type for FreeList");


### PR DESCRIPTION
Attempt to make library code which has to handle old D1 typedef more
concise while clearly distinguishing places where typedef-specific will
need to remain even after dropping D1 from those where such code
branches can immediately be safely removed after dropping D1.