### PR TITLE
Allow users to choose HTTP response buffer size

### DIFF
--- a/relnotes/configurable_http_response_buffer_size.feature.md
+++ b/relnotes/configurable_http_response_buffer_size.feature.md
@@ -1,0 +1,6 @@
+* `ocean.net.http.HttpResponse`
+
+  The constructor for `HttpResponse` now takes an optional parameter
+  specifying how big to make the initial buffer to build responses in. The
+  default is 1KB. If you know you will be sending larger responses than this
+  then it is more GC friendly to use a larger value when constructing.

--- a/relnotes/configurable_uri_buffer_size.feature.md
+++ b/relnotes/configurable_uri_buffer_size.feature.md
@@ -1,0 +1,14 @@
+* `ocean.net.Uri`
+
+  One constructor for `Uri` now takes an optional parameter specifying how big
+  to make the initial buffer used to URL decode URIs into.
+  The default is 512B. If you know you will be using larger URIs than this
+  then it is more GC friendly to use a larger value when constructing.
+
+* `ocean.net.http.HttpRequest`
+
+  One constructor for `HttpRequest` now takes an optional parameter specifying
+  how big a buffer the internal `Uri` object should use to decode URIs into.
+  The default is 512B. If you know you will be receiving requests with URIs
+  longer than this then it is more GC friendly to use a larger value when
+  constructing.

--- a/src/ocean/net/Uri.d
+++ b/src/ocean/net/Uri.d
@@ -225,12 +225,17 @@ class Uri : UriView
 
                 Create an empty Uri
 
+                Params:
+                    initial_buffer_size = the initial amount of memory to
+                        allocate to hold the URI-decoded URI. Will be extended
+                        if necessary.
+
         ***********************************************************************/
 
-        this ()
+        this ( uint initial_buffer_size = 512 )
         {
                 port_ = InvalidPort;
-                decoded.expand (512);
+                decoded.expand (initial_buffer_size);
         }
 
         /***********************************************************************

--- a/src/ocean/net/http/HttpRequest.d
+++ b/src/ocean/net/http/HttpRequest.d
@@ -167,17 +167,22 @@ class HttpRequest : HttpHeader
                                        header fields as well
             msg_body_prealloc_length = expected message body length for
                                        preallocation;
+            uri_prealloc_length      = the initial amount of memory the
+                                       contained Uri object will be asked to
+                                       pre-allocate to hold the URI-decoded
+                                       URI of a request.
 
      **************************************************************************/
 
-    public this ( bool add_entity_headers = false, size_t msg_body_prealloc_length = 0 )
+    public this ( bool add_entity_headers = false, size_t msg_body_prealloc_length = 0,
+            uint uri_prealloc_length = 512)
     {
         super(HeaderFieldNames.Request.NameList,
               add_entity_headers? HeaderFieldNames.Entity.NameList : null);
 
         this.header = this.parser = new HttpHeaderParser;
 
-        this._uri = new Uri;
+        this._uri = new Uri(uri_prealloc_length);
 
         this.msg_body_ = new char[msg_body_prealloc_length];
 

--- a/src/ocean/net/http/HttpRequest.d
+++ b/src/ocean/net/http/HttpRequest.d
@@ -158,9 +158,9 @@ class HttpRequest : HttpHeader
         standard Entity header fields. (The standard General-Header and
         Request-Header fields are added automatically.)
 
-        Note that a non-zero value for msg_body_prealloc_length is senseful only
-        when requests with message body (POST, PUT etc.) are supported by this
-        server.
+        Note that a non-zero value for msg_body_prealloc_length is only
+        sensible when requests with a message body (POST, PUT etc.) are
+        supported by this server.
 
         Params:
             add_entity_headers       = set to true to add the standard Entity

--- a/src/ocean/net/http/HttpResponse.d
+++ b/src/ocean/net/http/HttpResponse.d
@@ -107,15 +107,19 @@ class HttpResponse : HttpHeader
 
         Constructor
 
+        Params:
+            initial_buffer_size = the initial amount of memory to allocate to
+                hold the rendered response. Will be extended if necessary.
+
      **************************************************************************/
 
-    public this ( )
+    public this ( size_t initial_buffer_size = 1024 )
     {
         super(HeaderFieldNames.Response.NameList,
               HeaderFieldNames.Entity.NameList);
 
         this.append_header_lines = new AppendHeaderLines(
-                this.content = new AppendBuffer!(char)(1024));
+                this.content = new AppendBuffer!(char)(initial_buffer_size));
     }
 
     /**************************************************************************


### PR DESCRIPTION
In order to minimise GC activity it is useful to pre-allocate buffers to a size that is a reasonable estimate of the largest size that will be seen. This change allows clients to do just that without changing the behaviour of existing clients.