### PR TITLE
SortedMap: Do not use the return of CommaExp

### DIFF
--- a/src/ocean/util/container/SortedMap.d
+++ b/src/ocean/util/container/SortedMap.d
@@ -926,8 +926,12 @@ class SortedMap (K, V, alias Reap = Container.reap,
 
                 bool next (ref K k, ref V v)
                 {
-                        auto n = next (k);
-                        return (n) ? v = *n, true : false;
+                    if (auto n = next(k))
+                    {
+                        v = *n;
+                        return true;
+                    }
+                    return false;
                 }
 
                 /***************************************************************


### PR DESCRIPTION
It triggers a deprecation warning in recent D2 compiler (hence targeting v3).