### PR TITLE
Add missing const and inout annotations to gnu.string

### DIFF
--- a/src/ocean/stdc/gnu/string.d
+++ b/src/ocean/stdc/gnu/string.d
@@ -17,24 +17,25 @@ module ocean.stdc.gnu.string;
 
 version (GLIBC):
 
-
+import ocean.transition;
 import core.stdc.stddef: wchar_t;
 
 
 extern (C):
 
-size_t   strnlen(char* s, size_t maxlen);
-size_t   wcsnlen(wchar_t* ws, size_t maxlen);
+size_t   strnlen(in char* s, size_t maxlen);
+size_t   wcsnlen(in wchar_t* ws, size_t maxlen);
 void*    mempcpy(void* to, void *from, size_t size);
 wchar_t* wmempcpy(wchar_t* wto, wchar_t* wfrom, size_t size);
-wchar_t* wcsdup (wchar_t* ws);
-char*    strndup(char* s, size_t size);
-int      strverscmp(char* s1, char* s2);
-void*    rawmemchr(void* block, int c);
-void*    memrchr(void* block, int c, size_t size);
-char*    strchrnul(char* string, int c);
-wchar_t* wcschrnul(wchar_t* wstring, wchar_t wc);
-void*    memmem(void* haystack, size_t hlen, void *needle, size_t nlen);
+wchar_t* wcsdup (in wchar_t* ws);
+char*    strndup(in char* s, size_t size);
+int      strverscmp(in char* s1, in char* s2);
+Inout!(void)* rawmemchr(Inout!(void)* block, int c);
+Inout!(void)* memrchr(Inout!(void)* block, int c, size_t size);
+Inout!(char)* strchrnul(Inout!(char)* str, int c);
+Inout!(wchar_t)* wcschrnul(Inout!(wchar_t)* wstr, wchar_t wc);
+Inout!(void)* memmem(Inout!(void)* haystack, size_t hlen,
+                    in void *needle, size_t nlen);
 
 static if (__VERSION__ < 2070)
 {

--- a/src/ocean/text/utf/UtfUtil.d
+++ b/src/ocean/text/utf/UtfUtil.d
@@ -248,7 +248,8 @@ body
                 last = g_utf8_offset_to_pointer(str.ptr, last) - str.ptr;
             }
 
-            auto c = cast (char*) memrchr(str.ptr, ' ', last);
+            void* result = memrchr(str.ptr, ' ', last);
+            char* c = cast(char*) result;
             if (c)
             {
                 // Skip consecutive ' ' characters.

--- a/src/ocean/text/util/ClassName.d
+++ b/src/ocean/text/util/ClassName.d
@@ -14,9 +14,8 @@
 
 module ocean.text.util.ClassName;
 
+import ocean.stdc.gnu.string;
 import ocean.transition;
-
-extern (C) private void* memrchr(Const!(void)* s, int c, size_t n);
 
 istring classname ( Const!(Object) o )
 {
@@ -29,7 +28,8 @@ istring classname ( Const!(Object) o, out istring mod )
 {
     istring str = o.classinfo.name;
 
-    char* lastdot = cast (char*) memrchr(str.ptr, '.', str.length);
+    Const!(void)* result = memrchr(str.ptr, '.', str.length);
+    Const!(char)* lastdot = cast(Const!(char)*) result;
 
     if (lastdot)
     {


### PR DESCRIPTION
Reported by @don-clugston-sociomantic 