### PR TITLE
Allow interactive session with UnixSocketExt/UnixConnectionHandler

### DIFF
--- a/relnotes/unixsocket.migration.md
+++ b/relnotes/unixsocket.migration.md
@@ -1,0 +1,8 @@
+* `ocean.net.server.unix.UnixListener`,
+  `ocean.net.server.unix.UnixConnectionHandler`,
+  `ocean.util.app.ext.UnixSocketExt`
+
+Handlers previously used for communicating with the user on UnixSocket now
+accept additional delegate: `waitReply`. Handlers now may initiate interactive
+session with the user by sending the data via `send_response` and waiting for
+user to reply via `wait_reply`.

--- a/src/ocean/net/server/unix/UnixListener.d
+++ b/src/ocean/net/server/unix/UnixListener.d
@@ -68,7 +68,8 @@ public class UnixListener : UnixSocketListener!( BasicCommandHandler )
                              The type is passed as the template argument of
                              UnixConnectionHandler and is assumed to have a
                              callable member `void handle ( cstring, cstring,
-                             void delegate ( cstring ))`.
+                             void delegate ( cstring ),
+                             void delegate ( ref mstring ))`.
 
 *******************************************************************************/
 

--- a/test/unixlistener/main.d
+++ b/test/unixlistener/main.d
@@ -16,6 +16,14 @@
 import ocean.transition;
 
 import core.thread;
+import core.stdc.errno;
+import core.stdc.stdio;
+import core.sys.posix.stdlib;
+import core.sys.posix.semaphore;
+import core.sys.posix.sys.mman;
+import core.sys.posix.unistd;
+import core.sys.posix.sys.wait;
+
 import ocean.core.Test;
 import ocean.core.Enforce;
 import ocean.core.Time;
@@ -25,38 +33,116 @@ import ocean.stdc.posix.sys.un;
 import ocean.sys.socket.UnixSocket;
 import ocean.net.server.unix.UnixListener;
 import Integer = ocean.text.convert.Integer_tango;
+import ocean.text.util.SplitIterator: ChrSplitIterator;
+import ocean.text.util.StringC;
+import ocean.task.Task;
+import ocean.task.Scheduler;
+import ocean.sys.ErrnoException;
+import core.stdc.string;
 
-
+static if (!is(typeof(mkdtemp)))
+{
+    extern (C) char* mkdtemp(char*);
+}
 
 /*******************************************************************************
 
-    Opens a client connection and issues a request.
-
-    Params:
-        socket_path = the unix socket path.
-        command = command to be sent
-
-    Throws:
-        an exception if something goes wrong (could not connect,  etc)
+    Semaphore to synchronize child and parent process. The child process should
+    connect to the unix domain socket, only after the parent one binded to it.
 
 *******************************************************************************/
 
-void writeToClient( cstring socket_path, cstring command )
-{
-    auto local_address = sockaddr_un.create(socket_path);
-    auto client = new UnixSocket();
+sem_t* start_semaphore;
 
-    scope (exit) client.close();
+/*******************************************************************************
+
+    Helper function to wait for the start_semaphore.
+
+*******************************************************************************/
+
+void waitForSemaphore ()
+{
+    // Wait for the parent to send signals, then connect and start
+    // issuing commands
+    int ret;
+
+    do
+    {
+        ret = sem_wait(start_semaphore);
+    }
+    while (ret == -1 && errno == EINTR);
+    enforce (ret == 0);
+}
+
+/*******************************************************************************
+
+    Body of a client process. Connects to the unix domain sockets and sends
+    some commands, some of which are interactive.
+
+    Params:
+        socket_path = path to connect to.
+
+*******************************************************************************/
+
+void client_process (cstring socket_path)
+{
+    mstring read_buffer;
+    UnixSocket client;
+
+    cstring readData ()
+    {
+        read_buffer.length = 100;
+        enableStomping(read_buffer);
+
+        auto buff = cast(void[])read_buffer;
+
+        // receive some data
+        ssize_t read_bytes;
+
+        do
+        {
+            read_bytes = client.recv(buff, 0);
+        }
+        while (read_bytes == -1 && errno == EINTR);
+
+        enforce(read_bytes > 0);
+
+        read_buffer.length = read_bytes;
+        enableStomping(read_buffer);
+        return read_buffer;
+    }
+
+    waitForSemaphore();
+
+    // Connect to a listening socket and keep it open.
+    auto local_sock_add = sockaddr_un.create(socket_path);
+    client = new UnixSocket();
 
     auto socket_fd = client.socket();
     enforce(socket_fd >= 0, "socket() call failed!");
 
-    auto connect_result = client.connect(&local_address);
+    auto connect_result = client.connect(&local_sock_add);
     enforce(connect_result == 0, "connect() call failed.");
 
-    client.write(command);
-}
+    client.write("increment 2\n");
+    client.write("increment 1\n");
 
+    client.write("askMyName John Angie\n");
+    test!("==")(readData(), "first name? ");
+    client.write("John\n");
+    test!("==")(readData(), "second name? ");
+    client.write("Angie\n");
+
+    client.write("askMeAgain John Angie");
+    client.write("\n");
+    test!("==")(readData(), "second name? ");
+    client.write("Angie\n");
+    test!("==")(readData(), "first name? ");
+    client.write("John\n");
+
+    client.write("shutdown\n");
+    client.close();
+}
 
 /*******************************************************************************
 
@@ -67,46 +153,147 @@ void writeToClient( cstring socket_path, cstring command )
 
 int main ( )
 {
-    auto local_address = "/tmp/ocean_unixsocket_test.socket";
-    auto epoll = new EpollSelectDispatcher();
-    auto unix_socket   = new UnixSocket;
+    // Since this is a one-off test, we will not care about destroying
+    // these
+    start_semaphore = cast(sem_t*)mmap(null,
+            sem_t.sizeof, PROT_READ | PROT_WRITE,
+            MAP_SHARED | MAP_ANON, -1, 0);
 
-    // Value to be incremented via command to server
-    // Needs to be 3 after end of tests.
-    int expected_value = 0;
-
-    void handleIncrementCommand ( cstring args,
-            void delegate ( cstring response ) send_response )
+    if (start_semaphore is null)
     {
-        expected_value += Integer.parse(args);
+        return 1;
     }
 
-    void handleShutdown ( cstring args,
-            void delegate ( cstring response ) send_response )
+    if (sem_init(start_semaphore, 1, 0) == -1)
     {
-        epoll.shutdown();
+        return 1;
     }
 
-    auto unix_server   = new UnixListener(local_address, epoll,
-            ["shutdown"[]: &handleShutdown,
-             "increment": &handleIncrementCommand]
-    );
+    auto e = new ErrnoException;
 
-    epoll.register(unix_server);
+    // Create a tmp directory
+    mstring dir_name = "/tmp/ocean_socket_testXXXXXX".dup;
+    char* tmp_dir = mkdtemp(dir_name.ptr);
+    enforce(tmp_dir == dir_name.ptr);
+    auto local_address = dir_name ~ "/ocean.socket";
 
-    // Write all to the socket, including shutdown, so we can just eventLoop
-    // and collect what's there
+    int child_pid = fork();
+    enforce(child_pid >= 0);
 
-    // Example passing arguments to handler:
-    writeToClient(local_address, "increment 2\n");
-    writeToClient(local_address, "increment 1\n");
-    writeToClient(local_address, "shutdown\n");
+    if (child_pid == 0)
+    {
+        client_process(local_address);
+        return 0;
+    }
+    else
+    {
+        // Only parent cleans up
+        scope (exit)
+        {
+            auto filename = StringC.toCString(local_address);
+            if (access(filename, F_OK) != -1)
+            {
+                if (unlink(filename) != 0)
+                {
+                    throw e.useGlobalErrno("unlink");
+                }
+            }
 
-    // Spin the server
-    epoll.eventLoop();
+            if (rmdir(tmp_dir) != 0)
+            {
+                throw e.useGlobalErrno("rmdir");
+            }
+        }
 
-    // This will be reached only if "shutdown" command was successful.
-    test!("==")(expected_value, 3);
+        auto epoll = new EpollSelectDispatcher();
+        auto unix_socket   = new UnixSocket;
+
+        // Value to be incremented via command to server
+        // Needs to be 3 after end of tests.
+        int expected_value = 0;
+
+        void handleIncrementCommand ( cstring args,
+                void delegate ( cstring response ) send_response,
+                void delegate ( ref mstring response ) wait_reply )
+        {
+            expected_value += Integer.parse(args);
+        }
+
+        // Command shutting down the epoll
+        void handleShutdown ( cstring args,
+                void delegate ( cstring response ) send_response,
+                void delegate ( ref mstring response ) wait_reply )
+        {
+            epoll.shutdown();
+        }
+
+        // test doesn't work in this callbacks, as the exceptions will be swallowed
+        int success_count = 0;
+
+        // Interactive callback. This will ask the client for the two names,
+        // which should be the same as two arguments with which 
+        void handleAskMyName ( cstring args,
+                void delegate ( cstring response ) send_response,
+                void delegate ( ref mstring response ) wait_reply )
+        {
+            scope i = new ChrSplitIterator(' ');
+            i.reset(args);
+            cstring first = i.next();
+            cstring second = i.remaining();
+            mstring response;
+            send_response("first name? "); wait_reply(response);
+            success_count += first == response ? 1 : 0;
+            send_response("second name? "); wait_reply(response);
+            success_count += second == response ? 1 : 0;
+        }
+
+        // Interactive callback for the other command
+        // Used to check if we can execute more handlers
+        void handleAskMyNameReverse ( cstring args,
+                void delegate ( cstring response ) send_response,
+                void delegate ( ref mstring response ) wait_reply )
+        {
+            scope i = new ChrSplitIterator(' ');
+            i.reset(args);
+            cstring first = i.next();
+            cstring second = i.remaining();
+            mstring response;
+            send_response("second name? "); wait_reply(response);
+            success_count += second == response ? 1 : 0;
+            send_response("first name? "); wait_reply(response);
+            success_count += first == response ? 1 : 0;
+        }
+        auto unix_server   = new UnixListener(idup(local_address), epoll,
+                ["shutdown"[]: &handleShutdown,
+                 "increment": &handleIncrementCommand,
+                 "askMyName": &handleAskMyName,
+                 "askMeAgain": &handleAskMyNameReverse]
+        );
+
+        epoll.register(unix_server);
+
+        // let the child process know it may connect & start
+        sem_post(start_semaphore);
+
+        // Spin the server
+        epoll.eventLoop();
+
+        // This will be reached only if "shutdown" command was successful.
+        test!("==")(expected_value, 3);
+        test!("==")(success_count, 4);
+
+        // Let's reap the zombies
+
+        int ret;
+        int status;
+
+        do
+        {
+            ret = wait(&status);
+        }
+        while (ret == -1 && errno == EINTR);
+        enforce (ret == child_pid);
+    }
 
     return 0;
 }


### PR DESCRIPTION
UnixListener now accepts a handlers with an additional delegate,
get_response, which can be used inside a handler for an interactive
session.

Fixes #52