### PR TITLE
Deprecate old loggers

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -29,7 +29,8 @@ TEST_FILTER_OUT += \
 	$C/src/ocean/io/device/SerialPort.d \
 	$C/src/ocean/io/device/ProgressFile.d \
 	$C/src/ocean/math/BigInt.d \
-	$C/src/ocean/util/log/LayoutChainsaw.d
+	$C/src/ocean/util/log/LayoutChainsaw.d \
+	$C/src/ocean/util/log/Log.d \
 
 # integration test which is disabled by default because it depends on Collectd
 TEST_FILTER_OUT += \

--- a/relnotes/daemonapp-newlogger.deprecation.md
+++ b/relnotes/daemonapp-newlogger.deprecation.md
@@ -1,0 +1,5 @@
+* `ocean.util.app.DaemonApp`
+
+  The `exit` function, which accepted an `ocean.util.log.Log : Logger`
+  has been deprecated in favor of an overload which accept the
+  new logger type.

--- a/relnotes/logger-stats-total.feature.md
+++ b/relnotes/logger-stats-total.feature.md
@@ -1,0 +1,5 @@
+* `ocean.util.log.Logger`
+
+  `Log.Stats` now provides total method which returns the total count of
+  emitted events. This was already present in the old logger from
+  v2.7.0 / v3.1.0 but was not added in the new logger at the time.

--- a/relnotes/old-loggers.deprecation.md
+++ b/relnotes/old-loggers.deprecation.md
@@ -1,0 +1,9 @@
+* `ocean.util.log.Log`
+
+  This module is now deprecated, and all usages should be replaced with
+  `ocean.util.log.Logger` which provides the same functionalities,
+  but uses the Formatter (and hence all data types can be logged).
+  The module itself, the `Logger` type, and a couple of function are
+  not marked as `deprecated` due to complications with the compiler,
+  but enough functions (including the formatting primitives) are
+  marked as deprecated so make any user notice they are using it.

--- a/src/ocean/io/select/client/EpollProcess.d
+++ b/src/ocean/io/select/client/EpollProcess.d
@@ -119,7 +119,7 @@ debug import ocean.io.Stdout;
 
 import core.stdc.errno;
 
-import ocean.util.log.Log;
+import ocean.util.log.Logger;
 
 import core.sys.posix.signal : SIGCHLD;
 

--- a/src/ocean/io/select/protocol/task/TaskSelectClient.d
+++ b/src/ocean/io/select/protocol/task/TaskSelectClient.d
@@ -27,7 +27,7 @@ class TaskSelectClient: ISelectClient
     import ocean.task.Scheduler: theScheduler;
     import ocean.io.select.protocol.task.TimeoutException;
     import ocean.core.Traits: StripTypedef;
-    import ocean.util.log.Log;
+    import ocean.util.log.Logger;
     import ocean.transition;
 
     debug (SelectFiber) import ocean.io.Stdout: Stdout;

--- a/src/ocean/net/server/SelectListener.d
+++ b/src/ocean/net/server/SelectListener.d
@@ -47,7 +47,7 @@ import ocean.sys.socket.model.ISocket;
 import ocean.io.select.protocol.generic.ErrnoIOException: SocketError;
 
 
