### PR TITLE
Allow usage of Buffer!(char) and Buffer!(Wchar) with StringC.toStringC

### DIFF
--- a/relnotes/stringcbuffer.feature.md
+++ b/relnotes/stringcbuffer.feature.md
@@ -1,0 +1,4 @@
+* `ocean.text.util.StringC`
+
+  `StringC`'s `toCString` overloads now support `Buffer!(char)` as well, so
+  it can work with `Buffer!(char)`.

--- a/relnotes/stringcwchar.deprecation.md
+++ b/relnotes/stringcwchar.deprecation.md
@@ -1,0 +1,4 @@
+* `ocean.text.util.StringC`
+
+  `StringC`'s `toCString` overload that accepts `Wchar` is now deprecated,
+  since we are not using it and it's a maintenance burden.

--- a/src/ocean/text/util/StringC.d
+++ b/src/ocean/text/util/StringC.d
@@ -105,6 +105,7 @@ class StringC
 
     ***************************************************************************/
 
+    deprecated("Usage of Wchar strings is deprecated.")
     public static Wchar* toCString ( ref Wchar[] str )
     {
         if (str.length && !!str[$ - 1])

--- a/src/ocean/text/util/StringC.d
+++ b/src/ocean/text/util/StringC.d
@@ -39,6 +39,7 @@ module ocean.text.util.StringC;
 
 import ocean.transition;
 
+import ocean.core.Buffer;
 import ocean.stdc.string: strlen, wcslen;
 import core.stdc.stddef: wchar_t;
 
@@ -87,12 +88,7 @@ class StringC
 
     public static char* toCString ( ref mstring str )
     {
-        if (str.length && !!str[$ - 1])
-        {
-            str ~= StringC.Term;
-        }
-
-        return str.ptr;
+        return typeof(this).toCString(*(cast(Buffer!(char)*)&str));
     }
 
     /***************************************************************************
@@ -117,6 +113,31 @@ class StringC
         }
 
         return str.ptr;
+    }
+
+    /***************************************************************************
+
+        Converts str to a C string, that is, if a null terminator is not
+        present then it is appended to the original string. A pointer to the
+        string is returned.
+
+        Params:
+            str = input string buffer
+
+        Returns:
+            C compatible (null terminated) string
+
+    ***************************************************************************/
+
+    public static char* toCString ( ref Buffer!(char) str )
+    {
+        if (str.length && !!*str[str.length - 1])
+        {
+            str.length = str.length + 1;
+            str[str.length - 1] = StringC.Term;
+        }
+
+        return str[].ptr;
     }
 
     /***************************************************************************
@@ -191,4 +212,9 @@ unittest
     assert(const_empty !is null);
     cstring r2 = StringC.toDString(const_empty);
     test!("is")(const_empty, r2.ptr);
+
+    Buffer!(char) buff;
+    buff = "Regular D string".dup;
+    StringC.toCString(buff);
+    test!("==")(buff[], "Regular D string\0");
 }


### PR DESCRIPTION
`StringC`'s `toCString` overloads now support `Buffer!(char)` and
`Buffer!(Wchar)` as well as the arrays.