### PR TITLE
Allow Base64's decode to decode multiple concatenated strings.

### DIFF
--- a/relnotes/base64_multiple.feature.md
+++ b/relnotes/base64_multiple.feature.md
@@ -1,0 +1,5 @@
+* `ocean.util.encode.Base64`
+
+  `decode` method is now able to decode multiple concatenated base64 strings.
+  Note that for this to work, padding must be correctly applied on every string,
+  but the last one.


### PR DESCRIPTION
`decode` method is now able to decode multiple concatenated base64 strings.
Note that for this to work, padding must be correctly applied on every string,
but the last one.