-import ocean.util.log.Log;
+import ocean.util.log.Logger;
 
 /*******************************************************************************
 

--- a/src/ocean/net/server/SelectListener_slowtest.d
+++ b/src/ocean/net/server/SelectListener_slowtest.d
@@ -26,7 +26,7 @@ import ocean.transition;
 import ocean.net.server.SelectListener;
 import ocean.net.server.connection.IConnectionHandler;
 import ocean.io.select.protocol.generic.ErrnoIOException: SocketError;
-import ocean.util.log.Log;
+import ocean.util.log.Logger;
 
 import ocean.core.Test;
 import ocean.sys.socket.AddressIPSocket;

--- a/src/ocean/net/server/unix/UnixConnectionHandler.d
+++ b/src/ocean/net/server/unix/UnixConnectionHandler.d
@@ -59,7 +59,7 @@ import ocean.io.select.protocol.fiber.FiberSelectWriter;
 import ocean.sys.socket.UnixSocket;
 import ocean.io.select.protocol.generic.ErrnoIOException : SocketError;
 
-import ocean.util.log.Log;
+import ocean.util.log.Logger;
 import ocean.text.util.SplitIterator: ChrSplitIterator;
 import ocean.core.array.Mutation : copy;
 

--- a/src/ocean/net/server/unix/UnixListener.d
+++ b/src/ocean/net/server/unix/UnixListener.d
@@ -89,7 +89,7 @@ public class UnixSocketListener ( CommandHandlerType ) : SelectListener!(
 
     import ocean.core.Enforce;
 
-    import ocean.util.log.Log;
+    import ocean.util.log.Logger;
 
     import core.sys.posix.sys.stat: umask;
 

--- a/src/ocean/sys/Stats.d
+++ b/src/ocean/sys/Stats.d
@@ -19,7 +19,7 @@ import ocean.transition;
 import core.sys.posix.sys.resource;
 import ProcVFS = ocean.sys.stats.linux.ProcVFS;
 import ocean.sys.stats.linux.Queriable;
-import ocean.util.log.Log;
+import ocean.util.log.Logger;
 
 /// Logger for logging errors
 private Logger stats_module_logger;

--- a/src/ocean/util/app/DaemonApp.d
+++ b/src/ocean/util/app/DaemonApp.d
@@ -75,6 +75,7 @@ public abstract class DaemonApp : Application,
     import ocean.util.app.ext.UnixSocketExt;
     import ocean.util.app.ExitException;
     import ocean.util.log.Log;
+    import NewLog = ocean.util.log.Logger;
     import ocean.util.log.Stats;
 
 
@@ -470,7 +471,7 @@ public abstract class DaemonApp : Application,
 
     override public void exit ( int status, istring msg = null )
     {
-        this.exit(status, msg, null);
+        this.exit(status, msg, NewLog.Logger.init);
     }
 
     /***************************************************************************
@@ -486,6 +487,7 @@ public abstract class DaemonApp : Application,
 
     ***************************************************************************/
 
+    deprecated("Use the overload that accepts a new Logger")
     public void exit ( int status, istring msg, Logger logger )
     {
         if (logger !is null)
@@ -494,6 +496,17 @@ public abstract class DaemonApp : Application,
         }
         throw new ExitException(status, msg);
     }
