### PR TITLE
No recursive types for serializer

### DIFF
--- a/relnotes/contains-dynarr.feature.md
+++ b/relnotes/contains-dynarr.feature.md
@@ -1,0 +1,17 @@
+## Template to recursively check if type contains dynamic arrays
+
+`ocean.meta.traits.Indirectons`
+
+New `containsDynamicArray` template is implemented on top of generic
+`ReduceType` facility and provides a more reliable and robust way to detect that
+a given type transitively contains some dynamic array.
+
+```D
+static struct S
+{
+  struct Arr { int[] x; }
+  Arr[3][4] arr;
+}
+
+static assert(containsDynamicArray!(S2));
+```

--- a/relnotes/recursive-serializer.migration.md
+++ b/relnotes/recursive-serializer.migration.md
@@ -1,0 +1,16 @@
+## Contiguous (de)serializer does not support recursive types
+
+This struct used to be accepted by serializer but will cause compilation error
+with the new ocean:
+
+```D
+struct S
+{
+  S[] x;
+}
+```
+
+This is unfortunate side effect of making serializer more generic and
+separating type analysis from serialization code. As this feature was not used
+by Sociomantic projects and new implementation will simplify maintenance, it was
+considered a desirable trade-off.

--- a/src/ocean/meta/traits/Indirections.d
+++ b/src/ocean/meta/traits/Indirections.d
@@ -208,3 +208,52 @@ unittest
 
     static assert(!containsMultiDimensionalDynamicArrays!(C));
 }
+
+/*******************************************************************************
+
+    Checks if T or any of its subtypes is a dynamic array.
+
+    Params:
+        T = type to check
+
+    Returns:
+        true if T or any of its subtypes is a dynamic array or
+        false otherwise.
+
+*******************************************************************************/
+
+public template containsDynamicArray ( T )
+{
+    const containsDynamicArray =
+        ReduceType!(T, DynArrayReducer);
+}
+
+///
+unittest
+{
+    static assert (!containsDynamicArray!(void));
+
+    static struct S
+    {
+        int[] x;
+    }
+    static assert ( containsDynamicArray!(Const!(S)));
+
+    static struct S2
+    {
+        struct Arr { Const!(int[]) x; }
+        Arr[3][4] arr;
+    }
+
+    static assert( containsDynamicArray!(Immut!(S2)));
+}
+
+private struct DynArrayReducer
+{
+    alias bool Result;
+
+    Result visit ( T ) ( )
+    {
+        return isArrayType!(T) == ArrayKind.Dynamic;
+    }
+}

--- a/src/ocean/util/serialize/contiguous/Deserializer.d
+++ b/src/ocean/util/serialize/contiguous/Deserializer.d
@@ -23,7 +23,8 @@ import ocean.core.Verify;
 import ocean.util.serialize.contiguous.Contiguous;
 
 import ocean.core.Exception;
-import ocean.core.Traits;
+import ocean.core.Enforce;
+import ocean.meta.traits.Indirections;
 
 debug (DeserializationTrace) import ocean.io.Stdout;
 

--- a/src/ocean/util/serialize/contiguous/Serializer.d
+++ b/src/ocean/util/serialize/contiguous/Serializer.d
@@ -20,9 +20,7 @@ module ocean.util.serialize.contiguous.Serializer;
 import ocean.transition;
 
 import ocean.util.serialize.contiguous.Contiguous;
-
-import ocean.core.Traits : ContainsDynamicArray;
-
+import ocean.meta.traits.Indirections;
 import ocean.core.Test;
 
 debug(SerializationTrace) import ocean.io.Stdout;
@@ -87,7 +85,7 @@ struct Serializer
         data[0 .. S.sizeof] = (cast(void*) &src)[0 .. S.sizeof];
         auto s_root = cast(Unqual!(S)*) data.ptr;
 
-        static if (ContainsDynamicArray!(S))
+        static if (containsDynamicArray!(S))
         {
             void[] remaining = This.dumpAllArrays(*s_root, data[S.sizeof .. $]);
 
@@ -153,7 +151,7 @@ struct Serializer
             Stdout.formatln("> countRequiredSize!({})(<input>)", S.stringof);
         }
 
