### PR TITLE
Formatter: Treat null and empty array the same

### DIFF
--- a/relnotes/ce-formatter-est-null.migration.md
+++ b/relnotes/ce-formatter-est-null.migration.md
@@ -1,0 +1,6 @@
+* `ocean.text.convert.Formatter`
+
+  The formatter will now treat `null` arrays the same way it treats empty array.
+  This means `null` typed as array of char will result in empty string instead of
+  the string `null`, and other null arrays will result in `[]`.
+  Null associative array will result in `[:]`.

--- a/src/ocean/text/convert/Formatter.d
+++ b/src/ocean/text/convert/Formatter.d
@@ -345,7 +345,7 @@ private void handle (T) (T v, FormatInfo f, FormatterSink sf, ElemSink se)
 
     // Cannot print enum member name in D1, so just print the value
     else static if (is (T V == enum))
-             handle!(V)(v, f, sf, se);
+        handle!(V)(v, f, sf, se);
 
     // Delegate / Function pointers
     else static if (is(T == delegate))


### PR DESCRIPTION
This was originally different but it proved to be more of a problem
than an help. Reverting to the old Tango Layout's behavior.

Fixes sociomantic-tsunami/ocean#171