+
+    /// Ditto
+    public void exit ( int status, istring msg, NewLog.Logger logger )
+    {
+        if (logger !is null)
+        {
+            logger.fatal(msg);
+        }
+        throw new ExitException(status, msg);
+    }
+
 
     /***************************************************************************
 

--- a/src/ocean/util/app/ext/LogExt.d
+++ b/src/ocean/util/app/ext/LogExt.d
@@ -33,6 +33,7 @@ import ocean.util.app.ext.ConfigExt;
 
 import ocean.util.app.ext.ReopenableFilesExt;
 
+import ocean.util.config.ConfigFiller;
 import ocean.util.config.ConfigParser;
 import LogUtil = ocean.util.log.Config;
 import ConfigFiller = ocean.util.config.ConfigFiller;
@@ -54,8 +55,6 @@ import ocean.util.log.Appender;
 
 class LogExt : IConfigExtExtension
 {
-    import ocean.util.config.ConfigFiller;
-
     /***************************************************************************
 
         Adds a list of extensions (this.extensions) and methods to handle them.
@@ -171,7 +170,7 @@ class LogExt : IConfigExtExtension
 
         enable_loose_parsing(conf_ext.loose_config_parsing);
 
-        LogUtil.configureOldLoggers(log_config, log_meta_config, &appender,
+        configureOldLoggersLogExtHack(log_config, log_meta_config, &appender,
             this.layout_maker, this.use_insert_appender);
 
         LogUtil.configureNewLoggers(log_config, log_meta_config, &appender,
@@ -249,3 +248,18 @@ class LogExt : IConfigExtExtension
         return LogUtil.newLayout(name);
     }
 }
+
+
+/// Hack to allow to call a deprecated function without deprecations
+/// TODO: Remove for v4.0.0 release with other deprecated things
+private extern extern(C) void configureOldLoggersLogExtHack (
+    ClassIterator!(LogUtil.Config, ConfigParser) config,
+    LogUtil.MetaConfig m_config,
+    AppenderExternD file_appender, MakeLayoutExternD makeLayout,
+    bool use_insert_appender = false);
+/// Hack because DMD1 applies extern(C) to the delegate type as well...
+private alias extern(D) Appender delegate (istring, Appender.Layout)
+    AppenderExternD;
+/// Ditto
+private alias extern(D) Appender.Layout delegate (cstring)
+    MakeLayoutExternD;

--- a/src/ocean/util/app/ext/VersionArgsExt.d
+++ b/src/ocean/util/app/ext/VersionArgsExt.d
@@ -38,7 +38,7 @@ import ocean.io.Stdout;
 import ocean.core.Array: startsWith;
 
 import ocean.transition;
-import ocean.util.log.Log;
+import ocean.util.log.Logger;
 import ocean.util.log.AppendFile;
 import ocean.util.log.LayoutDate;
 import ocean.core.Array: sort;

--- a/src/ocean/util/container/queue/FlexibleFileQueue.d
+++ b/src/ocean/util/container/queue/FlexibleFileQueue.d
@@ -29,7 +29,7 @@ import ocean.core.Buffer;
 import ocean.util.container.queue.FlexibleRingQueue;
 import ocean.util.container.queue.model.IByteQueue;
 import ocean.util.container.queue.model.IQueueInfo;
-import ocean.util.log.Log;
+import ocean.util.log.Logger;
 import ocean.io.device.File;
 import Filesystem = ocean.io.Path;
 import ocean.io.stream.Buffered;

--- a/src/ocean/util/log/Config.d
+++ b/src/ocean/util/log/Config.d
@@ -753,9 +753,9 @@ file = dummy
     auto log_config = iterate!(Config)("LOG", config_parser);
     auto dummy_meta_config = new MetaConfig();
 
-    configureOldLoggers(log_config, dummy_meta_config, &appender);
+    configureNewLoggers(log_config, dummy_meta_config, &appender);
 
-    auto log_D = OldLog.Log.lookup("A.B.C.D");
+    auto log_D = NewLog.Log.lookup("A.B.C.D");
 
     log_D.trace("trace log (shouldn't be sent to appender)");
     test!("==")(temp_appender.latest_log_msg, "");

--- a/src/ocean/util/log/Config.d
+++ b/src/ocean/util/log/Config.d
@@ -339,6 +339,7 @@ public Layout newLayout ( cstring layout_str )
 
 *******************************************************************************/
 
+deprecated("Old Loggers are deprecated, use configureNewLoggers instead")
 public void configureOldLoggers (
     ClassIterator!(Config, ConfigParser) config, MetaConfig m_config,
     Appender delegate ( istring file, Layout layout ) file_appender,
@@ -347,6 +348,24 @@ public void configureOldLoggers (
     configureOldLoggers(config, m_config, file_appender,
         (cstring v) { return newLayout(v); }, use_insert_appender);
 }
+
+
+/// Hack to allow to call a deprecated function without deprecations
+private deprecated extern(C) void configureOldLoggersLogExtHack (
+    ClassIterator!(Config, ConfigParser) config, MetaConfig m_config,
+    AppenderExternD file_appender, MakeLayoutExternD makeLayout,
+    bool use_insert_appender = false)
+{
+    configureOldLoggers(config, m_config, file_appender, makeLayout,
+                        use_insert_appender);
+}
+
+/// Hack because DMD1 applies extern(C) to the delegate type as well...
+private alias extern(D) Appender delegate (istring, Appender.Layout)
+    AppenderExternD;
+/// Ditto
+private alias extern(D) Layout delegate (cstring)
+    MakeLayoutExternD;
 
 
 /*******************************************************************************
@@ -372,6 +391,7 @@ public void configureOldLoggers (
 
 *******************************************************************************/
 
+deprecated("Old Loggers are deprecated, use configureNewLoggers instead")
 public void configureOldLoggers (
     ClassIterator!(Config, ConfigParser) config, MetaConfig m_config,
     Appender delegate ( istring file, Layout layout ) file_appender,
@@ -421,10 +441,32 @@ unittest
                 return new SubmarineLayout;
             return ocean.util.log.Config.newLayout(name);
         }
-        ocean.util.log.Config.configureOldLoggers(config, m_config,
-            file_appender, &makeLayout, use_insert_appender);
-        // For new loggers:
         ocean.util.log.Config.configureNewLoggers(config, m_config,
+            file_appender, &makeLayout, use_insert_appender);
+    }
+}
+
+deprecated unittest
+{
+    // In a real app those would be full-fledged implementation
+    alias LayoutSimple AquaticLayout;
+    alias LayoutSimple SubmarineLayout;
+
+    void myConfigureLoggers (
+        ClassIterator!(Config, ConfigParser) config,
+        MetaConfig m_config,
+        Appender delegate ( istring file, Layout layout ) file_appender,
+        bool use_insert_appender = false)
+    {
+        Layout makeLayout (cstring name)
+        {
+            if (name == "aquatic")
+                return new AquaticLayout;
+            if (name == "submarine")
+                return new SubmarineLayout;
+            return ocean.util.log.Config.newLayout(name);
+        }
+        ocean.util.log.Config.configureOldLoggers(config, m_config,
             file_appender, &makeLayout, use_insert_appender);
     }
 }

