### PR TITLE
Clear any previous log stats state before counting log events

### DIFF
--- a/test/loggerstats/main.d
+++ b/test/loggerstats/main.d
@@ -37,6 +37,9 @@ void main ( )
     auto log2 = Log.lookup("MyLog2");
     log2.level = log2.Warn;
 
+    // Clear any previous logger stats state
+    Log.stats();
+
     // Confirm that stats are auto reset
     for (auto i = 0; i < 3; i++)
     {


### PR DESCRIPTION
In the logger stats' tests, emitted log events have been counted,
but if the target is built with -unittests and any of the unittest
emit log message, that will be counted as well. This clears the log
stats before emitting log events, so we're at the clean state.