### PR TITLE
Reduce dependency on old loggers, move some functionality in ILogger

### DIFF
--- a/relnotes/ilogger-convert.feature.md
+++ b/relnotes/ilogger-convert.feature.md
@@ -1,0 +1,6 @@
+* `ocean.util.log.model.ILogger`
+
+  The `ILogger` interface gained two static `convert` functions,
+  which, first the first overload will convert an `ILogger.Level`
+  to its string representation, and will convert a string representation
+  to an `ILogger.Level` for the second one.

--- a/src/ocean/io/console/AppStatus.d
+++ b/src/ocean/io/console/AppStatus.d
@@ -92,7 +92,8 @@ import core.stdc.time: clock_t, clock, tm, time_t, time;
 
 import ocean.text.convert.Format;
 
-import ocean.util.log.Log;
+import ocean.util.log.Event;
+import ocean.util.log.model.ILogger;
 
 import ocean.io.Console;
 
@@ -665,10 +666,8 @@ public class AppStatus
             return this;
         }
 
-        Hierarchy host_;
-        Level level_;
         LogEvent event;
-        event.set(host_, level_, this.msg[], "");
+        event.set(ILogger.Context.init, ILogger.Level.init, this.msg[], "");
 
         this.applyDisplayProps(this.current_display_props);
 

--- a/src/ocean/io/select/timeout/TimerEventTimeoutManager.d
+++ b/src/ocean/io/select/timeout/TimerEventTimeoutManager.d
@@ -56,20 +56,7 @@ debug
     import ocean.io.Stdout_tango;
 }
 
-import ocean.util.log.Log;
 
-/*******************************************************************************
-
-    Static module logger
-
-*******************************************************************************/
-
-private Logger log;
-
-static this ( )
-{
-    log = Log.lookup("ocean.io.select.timeout.TimerEventTimeoutManager");
-}
 
 /******************************************************************************/
 

--- a/src/ocean/util/app/ext/LogExt.d
+++ b/src/ocean/util/app/ext/LogExt.d
@@ -41,8 +41,6 @@ import ocean.transition;
 import ocean.io.device.File;
 
 import ocean.util.log.Appender;
-import ocean.util.log.Log;
-
 
 
 /*******************************************************************************

--- a/src/ocean/util/app/ext/StatsExt.d
+++ b/src/ocean/util/app/ext/StatsExt.d
@@ -54,7 +54,6 @@ import ocean.util.app.ext.ReopenableFilesExt;
 
 import ocean.util.config.ConfigParser;
 import ocean.util.log.Appender;
-import ocean.util.log.Log;
 import ocean.util.log.Stats;
 import ConfigFiller = ocean.util.config.ConfigFiller;
 

--- a/src/ocean/util/container/queue/LinkedListQueue.d
+++ b/src/ocean/util/container/queue/LinkedListQueue.d
@@ -16,7 +16,6 @@ module ocean.util.container.queue.LinkedListQueue;
 import ocean.transition;
 
 import core.memory;
-import ocean.util.log.Log;
 import ocean.util.container.Container;
 import ocean.core.Test;
 import ocean.util.container.queue.model.ITypedQueue;

--- a/src/ocean/util/log/Event.d
+++ b/src/ocean/util/log/Event.d
@@ -27,8 +27,6 @@ import ocean.transition;
 import ocean.time.Clock;
 import ocean.util.log.model.ILogger;
 
-import ocean.util.log.Log;
-
 ///
 public struct LogEvent
 {
@@ -94,7 +92,7 @@ public struct LogEvent
     /// Return the logger level name of this event.
     cstring levelName ()
     {
-        return Log.LevelNames[level_];
+        return ILogger.convert(this.level_);
     }
 
     /// Convert a time value (in milliseconds) to ascii

--- a/src/ocean/util/log/Log.d
+++ b/src/ocean/util/log/Log.d
@@ -280,11 +280,6 @@ public struct Log
                         {"none",   Level.None},
                         ];
 
-        // logging-level names
-        package static istring[] LevelNames =
-        [
-                "Trace", "Info", "Warn", "Error", "Fatal", "None"
-        ];
 
         /***********************************************************************
 
@@ -378,8 +373,9 @@ public struct Log
 
         static istring convert (int level)
         {
-                assert (level >= Level.Trace && level <= Level.None);
-                return LevelNames[level];
+            assert (level >= Level.Trace && level <= Level.None);
+            Level l = cast(Level) level;
+            return ILogger.convert(l);
         }
 
         /***********************************************************************

--- a/src/ocean/util/log/model/ILogger.d
+++ b/src/ocean/util/log/model/ILogger.d
@@ -1,17 +1,23 @@
 /*******************************************************************************
 
-        Copyright:
-            Copyright (c) 2004 Kris Bell.
-            Some parts copyright (c) 2009-2016 Sociomantic Labs GmbH.
-            All rights reserved.
+    Base interface for Loggers implementation
 
-        License:
-            Tango Dual License: 3-Clause BSD License / Academic Free License v3.0.
-            See LICENSE_TANGO.txt for details.
+    Note:
+        The formatting primitives (error, info, warn...) are not part of the
+        interface anymore, as they can be templated functions.
 
-        Version: Initial release: May 2004
+    Copyright:
+        Copyright (c) 2004 Kris Bell.
+        Some parts copyright (c) 2009-2016 Sociomantic Labs GmbH.
+        All rights reserved.
 
-        Authors: Kris
+    License:
+        Tango Dual License: 3-Clause BSD License / Academic Free License v3.0.
+        See LICENSE_TANGO.txt for details.
+
+    Version: Initial release: May 2004
+
+    Authors: Kris
 
 *******************************************************************************/
 
