### PR TITLE
Fix bad merge conflict resolution and alias conflicts

### DIFF
--- a/src/ocean/util/app/DaemonApp.d
+++ b/src/ocean/util/app/DaemonApp.d
@@ -62,7 +62,6 @@ public abstract class DaemonApp : Application,
 
     import ocean.sys.Stats;
     import ocean.task.Scheduler;
-    import ocean.text.Arguments : Arguments;
     import ocean.util.app.ext.ArgumentsExt;
     import ocean.util.app.ext.ConfigExt;
     import ocean.util.app.ext.VersionArgsExt;
@@ -75,7 +74,6 @@ public abstract class DaemonApp : Application,
     import ocean.util.app.ext.PidLockExt;
     import ocean.util.app.ext.UnixSocketExt;
     import ocean.util.app.ExitException;
-    import ocean.util.config.ConfigParser : ConfigParser;
     import ocean.util.log.Log;
     import ocean.util.log.Stats;
 


### PR DESCRIPTION
Merging the v2.7.5 into v3.1.x ignored the changes done
in c238e880bc8e802c3f1e22b8896d76e01185444a causing duplicated
aliases.