### PR TITLE
Better const compatibility of Map

### DIFF
--- a/relnotes/map.migration.md
+++ b/relnotes/map.migration.md
@@ -1,0 +1,5 @@
+* `ocean.util.container.map.model.BucketSet`
+
+  Asbtract `toHash` method was changed to accept `in K key` instead of just
+  `K key`. Any class that overrides it directly or indirectly will have to be
+  adjusted accordingly.

--- a/src/ocean/io/select/selector/RegisteredClients.d
+++ b/src/ocean/io/select/selector/RegisteredClients.d
@@ -202,7 +202,7 @@ public final class ClientSet : IRegisteredClients
 
         ***********************************************************************/
 
-        public override hash_t toHash ( ISelectClient c )
+        public override hash_t toHash ( in ISelectClient c )
         {
             return cast(hash_t)cast(void*)c;
         }

--- a/src/ocean/time/timeout/TimeoutManager.d
+++ b/src/ocean/time/timeout/TimeoutManager.d
@@ -284,7 +284,7 @@ abstract class TimeoutManagerBase : ITimeoutManager
             }
         }
 
-        protected override hash_t toHash ( Expiry* expiry )
+        protected override hash_t toHash ( in Expiry* expiry )
         {
             return StandardHash.fnv1aT(expiry);
         }

--- a/src/ocean/util/container/map/HashMap.d
+++ b/src/ocean/util/container/map/HashMap.d
@@ -104,6 +104,10 @@ public class HashMap ( V ) : Map!(V, hash_t)
         Calculates the hash value from key. Uses the identity since key is
         expected to be a suitable hash value.
 
+        This method has to accept `const(hash_t)` because it overrides templated
+        base `toHash (K) (in K key)` method and DMD demands exact qualifier
+        match for arguments.
+
         Params:
             key = key to hash
 
@@ -112,7 +116,7 @@ public class HashMap ( V ) : Map!(V, hash_t)
 
     ***************************************************************************/
 
-    public override hash_t toHash ( hash_t key )
+    public override hash_t toHash ( in hash_t key )
     {
         return key;
     }

--- a/src/ocean/util/container/map/HashSet.d
+++ b/src/ocean/util/container/map/HashSet.d
@@ -132,7 +132,7 @@ public class HashSet : Set!(hash_t)
 
     ***************************************************************************/
 
-    public override hash_t toHash ( hash_t key )
+    public override hash_t toHash ( in hash_t key )
     {
         return key;
     }

--- a/src/ocean/util/container/map/Map.d
+++ b/src/ocean/util/container/map/Map.d
@@ -467,7 +467,7 @@ public abstract class Map ( V, K ) : BucketSet!(V.sizeof, K)
 
     ***************************************************************************/
 
