### PR TITLE
Deprecate `Stopwatch.stop` in favour of `StopWatch.sec`

### DIFF
--- a/relnotes/stopwatch-stop.deprecation.md
+++ b/relnotes/stopwatch-stop.deprecation.md
@@ -1,0 +1,7 @@
+* `ocean.time.StopWatch`
+
+  The `stop` method of `StopWatch` was highly misleading in its name and
+  documentation, since it did not (contra to claims) stop the underlying
+  timer.  It has therefore been renamed (and redocumented) to `sec` (by
+  analogy to the existing `microsec` method), with a deprecated alias to
+  support calls to the old `stop`.

--- a/src/ocean/time/StopWatch.d
+++ b/src/ocean/time/StopWatch.d
@@ -20,6 +20,12 @@ module ocean.time.StopWatch;
 // CLOCK_MONOTONIC and clock_gettime will be added to core.sys.posix.time in
 // tangort v1.7.0, see tangort issue #6.
 import core.sys.posix.time; // clockid_t, timespec
+
+version (UnitTest)
+{
+    import ocean.core.Test;
+}
+
 extern (C) private
 {
     enum: clockid_t
@@ -125,22 +131,20 @@ public struct StopWatch
         }
 }
 
-
-/*******************************************************************************
-
-*******************************************************************************/
-
-debug (StopWatch)
+unittest
 {
-        import ocean.io.Stdout_tango;
+    StopWatch t;
+    t.start;
 
-        void main()
-        {
-                StopWatch t;
-                t.start;
+    auto wait_time = timespec(0, 10_000);  // 10_000 ns = 10 microsec
 
-                for (int i=0; i < 100_000_000; ++i)
-                    {}
-                Stdout.format ("{:f9}", t.stop).newline;
-        }
+    // validate that stopwatch time counts up
+    nanosleep(&wait_time, null);
+    auto stopwatch_sec = t.stop;
+    test!(">")(stopwatch_sec, 0);
+
+    // prove that `stop` doesn't stop anything ...
+    nanosleep(&wait_time, null);
+    auto stopwatch_sec_again = t.stop;
+    test!(">")(stopwatch_sec_again, stopwatch_sec);
 }

--- a/src/ocean/time/StopWatch.d
+++ b/src/ocean/time/StopWatch.d
@@ -95,14 +95,17 @@ public struct StopWatch
 
         /***********************************************************************
 
-                Stop the timer and return elapsed duration since start()
+                Return elapsed duration (in seconds) since start()
 
         ***********************************************************************/
 
-        double stop ()
+        double sec ()
         {
                 return multiplier * this.microsec;
         }
+
+        deprecated("Use `sec` instead of `stop` (which does not stop anything)")
+        alias sec stop;
 
         /***********************************************************************
 
@@ -132,6 +135,24 @@ public struct StopWatch
 }
 
 unittest
+{
+    StopWatch t;
+    t.start;
+
+    auto wait_time = timespec(0, 10_000);  // 10_000 ns = 10 microsec
+
+    // validate that stopwatch time counts up
+    nanosleep(&wait_time, null);
+    auto stopwatch_sec = t.sec;
+    test!(">")(stopwatch_sec, 0);
+
+    // validate that checking the elapsed time doesn't stop the timer
+    nanosleep(&wait_time, null);
+    auto stopwatch_sec_again = t.sec;
+    test!(">")(stopwatch_sec_again, stopwatch_sec);
+}
+
+deprecated unittest
 {
     StopWatch t;
     t.start;


### PR DESCRIPTION
The old `stop` method of `StopWatch` was both misleadingly named and misleadingly documented: contrary to what it claimed, it did not stop the timer.  With this in mind it has been renamed to `sec` (by analogy to the existing `microsec` method).

In order to validate the changes, unittests have been added (for both old and new functionality), which as a side effect demonstrate the wicked wicked lies that the `stop` method and its documentation were telling us ... ;-)  These tests replace a wonderful bit of prehistoric debug checking the like of not we shall hopefully never see again.

Note, this is submitted against 3.x.x (given that it involves a deprecation), but can easily be rebased on 2.x.x if preferred.