### PR TITLE
Replace explicit cast when deserializing

### DIFF
--- a/src/ocean/task/util/TaskPoolSerializer.d
+++ b/src/ocean/task/util/TaskPoolSerializer.d
@@ -245,7 +245,7 @@ unittest
 
         public void deserialize ( void[] buffer )
         {
-            Deserializer.deserialize!(TaskArgs)(buffer, this.args);
+            Deserializer.deserialize(buffer, this.args);
         }
     }
 

--- a/src/ocean/util/container/queue/NotifyingQueue.d
+++ b/src/ocean/util/container/queue/NotifyingQueue.d
@@ -108,6 +108,8 @@ import ocean.util.serialize.contiguous.Deserializer;
 
 import ocean.core.Array;
 
+import ocean.transition;
+
 import ocean.util.container.AppendBuffer;
 
 import ocean.io.serialize.StructSerializer;
@@ -617,7 +619,7 @@ class NotifyingQueue ( T ) : NotifyingByteQueue
                 return null;
             }
 
-            auto void_buffer = cast(void[]) data;
+            Const!(void[]) void_buffer = data;
 
             Deserializer.deserialize(void_buffer, cont_buffer);
 

--- a/src/ocean/util/container/queue/NotifyingQueue.d
+++ b/src/ocean/util/container/queue/NotifyingQueue.d
@@ -619,7 +619,7 @@ class NotifyingQueue ( T ) : NotifyingByteQueue
 
             auto void_buffer = cast(void[]) data;
 
-            Deserializer.deserialize!(T)(void_buffer, cont_buffer);
+            Deserializer.deserialize(void_buffer, cont_buffer);
 
             return cont_buffer.ptr;
         }

--- a/src/ocean/util/serialize/contiguous/Deserializer.d
+++ b/src/ocean/util/serialize/contiguous/Deserializer.d
@@ -1131,5 +1131,5 @@ unittest
     auto r1 = Deserializer.deserialize!(Trivial)(buf);
 
     Contiguous!(Trivial) copy_dst;
-    auto r2 = Deserializer.deserialize!(Trivial)(buf, copy_dst);
+    auto r2 = Deserializer.deserialize(buf, copy_dst);
 }

--- a/src/ocean/util/serialize/contiguous/Util.d
+++ b/src/ocean/util/serialize/contiguous/Util.d
@@ -48,7 +48,7 @@ import ocean.core.Test;
 
 public Contiguous!(S) copy(S) ( in Contiguous!(S) src, ref Contiguous!(S) dst )
 {
-    Deserializer.deserialize!(S)(src.data, dst);
+    Deserializer.deserialize(src.data, dst);
     return dst;
 }
 

--- a/src/ocean/util/serialize/contiguous/package_.d
+++ b/src/ocean/util/serialize/contiguous/package_.d
@@ -420,7 +420,7 @@ unittest
     test!("==")(buffer.length, s.serialized_length);
     S.trivialDeserialize(buffer).testNullReferences();
     Contiguous!(S) destination;
-    auto cont_S = Deserializer.deserialize!(S)(buffer, destination);
+    auto cont_S = Deserializer.deserialize(buffer, destination);
     cont_S.enforceIntegrity();
 
     t.test(cont_S.ptr is destination.ptr);
@@ -473,7 +473,7 @@ unittest
     buffer.length = buffer.length * 2;
 
     Contiguous!(S) destination;
-    auto cont_S = Deserializer.deserialize!(S)(buffer, destination);
+    auto cont_S = Deserializer.deserialize(buffer, destination);
     cont_S.enforceIntegrity();
 
     t.test(cont_S.ptr is destination.ptr);
@@ -551,7 +551,7 @@ unittest
     test!("==")(buffer.length, s.serialized_length);
     S.trivialDeserialize(buffer).testNullReferences();
     Contiguous!(S) destination;
-    auto cont_S = Deserializer.deserialize!(S)(buffer, destination);
+    auto cont_S = Deserializer.deserialize(buffer, destination);
     cont_S.enforceIntegrity();
 
     t.test(cont_S.ptr is destination.ptr);
@@ -720,7 +720,7 @@ unittest
     auto cont_s = Deserializer.deserialize!(S)(buffer);
     testNoAlloc(Deserializer.deserialize!(S)(buffer));
     buffer = buffer.dup;
-    testNoAlloc(Deserializer.deserialize!(S)(buffer, cont_s));
+    testNoAlloc(Deserializer.deserialize(buffer, cont_s));
 }
 
 


### PR DESCRIPTION
It is safer to define the data type to deserialize rather
than casting it to `void[]`, otherwise the compiler wouldn't
complain about it if the data type changes to something that
cannot be implicitly converted to void[].