--- a/src/ocean/util/log/Log.d
+++ b/src/ocean/util/log/Log.d
@@ -116,6 +116,7 @@ alias va_list ArgList;
 
 *******************************************************************************/
 
+deprecated("Import ocean.util.log.Logger instead")
 alias ILogger.Level Level;
 
 
@@ -128,6 +129,7 @@ alias ILogger.Level Level;
 
 *******************************************************************************/
 
+deprecated("Import ocean.util.log.Logger instead")
 public struct Log
 {
         /***********************************************************************
@@ -497,13 +499,18 @@ public struct Log
 
 public class Logger : ILogger
 {
-
+        deprecated("Import ocean.util.log.Logger instead")
         alias Level.Trace Trace;        // shortcut to Level values
+        deprecated("Import ocean.util.log.Logger instead")
         alias Level.Info  Info;         // ...
+        deprecated("Import ocean.util.log.Logger instead")
         alias Level.Warn  Warn;         // ...
+        deprecated("Import ocean.util.log.Logger instead")
         alias Level.Error Error;        // ...
+        deprecated("Import ocean.util.log.Logger instead")
         alias Level.Fatal Fatal;        // ...
 
+        deprecated("Import ocean.util.log.Logger instead")
         alias append      opCall;       // shortcut to append
 
         /***********************************************************************
@@ -557,6 +564,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        deprecated("Import ocean.util.log.Logger instead")
         final bool enabled (Level level = Level.Fatal)
         {
                 return host_.context.enabled (level_, level);
@@ -568,6 +576,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        deprecated("Use ocean.util.log.Logger instead")
         final void trace (cstring fmt, ...)
         {
             format (Level.Trace, fmt, _arguments, _argptr);
@@ -579,6 +588,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        deprecated("Use ocean.util.log.Logger instead")
         final void info (cstring fmt, ...)
         {
             format (Level.Info, fmt, _arguments, _argptr);
@@ -590,6 +600,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        deprecated("Use ocean.util.log.Logger instead")
         final void warn (cstring fmt, ...)
         {
             format (Level.Warn, fmt, _arguments, _argptr);
@@ -601,6 +612,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        deprecated("Use ocean.util.log.Logger instead")
         final void error (cstring fmt, ...)
         {
             format (Level.Error, fmt, _arguments, _argptr);
@@ -612,6 +624,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        deprecated("Use ocean.util.log.Logger instead")
         final void fatal (cstring fmt, ...)
         {
             format (Level.Fatal, fmt, _arguments, _argptr);
@@ -623,6 +636,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        // Not deprecated: Triggers wrong deprecation messages
         final cstring name ()
         {
                 auto i = name_.length;
@@ -637,6 +651,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        // Not deprecated: Triggers wrong deprecation messages
         final Level level ()
         {
                 return level_;
@@ -648,6 +663,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        deprecated("Use ocean.util.log.Logger instead")
         final Logger level (Level l)
         {
                 return level (l, false);
@@ -660,6 +676,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        // Not deprecated: Triggers wrong deprecation messages
         final Logger level (Level level, bool propagate)
         {
                 level_ = level;
@@ -679,6 +696,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        deprecated("Import ocean.util.log.Logger instead")
         final bool additive ()
         {
                 return additive_;
@@ -690,6 +708,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        // Not deprecated: Triggers wrong deprecation messages
         final Logger additive (bool enabled)
         {
                 additive_ = enabled;
@@ -704,6 +723,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        // Not deprecated: Triggers wrong deprecation messages
         final Logger add (AP.Appender another)
         {
                 assert (another);
@@ -718,6 +738,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        // Not deprecated: Triggers wrong deprecation messages
         final Logger clear ()
         {
                 appender_ = null;
@@ -730,6 +751,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        deprecated("Import ocean.util.log.Logger instead")
         final mstring buffer ()
         {
                 return buffer_;
@@ -743,6 +765,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        // Not deprecated: Triggers wrong deprecation messages
         final Logger buffer (mstring buf)
         {
                 buffer_ = buf;
@@ -763,6 +786,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        // Not deprecated: Triggers wrong deprecation messages
         void collectStats (bool value, bool propagate)
         {
             this.collect_stats = value;
@@ -779,6 +803,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        deprecated("Import ocean.util.log.Logger instead")
         final TimeSpan runtime ()
         {
             return Clock.now - Clock.startTime();
@@ -790,6 +815,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        deprecated("Use ocean.util.log.Logger instead")
         final Logger append (Level level, lazy cstring exp)
         {
                 if (host_.context.enabled (level_, level))
@@ -809,6 +835,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        deprecated("Use ocean.util.log.Logger instead")
         private void append (EV.LogEvent event)
         {
                 // indicator if the event was at least once emitted to the
@@ -857,6 +884,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        deprecated("Use ocean.util.log.Logger instead")
         final mstring format (mstring buffer, cstring formatStr, ...)
         {
             return Format.vprint (buffer, formatStr, _arguments, _argptr);
@@ -869,6 +897,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        deprecated("Use ocean.util.log.Logger instead")
         final void format (Level level, cstring fmt, ...)
         {
             format (level, fmt, _arguments, _argptr);
@@ -880,6 +909,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        deprecated("Use ocean.util.log.Logger instead")
         final Logger format (Level level, cstring fmt, TypeInfo[] types, ArgList args)
         {
                 if (types.length)
@@ -894,18 +924,21 @@ public class Logger : ILogger
                 return this;
         }
 
+        deprecated("Use ocean.util.log.Logger instead")
         private void formatWithDefaultBuffer(Level level, cstring fmt, TypeInfo[] types, ArgList args)
         {
             char[2048] tmp = void;
             formatWithBuffer(level, fmt, types, args, tmp);
         }
 
+        deprecated("Use ocean.util.log.Logger instead")
         private void formatWithProvidedBuffer(Level level, cstring fmt, TypeInfo[] types, ArgList args)
         {
             formatWithBuffer(level, fmt, types, args, buffer_);
             buffer_.length = buffer_size_;
         }
 
+        deprecated("Use ocean.util.log.Logger instead")
         private void formatWithBuffer(Level level, cstring fmt, TypeInfo[] types, ArgList args, mstring buf)
         {
             append (level, Format.vprint (buf, fmt, types, args));
@@ -919,6 +952,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        // Not deprecated: Triggers wrong deprecation messages
         package final bool isChildOf (istring candidate)
         {
                 auto len = candidate.length;
@@ -941,6 +975,7 @@ public class Logger : ILogger
 
         ***********************************************************************/
 
+        // Not deprecated: Triggers wrong deprecation messages
         package final bool isCloserAncestor (Logger other)
         {
                 auto name = other.name_;
@@ -965,4 +1000,5 @@ public class Logger : ILogger
 
 *******************************************************************************/
 
+deprecated("Import ocean.util.log.Logger instead")
 public alias HierarchyT!(Logger) Hierarchy;

--- a/src/ocean/util/log/Logger.d
+++ b/src/ocean/util/log/Logger.d
@@ -132,6 +132,27 @@ public struct Log
         static assert(Level.max == This.tupleof.length,
                       "Number of members doesn't match Levels");
 
+        /***********************************************************************
+
+            Total count of all events emitted during this period.
+
+            Returns:
+                Total count of all events emitted during this period.
+
+        ***********************************************************************/
+
+        public uint total ()
+        {
+            uint total;
+
+            foreach (field; this.tupleof)
+            {
+                total += field;
+            }
+
+            return total;
+        }
+
         /// Resets the counters
         private void reset ()
         {

--- a/src/ocean/util/log/Logger.d
+++ b/src/ocean/util/log/Logger.d
@@ -69,7 +69,6 @@ import ocean.util.log.model.ILogger;
 
 import ocean.util.log.Hierarchy;
 
-import ocean.stdc.string;
 
 version (UnitTest)
 {
@@ -185,28 +184,6 @@ public struct Log
     /// Time elapsed since the first logger instantiation
     private static Time beginTime;
 
-    /// Internal struct to associate a `Level` with its name
-    private struct Pair
-    {
-        /// The name associated with `value`
-        istring name;
-        /// An `ILogger.Level` value
-        Level value;
-    }
-
-    /// Poor man's SmartEnum: We don't use SmartEnum directly because
-    /// it would change the public interface, and we accept any case anyway.
-    /// This can be fixed when we drop D1 support.
-    private const Pair[Level.max + 1] Pairs =
-    [
-        { "Trace",  Level.Trace },
-        { "Info",   Level.Info },
-        { "Warn",   Level.Warn },
-        { "Error",  Level.Error },
-        { "Fatal",  Level.Fatal },
-        { "None",   Level.None }
-    ];
-
     /// Logger stats
     private static Stats logger_stats;
 
@@ -226,34 +203,24 @@ public struct Log
 
     public static Level convert (cstring name, Level def = Level.Trace)
     {
-        foreach (field; Pairs)
-        {
-            if (field.name.length == name.length
-                && !strncasecmp(name.ptr, field.name.ptr, name.length))
-                return field.value;
-        }
-        return def;
+        return ILogger.convert(name, def);
     }
 
     /***************************************************************************
 
-        Return the name associated with level, or `null`
+        Return the name associated with level
 
         Params:
             level = The `Level` to get the name for
 
         Returns:
             The name associated with `level`.
-            If `level` is out of bound, returns `null`.
 
     ***************************************************************************/
 
     public static istring convert (Level level)
     {
-        if (level >= Level.Trace && level <= Level.None)
-            return null;
-
-        return This.Pairs[level].name;
+        return ILogger.convert(level);
     }
 
 

--- a/src/ocean/util/log/Logger.d
+++ b/src/ocean/util/log/Logger.d
@@ -62,7 +62,6 @@ import ocean.io.model.IConduit;
 import ocean.sys.Common;
 import ocean.text.convert.Formatter;
 import ocean.time.Clock;
-import ocean.util.log.Log;
 import ocean.util.log.Appender;
 import ocean.util.log.Event;
 import ocean.util.log.model.ILogger;

--- a/src/ocean/util/log/Stats.d
+++ b/src/ocean/util/log/Stats.d
@@ -57,7 +57,7 @@ import ocean.sys.ErrnoException;
 import ocean.text.convert.Layout: StringLayout;
 import ocean.util.log.layout.LayoutStatsLog;
 import ocean.util.log.Appender;
-import ocean.util.log.Log;
+import ocean.util.log.Logger;
 
 
 version (UnitTest)

--- a/src/ocean/util/log/layout/LayoutSimple.d
+++ b/src/ocean/util/log/layout/LayoutSimple.d
@@ -36,7 +36,7 @@ import  Integer = ocean.text.convert.Integer_tango;
         Example:
         ------
         import ocean.util.log.layout.LayoutSimple;
-        import ocean.util.log.Log;
+        import ocean.util.log.Logger;
         import ocean.util.log.AppendConsole;
 
 

--- a/test/loggerstats/main.d
+++ b/test/loggerstats/main.d
@@ -13,7 +13,7 @@
 
 *******************************************************************************/
 
-import ocean.util.log.Log;
+import ocean.util.log.Logger;
 import ocean.core.Test;
 import ocean.io.device.File;
 


### PR DESCRIPTION
This set of patch deprecate the old loggers in favor of the new ones.
It means we can remove the old loggers in v4.x.x, and are one big step closer to remove Tango's Layout.