### PR TITLE
Do not format argumentless logging calls

### DIFF
--- a/src/ocean/util/log/Appender.d
+++ b/src/ocean/util/log/Appender.d
@@ -65,7 +65,21 @@ public class Appender
     /// Return the name of this Appender.
     abstract cstring name ();
 
-    /// Append a message to the output.
+    /***************************************************************************
+
+        Append a message to the output.
+
+        The event received is only valid for the duration of the `apppend`
+        call and shouldn't outlive the scope of `append`.
+        Moreover, as `Logger` use a class-local buffer, its tracing functions
+        which use formatting are not re-entrant and should not be called
+        from here.
+
+        Params:
+            event = Event to log
+
+    ***************************************************************************/
+
     abstract void append (LogEvent event);
 
     /// Create an Appender and default its layout to LayoutTimer.

--- a/src/ocean/util/log/Logger.d
+++ b/src/ocean/util/log/Logger.d
@@ -872,6 +872,12 @@ public final class Logger : ILogger
 
         Format and emit a textual log message from the given arguments
 
+        The formatted string emitted will have a length up to `buffer.length`,
+        which is 2048 by default.
+        If no formatting argument is provided (the call has only 2 parameters,
+        e.g. `format(Level.Trace, "Baguette");`), then the string will be just
+        emitted to the appender(s) verbatim and won't be limited in length.
+
         Params:
             Args  = Auto-deduced argument list
             level = Message severity
@@ -882,9 +888,14 @@ public final class Logger : ILogger
 
     public void format (Args...) (Level level, cstring fmt, Args args)
     {
-        // If the buffer has length 0 / is null, we just don't log anything
-        if (this.buffer_.length)
-            this.append(level, snformat(this.buffer_, fmt, args));
+        static if (Args.length == 0)
+            this.append(level, fmt);
+        else
+        {
+            // If the buffer has length 0 / is null, we just don't log anything
+            if (this.buffer_.length)
+                this.append(level, snformat(this.buffer_, fmt, args));
+        }
     }
 
     /***************************************************************************
@@ -955,4 +966,37 @@ unittest
     test!("==")(Log.convert("Baguette", Level.Warn), Level.Warn);
     // The first entry in the array
     test!("==")(Log.convert("trace", Level.Error), Level.Trace);
+}
+
+// Test that argumentless format call does not shrink the output
+unittest
+{
+    static class Buffer : Appender
+    {
+        public struct Event { Logger.Level level; cstring message; }
+        public Event[] result;
+
+        public override Mask mask () { Mask m = 42; return m; }
+        public override cstring name () { return "BufferAppender"; }
+        public override void append (LogEvent e)
+        {
+            this.result ~= Event(e.level, e.toString());
+        }
+    }
+
+    // Test string of 87 chars
+    const TestStr = "Ce qui se conçoit bien s'énonce clairement - Et les mots pour le dire arrivent aisément";
+    scope appender = new Buffer();
+    char[32] log_buffer;
+    Logger log = Log.lookup("ocean.util.log.Logger.TestLogTrim")
+        .add(appender).buffer(log_buffer);
+    log.info("{}", TestStr);
+    log.error(TestStr);
+    test!("==")(appender.result.length, 2);
+    // Trimmed string
+    test!("==")(appender.result[0].level, Logger.Level.Info);
+    test!("==")(appender.result[0].message, TestStr[0 .. 32]);
+    // Full string
+    test!("==")(appender.result[1].level, Logger.Level.Error);
+    test!("==")(appender.result[1].message, TestStr);
 }


### PR DESCRIPTION
> This allow to log pre-formatted strings which have a length > buffer.length.
> The old logger was behaving this way, but this was overlooked during the new logger implementation.
> Fixes sociomantic-tsunamic/ocean#184

CC @don-clugston-sociomantic 