### PR TITLE
Update LibFeatures to be ready for 2.9

### DIFF
--- a/src/ocean/LibFeatures.d
+++ b/src/ocean/LibFeatures.d
@@ -17,6 +17,8 @@
 
 module ocean.LibFeatures;
 
+const has_features_2_9 = true;
+const has_features_2_8 = true;
 const has_features_2_7 = true;
 const has_features_2_6 = true;
 const has_features_2_5 = true;


### PR DESCRIPTION
Merging it right now will ensure that it won't be forgotten by the time of actual
release. 2.8 is also included (despite the fact it is already added in patch branch)
to avoid merge conflict later.