-    public V* opIn_r ( K key )
+    public V* opIn_r ( in K key )
     {
         auto element = this.get_(key);
 
@@ -494,7 +494,7 @@ public abstract class Map ( V, K ) : BucketSet!(V.sizeof, K)
 
     ***************************************************************************/
 
-    public V* get ( K key )
+    public V* get ( in K key )
     out (val)
     {
         assert (val !is null);
@@ -521,7 +521,7 @@ public abstract class Map ( V, K ) : BucketSet!(V.sizeof, K)
 
     ***************************************************************************/
 
-    public VReturn opIndex ( K key )
+    public VReturn opIndex ( in K key )
     {
         return *this.get(key);
     }
@@ -865,7 +865,7 @@ public abstract class Map ( size_t V, K ) : BucketSet!(V, K)
 
      ***************************************************************************/
 
-    public void[] opIn_r ( K key )
+    public void[] opIn_r ( in K key )
     out (val)
     {
         if (val)
@@ -898,7 +898,7 @@ public abstract class Map ( size_t V, K ) : BucketSet!(V, K)
 
     ***************************************************************************/
 
-    public void[] get ( K key )
+    public void[] get ( in K key )
     out (val)
     {
         assert (val.length == V);
@@ -950,7 +950,7 @@ public abstract class Map ( size_t V, K ) : BucketSet!(V, K)
 
      ***************************************************************************/
 
-    public void[] put ( K key, out bool added )
+    public void[] put ( in K key, out bool added )
     out (val)
     {
         assert (val.length == V);
@@ -1040,7 +1040,7 @@ public abstract class Map ( size_t V, K ) : BucketSet!(V, K)
 
     ***************************************************************************/
 
-    public void[] remove ( K key )
+    public void[] remove ( in K key )
     out (val)
     {
         if (val)
@@ -1226,6 +1226,14 @@ unittest
     test_val!(short);
     test_val!(int);
     test_val!(long);
+}
+
+unittest
+{
+    // ensure opIn works with const keys
+    auto map = new StandardKeyHashingMap!(int, mstring)(5);
+    auto v = "something" in map;
+    test!("is")(v, null);
 }
 
 /*******************************************************************************

--- a/src/ocean/util/container/map/model/Bucket.d
+++ b/src/ocean/util/container/map/model/Bucket.d
@@ -177,7 +177,7 @@ public struct Bucket ( size_t V, K = hash_t )
 
      **************************************************************************/
 
-    public Element* find ( Element.Key key )
+    public Element* find ( in Element.Key key )
     out (element)
     {
         debug (HostingArrayMapBucket) if (element)

--- a/src/ocean/util/container/map/model/BucketSet.d
+++ b/src/ocean/util/container/map/model/BucketSet.d
@@ -417,7 +417,7 @@ public abstract class BucketSet ( size_t V, K = hash_t ) : IBucketSet
 
      ***************************************************************************/
 
-    final protected Bucket.Element* get_ ( K key, bool must_exist = false )
+    final protected Bucket.Element* get_ ( in K key, bool must_exist = false )
     out (element)
     {
         // FIXME: Disabled due to DMD bug 6417, the method parameter argument
@@ -437,7 +437,9 @@ public abstract class BucketSet ( size_t V, K = hash_t ) : IBucketSet
     }
     body
     {
-        auto element = this.buckets[this.toHash(key) & this.bucket_mask].find(key);
+        auto element = this
+            .buckets[this.toHash(key) & this.bucket_mask]
+            .find(key);
 
         if (element)
         {
@@ -608,7 +610,7 @@ public abstract class BucketSet ( size_t V, K = hash_t ) : IBucketSet
 
     ***************************************************************************/
 
-    abstract public hash_t toHash ( K key );
+    abstract public hash_t toHash ( in K key );
 
     /***************************************************************************
 

--- a/src/ocean/util/container/map/model/StandardHash.d
+++ b/src/ocean/util/container/map/model/StandardHash.d
@@ -58,7 +58,7 @@ struct StandardHash
 
      **************************************************************************/
 
-    hash_t toHash ( K ) ( K key )
+    hash_t toHash ( K ) ( in K key )
     {
         static if (StandardHash.IsPrimitiveValueType!(K))
         {

--- a/src/ocean/util/container/map/utils/MapSerializer.d
+++ b/src/ocean/util/container/map/utils/MapSerializer.d
@@ -1342,7 +1342,7 @@ version ( UnitTest )
 
         ***********************************************************************/
 
-        public override hash_t toHash ( K key )
+        public override hash_t toHash ( in K key )
         {
             return Fnv1a.fnv1(key);
         }
@@ -1863,7 +1863,11 @@ unittest
     class Map : SerializingMap!(int, int)
     {
         this ( ) { super(10); }
-        public override hash_t toHash ( int key ) { return key; }
+
+        // This method has to accept `const(int)` because it overrides templated
+        // base `toHash (K) (in K key)` method and DMD demands exact qualifier
+        // match for arguments.
+        public override hash_t toHash ( in int key ) { return key; }
     }
 
     scope device = new MemoryDevice;


### PR DESCRIPTION
For some of Map methods it is fine to accept const qualified version of
the key as it is neither stored nor mutated.

Has to be based against v4.x.x because it anything that overrides `toHash`
method will need small signature adjustment to keep compiling with D2 compiler.