### PR TITLE
Deprecate ocean.text.convert.Memory

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -114,6 +114,7 @@ TEST_FILTER_OUT += \
 	$C/src/ocean/stdc/posix/ucontext.d \
 	$C/src/ocean/stdc/posix/unistd.d \
 	$C/src/ocean/stdc/posix/utime.d \
+	$C/src/ocean/text/convert/Memory.d \
 	$C/src/ocean/io/stream/Zlib.d \
 	$C/src/ocean/math/BigInt.d
 

--- a/relnotes/text-convert-memory.deprecation.md
+++ b/relnotes/text-convert-memory.deprecation.md
@@ -1,0 +1,5 @@
+* `ocean.text.convert.Memory`
+
+  This module, and its sole function, `memoryToHexAscii`, is unused among all Sociomantic project.
+  Similar result can be achieved through `sformat(output, "{X}", memory_slice)`, for short slices of memory.
+  If this function is really needed, contact ocean's maintainer or copy it in your project.

--- a/src/ocean/text/convert/Memory.d
+++ b/src/ocean/text/convert/Memory.d
@@ -13,7 +13,7 @@
 
 *******************************************************************************/
 
-module ocean.text.convert.Memory;
+deprecated module ocean.text.convert.Memory;
 
 
 
@@ -52,6 +52,7 @@ import ocean.text.convert.Format;
 
 ******************************************************************************/
 
+deprecated("Copy this functionality directly, should you need it")
 public char[] memoryToHexAscii ( void[] mem, char[] output = null )
 {
     auto data = cast(ubyte[]) mem;


### PR DESCRIPTION
This function's signature is problematic and symptomatic of old patterns, as for example the output should be a ref
(passing a slice will make it allocate every time), and the memory should be Const!(void)[].
As fixing it is not trivial, and does not seem to bring anything (this module is unused), simply deprecate it.