### PR TITLE
Use docker image tag when reporting coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services: docker
 env:
     - DC=dmd1 DIST=trusty F=production
     - DC=dmd1 DIST=trusty F=devel
-    - DC=dmd1 DIST=xenial F=production
+    - DC=dmd1 DIST=xenial F=production AFTER_SCRIPT=1
     - DC=dmd1 DIST=xenial F=devel
     - DC=dmd-transitional DIST=trusty F=production
     - DC=dmd-transitional DIST=trusty F=devel

--- a/ci/travis-after-success.sh
+++ b/ci/travis-after-success.sh
@@ -7,7 +7,7 @@ docker run -ti --rm -v $PWD:/docker -w /docker \
     -e TRAVIS -e TRAVIS_BRANCH -e TRAVIS_COMMIT -e TRAVIS_JOB_NUMBER \
     -e TRAVIS_PULL_REQUEST -e TRAVIS_JOB_ID -e TRAVIS_REPO_SLUG -e TRAVIS_TAG \
     -e TRAVIS_OS_NAME -e TRAVIS_PULL_REQUEST_BRANCH -e TRAVIS_PULL_REQUEST_SHA \
-    ocean bash ci/codecov.sh
+    ocean:$DIST bash ci/codecov.sh
 
 # If this is a tag, convert and push to ocean-d2 repo
 if test -n "$TRAVIS_TAG"

--- a/ci/travis-after-success.sh
+++ b/ci/travis-after-success.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -xe
 
+test "$AFTER_SCRIPT" = "1" || exit 0
+
 # Submit code coverage report
 docker run -ti --rm -v $PWD:/docker -w /docker \
     -e CI \


### PR DESCRIPTION
Mergin code coverage bit script with matrix build changes has broken the
former because `ocean:latest` is not available anymore.