@@ -19,42 +25,68 @@ module ocean.util.log.model.ILogger;
 
 import ocean.transition;
 
-/*******************************************************************************
 
-*******************************************************************************/
-
+/// Ditto
 interface ILogger
 {
-        enum Level {Trace=0, Info, Warn, Error, Fatal, None};
+    /// Defines the level at which a message can be logged
+    public enum Level
+    {
+        ///
+        Trace = 0,
+        ///
+        Info,
+        ///
+        Warn,
+        ///
+        Error,
+        ///
+        Fatal,
+        ///
+        None
+    };
 
 
-        /***********************************************************************
+    /***************************************************************************
 
-                Context for a hierarchy, used for customizing behaviour
-                of log hierarchies. You can use this to implement dynamic
-                log-levels, based upon filtering or some other mechanism
+        Context for a hierarchy, used for customizing behaviour of log
+        hierarchies. You can use this to implement dynamic log-levels,
+        based upon filtering or some other mechanism
 
-        ***********************************************************************/
+    ***************************************************************************/
 
-        interface Context
-        {
-                /// return a label for this context
-                istring label ();
+    public interface Context
+    {
+        /// return a label for this context
+        public istring label ();
 
-                /// first arg is the setting of the logger itself, and
-                /// the second arg is what kind of message we're being
-                /// asked to produce
-                bool enabled (Level setting, Level target);
-        }
+        /// first arg is the setting of the logger itself, and
+        /// the second arg is what kind of message we're being
+        /// asked to produce
+        public bool enabled (Level setting, Level target);
+    }
 
 
-        /***********************************************************************
+    /***************************************************************************
 
-                Is this logger enabed for the specified Level?
+        Returns:
+            `true` if this logger is enabed for the specified `Level`
 
-        ***********************************************************************/
+        Params:
+            `Level` to test for, defaults to `Level.Fatal`.
 
-        bool enabled (Level level = Level.Fatal);
+    ***************************************************************************/
+
+    public bool enabled (Level level = Level.Fatal);
+
+    /***************************************************************************
+
+        Returns:
+            The name of this `ILogger` (without the appended dot).
+
+    ***************************************************************************/
+
+    public cstring name ();
 
         /***********************************************************************
 
@@ -96,52 +128,69 @@ interface ILogger
 
         void fatal (cstring fmt, ...);
 
-        /***********************************************************************
+    /***************************************************************************
 
-                Return the name of this ILogger (sans the appended dot).
+        Returns:
+            The `Level` this `ILogger` is set to
 
-        ***********************************************************************/
+    ***************************************************************************/
 
-        cstring name ();
+    public Level level ();
 
-        /***********************************************************************
+    /***************************************************************************
 
-                Return the Level this logger is set to
+        Set the current `Level` for this logger (and only this logger).
 
-        ***********************************************************************/
+        Params:
+            l = New `Level` value to set this logger to.
 
-        Level level ();
+        Returns:
+            `this` for easy chaining
 
-        /***********************************************************************
+    ***************************************************************************/
 
-                Set the current level for this logger (and only this logger).
+    public ILogger level (Level l);
 
-        ***********************************************************************/
+    /***************************************************************************
 
-        ILogger level (Level l);
+        Returns:
+            `true` if the logger is additive.
+            Additive loggers walk through ancestors looking for more appenders
 
-        /***********************************************************************
+    ***************************************************************************/
 
-                Is this logger additive? That is, should we walk ancestors
-                looking for more appenders?
+    public bool additive ();
 
-        ***********************************************************************/
+    /***************************************************************************
 
-        bool additive ();
+        Set the additive status of this logger
 
-        /***********************************************************************
+        Additive loggers walk through ancestors looking for more appenders
 
-                Set the additive status of this logger. See isAdditive().
+        Params:
+            enabled = Whereas this logger is additive.
 
-        ***********************************************************************/
+        Returns:
+            `this` for easy chaining
 
-        ILogger additive (bool enabled);
+    ***************************************************************************/
 
-        /***********************************************************************
+    public ILogger additive (bool enabled);
 
-                Send a message to this logger via its appender list.
+    /***************************************************************************
 
-        ***********************************************************************/
+        Send a message to this logger.
 
-        ILogger append (Level level, lazy cstring exp);
+        Params:
+            level = Level at which to log the message
+            exp   = Lazily evaluated message string
+                    If the `level` is not enabled for this logger, it won't
+                    be evaluated.
+
+        Returns:
+            `this` for easy chaining
+
+    ***************************************************************************/
+
+    public ILogger append (Level level, lazy cstring exp);
 }


### PR DESCRIPTION
I am currently working on deprecating the old loggers. I have a set of patches (almost) working on top of v3.x.x, but some of the changes can be done in v2.x.x, so I cherry-picked them here.
The 3rd patch (Trivial: Fix ILogger code style and comments) might create conflicts because the logging primitives were removed in v3.x.x. This should be trivial to fix, but feel free to ping me if it isn't.
Additionally, since those patches were authored agaisnt v3.x.x, the documentation mention they are removed. I'm not sure it's worth the trouble of writing "correct" documentation for v2.x.x and then changing it in v3.x.x...