-        static if (ContainsDynamicArray!(S))
+        static if (containsDynamicArray!(S))
         {
             return input.sizeof + This.countAllArraySize(input);
         }
@@ -250,7 +248,7 @@ struct Serializer
 
         size_t len = 0;
 
-        static if (ContainsDynamicArray!(S))
+        static if (containsDynamicArray!(S))
         {
             foreach (i, ref field; s.tupleof)
             {
@@ -259,7 +257,7 @@ struct Serializer
                 static if (is (Field == struct))
                 {
                     // Recurse into struct field.
-                    static if (ContainsDynamicArray!(Field))
+                    static if (containsDynamicArray!(Field))
                     {
                         len += This.countAllArraySize(field);
                     }
@@ -274,7 +272,7 @@ struct Serializer
                 {
                     // Static array
 
-                    static if (ContainsDynamicArray!(Element))
+                    static if (containsDynamicArray!(Element))
                     {
                         // Recurse into static array elements which contain a
                         // dynamic array.
@@ -348,7 +346,7 @@ struct Serializer
 
             len += array.length * T.sizeof;
 
-            static if (ContainsDynamicArray!(T))
+            static if (containsDynamicArray!(T))
             {
                 foreach (element; array)
                 {
@@ -388,7 +386,7 @@ struct Serializer
     }
     body
     {
-        static assert (ContainsDynamicArray!(T), T.stringof ~
+        static assert (containsDynamicArray!(T), T.stringof ~
                        " contains no dynamic array - nothing to do");
 
         debug (SerializationTrace)
@@ -398,7 +396,7 @@ struct Serializer
 
         static if (is (T == struct))
         {
-            static if (ContainsDynamicArray!(T))
+            static if (containsDynamicArray!(T))
             {
                 return This.countAllArraySize(element);
             }
@@ -465,7 +463,7 @@ struct Serializer
                 S.stringof, &s, data.ptr);
         }
 
-        static if (ContainsDynamicArray!(S))
+        static if (containsDynamicArray!(S))
         {
             foreach (i, ref field; s.tupleof)
             {
@@ -489,7 +487,7 @@ struct Serializer
                 {
                     // Dump static array
 
-                    static if (ContainsDynamicArray!(Element))
+                    static if (containsDynamicArray!(Element))
                     {
                         // Recurse into static array elements which contain a
                         // dynamic array.
@@ -591,7 +589,7 @@ struct Serializer
 
                 dst[] = array[];
 
-                static if (ContainsDynamicArray!(T))
+                static if (containsDynamicArray!(T))
                 {
                     // array is an array of structs or static arrays which
                     // contain dynamic arrays: Recurse into array elements.
@@ -696,7 +694,7 @@ struct Serializer
         // array is a dynamic array of structs or static arrays which
         // contain dynamic arrays.
 
-        static assert (ContainsDynamicArray!(T), "nothing to do for " ~ T.stringof);
+        static assert (containsDynamicArray!(T), "nothing to do for " ~ T.stringof);
 
         static if (is (T == struct))
         {
@@ -754,7 +752,7 @@ struct Serializer
     body
     {
         static assert (is (S == struct), "struct expected, not " ~ S.stringof);
-        static assert (ContainsDynamicArray!(S), "nothing to do for " ~ S.stringof);
+        static assert (containsDynamicArray!(S), "nothing to do for " ~ S.stringof);
 
         debug (SerializationTrace)
         {
@@ -769,7 +767,7 @@ struct Serializer
             {
                 // Recurse into field of struct type if it contains
                 // a dynamic array.
-                static if (ContainsDynamicArray!(Field))
+                static if (containsDynamicArray!(Field))
                 {
                     This.resetReferences(field);
                 }
@@ -784,7 +782,7 @@ struct Serializer
             {
                 // Static array
 
-                static if (ContainsDynamicArray!(Element))
+                static if (containsDynamicArray!(Element))
                 {
                     // Field of static array that contains a dynamic array:
                     // Recurse into field array elements.


### PR DESCRIPTION
Reminder PR to clean up serializer interaction with traits by the time of 4.0.0
release.