### PR TITLE
Implement Clock.startTime to get the application's start time

### DIFF
--- a/relnotes/clock-starttime.feature.md
+++ b/relnotes/clock-starttime.feature.md
@@ -1,0 +1,4 @@
+* `ocean.time.Clock`
+
+  `Clock` now expose a new static function, `startTime`, which is initialized
+  on application startup to the current time via a module constructor.

--- a/relnotes/logevent-started.deprecation.md
+++ b/relnotes/logevent-started.deprecation.md
@@ -1,0 +1,7 @@
+* `ocean.util.log.Log : Log.time`
+
+  This function have been deprecated. Use `ocean.time.Clock : Clock.now` instead.
+
+* `ocean.util.log.Event : started`
+
+  This function have been deprecated. Use `ocean.time.Clock : Clock.startTime` instead.

--- a/src/ocean/text/convert/DateTime_tango.d
+++ b/src/ocean/text/convert/DateTime_tango.d
@@ -34,14 +34,14 @@ import ocean.transition;
 
 import ocean.core.Exception_tango;
 
-import ocean.time.WallClock;
-
 import ocean.time.chrono.Calendar,
        ocean.time.chrono.Gregorian;
 
 import Utf = ocean.text.convert.Utf;
 
 import Integer = ocean.text.convert.Integer_tango;
+
+import core.sys.posix.time; // timezone
 
 /******************************************************************************
 
@@ -747,7 +747,7 @@ struct DateTimeLocale
                     // timezone offset
                 case 'z':
                     len = parseRepeat (format, index, c);
-                    auto minutes = cast(int) (WallClock.zone.minutes);
+                    auto minutes = cast(int) (TimeSpan.fromSeconds(-timezone).minutes);
                     if (minutes < 0)
                     {
                         minutes = -minutes;

--- a/src/ocean/time/Clock.d
+++ b/src/ocean/time/Clock.d
@@ -39,6 +39,20 @@ import ocean.core.Exception_tango;
 
 struct Clock
 {
+        /// Time at which the program started
+        private static Time start_time_;
+
+        /// Returns: Time at which the application started
+        public static Time startTime ()
+        {
+            return start_time_;
+        }
+
+        static this ()
+        {
+            start_time_ = Clock.now;
+        }
+
         // copied from Gregorian.  Used while we rely on OS for toDate.
         package static uint[] DaysToMonthCommon = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365];
         package static void setDoy(ref DateTime dt)

--- a/src/ocean/time/Clock.d
+++ b/src/ocean/time/Clock.d
@@ -206,11 +206,3 @@ unittest
 
     assert (time is Clock.fromDate(date));
 }
-
-debug (Clock)
-{
-    void main()
-    {
-        auto time = Clock.now;
-    }
-}

--- a/src/ocean/util/log/Event.d
+++ b/src/ocean/util/log/Event.d
@@ -40,7 +40,7 @@ public struct LogEvent
     /// Set the various attributes of this event.
     void set (ILogger.Context host, ILogger.Level level, cstring msg, cstring name)
     {
-        time_ = Log.time;
+        time_ = Clock.now;
         level_ = level;
         host_ = host;
         name_ = name;
@@ -75,7 +75,7 @@ public struct LogEvent
     /// relative to the start of this executable
     TimeSpan span ()
     {
-        return time_ - Log.beginTime;
+        return time_ - Clock.startTime();
     }
 
     /// Return the time this event was produced relative to Epoch
@@ -85,9 +85,10 @@ public struct LogEvent
     }
 
     /// Return time when the executable started
+    deprecated("Use ocean.time.Clock : Clock.startTime() directly")
     Time started ()
     {
-        return Log.beginTime;
+        return Clock.startTime();
     }
 
     /// Return the logger level name of this event.

--- a/src/ocean/util/log/Log.d
+++ b/src/ocean/util/log/Log.d
@@ -253,7 +253,6 @@ public struct Log
 
         // internal use only
         private static Hierarchy base;
-        package static Time beginTime;
 
         private struct  Pair {istring name; Level value;}
 
@@ -307,11 +306,6 @@ public struct Log
 
                 foreach (p; Pairs)
                          map[p.name] = p.value;
-
-                version (Posix)
-                {
-                        beginTime = Clock.now;
-                }
         }
 
         /***********************************************************************
@@ -334,6 +328,7 @@ public struct Log
 
         ***********************************************************************/
 
+        deprecated("Use ocean.time.Clock : Clock.now() directly")
         static Time time ()
         {
                 version (Posix)
@@ -862,7 +857,7 @@ public class Logger : ILogger
 
         final TimeSpan runtime ()
         {
-                return Clock.now - Log.beginTime;
+            return Clock.now - Clock.startTime();
         }
 
         /***********************************************************************


### PR DESCRIPTION
Replace a common requirement between old and new logger, using a more appropriate module.

I started to remove old loggers from v3.x.x and it turned out `LogEvent` still had a dependency.
Moving everything to `Clock` seemed like the best compromise.