### PR TITLE
Add BTree and operations over it to ocean

### DIFF
--- a/src/ocean/util/container/btree/BTreeMap.d
+++ b/src/ocean/util/container/btree/BTreeMap.d
@@ -1,0 +1,594 @@
+/********************************************************************************
+
+    B-Tree data structure and operations on it.
+
+    Copyright:
+        Copyright (c) 2017 sociomantic labs GmbH. All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+        Alternatively, this file may be distributed under the terms of the Tango
+        3-Clause BSD License (see LICENSE_BSD.txt for details).
+
+*******************************************************************************/
+
+module ocean.util.container.btree.BTreeMap;
+
+import ocean.transition;
+import ocean.util.container.mem.MemManager;
+
+/******************************************************************************
+
+    BTree structure.
+
+
+    BTree is a rooted tree, with the following properties:
+
+    - A BTree has characteristic called "degree". This indicates branching
+      factor of the tree, so that maximum number of the subtrees for a single
+      node is `2 * degree`. Having a high degree makes the tree shorter, and,
+      because the node contains large number of elements, it allows prefetching
+      many elements from the memory in one go.
+
+    - The layout of one node of the tree is as follows:
+
+      -----------------------------------------------------------------
+      | p1 | element1 | p2 | element2 | ... | pn-1 | element n-1 | pn |
+      -----------------------------------------------------------------
+
+      Every element (a key/value pair) in the node (for the non-leaf nodes) is
+      surrounded by two pointers. We call these pointers child nodes.
+
+    - Each pointer is a root of a subtree, for which the following holds true:
+      all the elements' keys in a tree pointed by p(i-1) (pointer left of the
+      elements) are smaller (in respect to the ordering defined by the key's
+      type) of the element(i), and all the elements' keys in a subtree pointed by
+      p(i) are larger than a element(i).
+
+    - Every node may contain at most 2*degree - 1 elements. Therefore, an internal
+      node may be root for at most 2*degree subtrees.
+
+    - Every node other than root must have at least (degree-1) elements.
+
+    - Every internal node other than the root has at least degree children.
+
+    - Every node has the following attributes:
+
+        node.number_of_elements = number of elements node currently contains
+            (as nodes are statically allocated block, the number of the elements
+             may not necessarily be maximal).
+        node.elements = the elements themselves
+        node.is_leaf = indicator if the node is a leaf.
+        node.child_nodes = number_of_elements+1 pointers to the subtrees whose
+            roots are this node. We refer to these nodes as child-nodes (this
+            node is a direct parent of them).
+
+    - All leaves have the same depth
+
+    Other than insert and delete operations, inorder traversal method is provided,
+    which traverses the tree in inorder order (left subtree is visited first,
+    then the element separating these subtrees, then the right subtree, then
+    the next element, etc.). This provides sequential access to the tree.
+    There's a recursive and range-based implementation of the inorder
+    traversal.
+
+    Range-based traversal is supported through `BTreeMapRange` structure, found in
+    in ocean.util.container.btree.BTreeMapRange.
+
+    CPU complexity of the operations (n is number of the elements, t is degree,
+    h is the tree height):
+
+        - Searching: O(th) = O(t * log_t(n))
+        - Inserting: O(th) = O(t * log_t(n))
+        - Deleting:  O(th) = O(t * log_t(n))
+
+    Complexity of the memory access (to read/write the node from/in memory):
+
+        - Searching O(h) = O(log_t(n))
+        - Inserting O(h) = O(log_t(n))
+        - Deleting: O(h) = O(log_t(n))
+
+    References:
+        - https://en.wikipedia.org/wiki/B-tree
+        - Thomas H. Cormen et al. "Introduction to Algorithms, 3rd edition"
+
+    Params:
+        TreeKeyType = type of the key.
+        TreeValueType = type of the element to store.
+        tree_degree = degree of the tree (refer to the documentation)
+
+******************************************************************************/
+
+struct BTreeMap(TreeKeyType, TreeValueType, int tree_degree)
+{
+    import ocean.util.container.btree.Implementation;
+
+    static assert (tree_degree > 0);
+
+    /**************************************************************************
+
+        Constructor.
+
+        Params:
+            allocator = memory manager to use to allocate/deallocate memory
+
+    ***************************************************************************/
+
+    package void initialize (IMemManager allocator = mallocMemManager)
+    {
+        this.impl.initialize(allocator);
+    }
+
+    // Disable constructor, so user always needs to use the makeBTreeMap method
+    version (D_Version2)
+    {
+        mixin("@disable this();");
+    }
+
+    /**************************************************************************
+
+        Inserts the (key, value) in the tree. This is passing the copy of the
+        value into the tree, so it's not necessary to manually create copy of
+        it.  Note that for the reference types, this will just copy the
+        reference.
+
+        Params:
+            key = key to insert
+            value = value associated to the key to insert.
+
+        Returns:
+            true if the element with the given key did not exist and it
+            was inserted, false otherwise
+
+        Complexity:
+            CPU: O(degree * log_degree(n))
+            Memory:O(log_degree(n))
+
+    ***************************************************************************/
+
+    public bool insert (KeyType key, ValueType value)
+    {
+        return this.impl.insert(key, value);
+    }
+
+    /******************************************************************************
+
+        Deletes the element from the BTreeMap.
+
+        Params:
+            key = key of the element to delete.
+
+        Returns:
+            true if the element was found and deleted, false otherwise.
+
+        Complexity:
+            CPU: O(degree * log_degree(n))
+            Memory:O(log_degree(n))
+
+     ******************************************************************************/
+
+    public bool remove (KeyType key)
+    {
+        return this.impl.remove(key);
+    }
+
+    /******************************************************************************
+
+        Searches the tree for the element with the given key and returns the
+        associated value.
+
+        Params:
+            key =  key to find in a tree.
+            found_element = indicator if the element with the given key has been
+                found in the map.
+
+        Returns:
+            copy of the value associated with the key, if found, ValueType.init
+            otherwise.
+
+        Complexity:
+            CPU: O(degree * log_degree(n))
+            Memory:O(log_degree(n))
+
+    *******************************************************************************/
+
+    public ValueType get (KeyType key, out bool found_element)
+    {
+        return this.impl.get(key, found_element);
+    }
+
+    /***********************************************************************
+
+        Recursive inorder iteration over keys and values. Note that, in case
+        the tree is changed during the iteration, iteration will halt.
+
+        Params:
+            dg = opApply's delegate
+
+        Returns:
+            return value of dg
+
+    ***********************************************************************/
+
+    public int opApply (int delegate (ref KeyType value, ref ValueType) dg)
+    {
+        return this.impl.inorder(dg);
+    }
+
+    /***********************************************************************
+
+        Recursive inorder iteration over values only. Note that, in case the
+        tree is changed during the iteration, iteration will halt.
+
+        Params:
+            dg = opApply's delegate
+
+        Returns:
+            return value of dg
+
+    ***********************************************************************/
+
+    public int opApply (int delegate (ref ValueType) dg)
+    {
+        return this.impl.inorder(dg);
+    }
+
+
+    /// Convenience alias for the implementation
+    package alias BTreeMapImplementation!(KeyType, ValueType, tree_degree)
+        Implementation;
+
+    /// Convenience alias for the key type
+    package alias TreeKeyType KeyType;
+
+    /// Convenience alias for the element type
+    package alias TreeValueType ValueType;
+
+    /// Private implementation
+    package Implementation impl;
+}
+
+/*******************************************************************************
+
+    Constructor-like method. Constructs the BTreeMap and initializes it.
+
+    Params:
+        KeyType = type of the key.
+        ValueType = type of the value to store.
+        tree_degree = degree of the tree (refer to the documentation)
+        memManager = memory management strategy to use
+
+    Returns:
+        empty BTreeMap which maps KeyType to ValueType of a given degree
+        which sues memManager allocation strategy.
+
+******************************************************************************/
+
+public BTreeMap!(KeyType, ValueType, tree_degree) makeBTreeMap
+    (KeyType, ValueType, int tree_degree)(IMemManager allocator = mallocMemManager)
+{
+    auto tree = BTreeMap!(KeyType, ValueType, tree_degree).init;
+    tree.initialize(allocator);
+    return tree;
+}
+
+version (UnitTest)
+{
+    import ocean.util.container.btree.BTreeMapRange;
+}
+
+///
+unittest
+{
+    // import ocean.util.container.btree.BTreeMapRange;
+    struct MyVal
+    {
+        int x;
+    }
+
+    auto map = makeBTreeMap!(int, MyVal, 2);
+
+    for (int i = 0; i <= 10; i++)
+    {
+        map.insert(i, MyVal(i*2));
+    }
+
+    // find the element by key
+    bool found;
+    auto val = map.get(5, found);
+    test!("==")(found, true);
+    test!("==")(val.x, 10);
+
+    // remove the element
+    map.remove(10);
+    map.get(10, found);
+    test!("==")(found, false);
+
+    // iterate over using opApply
+    foreach (key, val; map)
+    {
+        test!("==")(key * 2, val.x);
+    }
+
+    // iterate over using range
+    void[] buff;
+    for(auto range = byKeyValue(map, &buff);
+            !range.empty; range.popFront())
+    {
+        test!("==")(range.front.key * 2, range.front.value.x);
+    }
+
+    // Let's check that the memory is ready to be reused
+    test(buff.ptr !is null);
+}
+
+/*
+
+    Unittests. Compile with -debug=BTreeMapSanity to turn on
+    the invariant checks for the tree.
+
+*/
+
+version (UnitTest)
+{
+    import ocean.core.Test;
+}
+
+unittest
+{
+    BTreeMap!(int, File, 2) tree = makeBTreeMap!(int, File, 2);
+    bool found_element;
+
+    File f;
+
+    f.setName("5");
+    tree.insert(5, f);
+
+    f.setName("9");
+    tree.insert(9, f);
+
+    f.setName("3");
+    tree.insert(3, f);
+
+    f.setName("7");
+    tree.insert(7, f);
+
+    size_t index;
+    auto res = tree.get(7, found_element);
+
+    test!("==")(found_element, true);
+    test!("==")(res, f);
+
+    f.setName("1");
+    tree.insert(1, f);
+
+    f.setName("2");
+    tree.insert(2, f);
+
+    f.setName("8");
+    tree.insert(8, f);
+
+    f.setName("6");
+    tree.insert(6, f);
+
+    f.setName("0");
+    tree.insert(0, f);
+
+    f.setName("4");
+    tree.insert(4, f);
+}
+
+unittest
+{
+    bool found_element;
+    auto number_tree = makeBTreeMap!(int, int, 2);
+
+    for (int i = -1; i < 9; i++)
+    {
+        number_tree.insert(i, i);
+    }
+
+    // find "random" element
+    int i = 3;
+    auto xres = number_tree.get(i, found_element);
+    number_tree.remove(i);
+    number_tree.get(i, found_element);
+    test!("==")(found_element, false);
+
+    i = 7;
+    number_tree.remove(i);
+    number_tree.get(i, found_element);
+    test!("==")(found_element, false);
+
+    i = 9;
+    number_tree.remove(i);
+
+    i = 0;
+    number_tree.remove(i);
+
+    i = 1;
+    number_tree.remove(i);
+
+    i = 2;
+    number_tree.remove(i);
+
+    for (i = 0; i < 9; i++)
+    {
+        number_tree.remove(i);
+        number_tree.get(i, found_element);
+        test!("==")(found_element, false);
+    }
+
+    for (i = 0; i < 9; i++)
+    {
+        number_tree.insert(i, i);
+    }
+
+    for (i = 9; i > 0; i--)
+    {
+        number_tree.remove(i);
+        number_tree.get(i, found_element);
+        test!("==")(found_element, false);
+    }
+
+    i = 0;
+    number_tree.insert(i, i);
+    i = 1;
+    number_tree.insert(i, i);
+    i = 2;
+    number_tree.insert(i, i);
+
+    for (i = 0; i < 100000; i++)
+    {
+        number_tree.insert(i, i);
+    }
+
+    i = 0;
+    number_tree.remove(i);
+
+    i = 1;
+    number_tree.remove(i);
+
+    i = 2;
+    number_tree.remove(i);
+
+    for (i = 0; i < 100000; i++)
+    {
+        number_tree.remove(i);
+        number_tree.get(i, found_element);
+        test!("==")(found_element, false);
+    }
+
+    // remove reverse
+    for (i = 0; i < 100000; i++)
+    {
+        number_tree.insert(i, i);
+    }
+
+    for (i = 100000; i >= 0; i--)
+    {
+        number_tree.remove(i);
+        number_tree.get(i, found_element);
+        test!("==")(found_element, false);
+    }
+
+    // remove reverse from half
+    for (i = 0; i < 100000; i++)
+    {
+        number_tree.insert(i, i);
+    }
+
+
+    for (i = 5000; i >= 0; i--)
+    {
+        number_tree.remove(i);
+        number_tree.get(i, found_element);
+        test!("==")(found_element, false);
+    }
+
+
+    // random deletion
+    for (i = 0; i < 5000; i++)
+    {
+        number_tree.insert(i, i);
+    }
+
+    bool started;
+    int previous_value;
+    int counter;
+    foreach (value; number_tree)
+    {
+        counter++;
+
+        if (!started)
+        {
+            previous_value = value;
+            started = true;
+            continue;
+        }
+
+        test!("<")(previous_value, value);
+        previous_value = value;
+    }
+    test!("==")(counter, 100000);
+
+    foreach (key, value; number_tree)
+    {
+        test!("==")(key, value);
+    }
+
+    // Randomized tests
+
+    auto random = new Random();
+    int to_remove = 5864;
+    number_tree.remove(to_remove);
+    test(!number_tree.get(to_remove, found_element));
+
+    for (i = 0; i < 100000; i++)
+    {
+        to_remove = random.uniform!(int);
+        number_tree.remove(to_remove);
+        test(!number_tree.get(to_remove, found_element));
+    }
+}
+
+unittest
+{
+    class X
+    {
+        int x;
+
+        version (D_Version2)
+        {
+            mixin("immutable this () {}");
+        }
+    }
+
+    // Test immutable support
+    auto const_tree = makeBTreeMap!(void*, Const!(X), 2);
+
+    version (D_Version2)
+    {
+        mixin("Immut!(X) a = new immutable X;");
+    }
+    else
+    {
+        Immut!(X) a = new X;
+    }
+
+    const_tree.insert(cast(void*)&a, a);
+    bool found;
+    auto res = const_tree.get(cast(void*)&a, found);
+    test(found);
+    test(res == a);
+    test(const_tree.remove(cast(void*)&a));
+}
+
+version (UnitTest)
+{
+    import ocean.core.Test;
+    import ocean.core.Enforce;
+    import ocean.math.random.Random;
+
+    /// File structure - represents a directory or a file
+    /// For testing if the BTreeMap works with other value types
+    public struct File
+    {
+        /// Name of the directory/file
+        char[48] name_buf;
+        ubyte name_length;
+
+        cstring name () /* d1to2fix_inject: const */
+        {
+            return name_buf[0..name_length];
+        }
+
+        void setName (cstring name)
+        {
+            //logger.error("setting name: {}", name);
+            enforce (name.length <= ubyte.max);
+            this.name_length = cast(ubyte)name.length;
+            this.name_buf[0..this.name_length] = name[];
+        }
+   }
+}

--- a/src/ocean/util/container/btree/BTreeMapRange.d
+++ b/src/ocean/util/container/btree/BTreeMapRange.d
@@ -1,0 +1,409 @@
+/********************************************************************************
+
+    Range traversal support for BTreeMap.
+
+    Copyright:
+        Copyright (c) 2017 sociomantic labs GmbH. All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+        Alternatively, this file may be distributed under the terms of the Tango
+        3-Clause BSD License (see LICENSE_BSD.txt for details).
+
+*******************************************************************************/
+
+module ocean.util.container.btree.BTreeMapRange;
+
+import ocean.transition;
+import ocean.util.container.btree.BTreeMap;
+
+/*******************************************************************************
+
+    Exception thrown from the BTreeMapRange if a tree is modified during iteration.
+
+*******************************************************************************/
+
+class RangeInvalidatedException: Exception
+{
+    import ocean.core.Exception: DefaultExceptionCtor;
+    mixin DefaultExceptionCtor;
+}
+
+// shared between different ranges
+private RangeInvalidatedException range_exception;
+
+static this ()
+{
+    .range_exception = new RangeInvalidatedException(
+            "Container has been changed during iteration, please restart.");
+}
+
+/*******************************************************************************
+
+    Returns a range that performs an inorder iteration over the specified tree.
+
+    If tree has changed during the iteration, range will throw an
+    RangeInvalidatedException. In case user knows that the tree can be changed
+    any time, it is possible to call BTreeMapRange.isValid before performing any
+    action on the range to check if fetching the front element, or moving to
+    the next one is guaranteed to success. This is only true for the
+    single-threaded environment.
+
+    Params:
+        tree = tree to iterate over
+        buff = buffer for storing the state of the iteration. Useful
+               for the reusable-memory management strategy. The buffer size
+               is proportional to the height of the tree, so in most cases
+               it should be at most the size of the several pointers.
+               If the allocations are not a concern, null can passed for buff,
+               and range will allocate a buffer on its own.
+
+    Returns:
+        BTreeMapRange performing the full inorder iteration of the tree.
+
+*******************************************************************************/
+
+public BTreeMapRange!(BTreeMap) byKeyValue (BTreeMap) (ref BTreeMap tree, void[]* buff)
+{
+    if (buff is null)
+    {
+        // Struct wrapper is used to woraround D inability to allocate slice
+        // itself on heap via new
+        static struct Buffer
+        {
+            void[] data;
+        }
+
+        auto buf = new Buffer;
+        buff = &buf.data;
+    }
+    else
+    {
+        (*buff).length = 0;
+        enableStomping(*buff);
+    }
+
+    auto range = BTreeMapRange!(BTreeMap)(&tree.impl);
+    range.stack = cast(typeof(range.stack))buff;
+
+    range.start();
+    return range;
+}
+
+
+/*******************************************************************************
+
+    key/value pair. Akin to runtime's byKeyValue
+    NOTE: ideally, this should be optional. One might choose not to
+    care about keys at all. However, making this work without copying
+    entire code and without crashing dmd1 seems to be impossible.
+
+*******************************************************************************/
+
+private struct Pair(KeyType, ValueType)
+{
+    void* keyp;
+    void* valp;
+
+    KeyType key () { return *cast(KeyType*)keyp; }
+    ValueType value () { return *cast(ValueType*)valp; }
+}
+
+/*******************************************************************************
+
+    Structure representing an inorder range over a BTreeMap.
+
+    If tree has changed during the iteration, range will throw an
+    RangeInvalidatedException. If the user knows that the tree will not change
+    during the range traversal, it is safe to call range's methods - it will throw
+    an exception if this promise is broken. In case user knows that the tree
+    can be changed any time, it is possible to call BTreeMapRange.isValid before
+    performing any action on the range to check if the accessing is safe. This
+    is only true for the single-threaded environment.
+
+*******************************************************************************/
+
+public struct BTreeMapRange(BTreeMap)
+{
+    import ocean.core.Verify;
+    import ocean.core.array.Mutation;
+
+    /// (key, value) pair to return to the caller
+    alias Pair!(BTreeMap.KeyType, BTreeMap.ValueType) KeyValue;
+
+    /// Root node of a tree
+    private BTreeMap.Implementation* tree;
+
+
+    /// Copy of the content_version field of the tree at the time iteration began
+    private ulong tree_version;
+
+    /// Pair of the node/index for which we've paused iteration and pushed
+    /// to stack
+    private struct NodeElement
+    {
+        BTreeMap.Implementation.BTreeMapNode* node;
+        size_t index;
+
+        BTreeMap.ValueType* value ()
+        {
+            return &(node.elements[index].value);
+        }
+
+        BTreeMap.KeyType* key ()
+        {
+            return &(node.elements[index].key);
+        }
+    }
+
+    /// When IterationStep() moves from a node to iterate over its children,
+    /// the parent node is pushed to this stack, and popped upon completion
+    /// of traversal over the nodes.
+    private NodeElement[]* stack;
+
+    /// Next (node, element_index) pair we're should walk over
+    private NodeElement item;
+
+    /// Value of the current key to return with .front
+    private BTreeMap.KeyType* current_key;
+
+    /// Value of the current value to return with .front
+    private BTreeMap.ValueType* current_value;
+
+    invariant ()
+    {
+        verify(this.stack !is null);
+    }
+
+
+    /***************************************************************************
+
+        Returns:
+            the current element in the range.
+
+        Throws:
+           RangeInvalidatedException if the underlying tree has changed
+
+    ***************************************************************************/
+
+    public KeyValue front ()
+    {
+        this.enforceValid();
+        return Pair!(BTreeMap.KeyType, BTreeMap.ValueType)(this.current_key, this.current_value);
+    }
+
+    /***************************************************************************
+
+        Pops the next element from the tree.
+
+        Throws:
+           RangeInvalidatedException if the underlying tree has changed
+
+    ***************************************************************************/
+
+    public void popFront ()
+    {
+        this.enforceValid();
+        this.iterationStep();
+    }
+
+    /***************************************************************************
+
+        Returns:
+            true if there are no more elements to iterate over
+
+        Throws:
+           RangeInvalidatedException if the underlying tree has changed
+
+    ***************************************************************************/
+
+    public bool empty ()
+    {
+        this.enforceValid();
+        return this.tree.root is null ||
+            (this.item.node is null && this.stack.length == 0);
+    }
+
+    /***************************************************************************
+
+        Returns:
+            true if the underlying tree has not changed and it's safe
+            to use front/popFront/empty methods.
+
+    ***************************************************************************/
+
+    public bool isValid ()
+    {
+        return tree_version == this.tree.content_version;
+    }
+
+    /***************************************************************************
+
+        Ensures that a tree has not changed since the creation of this range.
+
+        Throws:
+           RangeInvalidatedException if the underlying tree has changed
+
+    ***************************************************************************/
+
+    private void enforceValid ()
+    {
+        if (!this.isValid())
+        {
+            throw .range_exception;
+        }
+    }
+
+    /***************************************************************************
+
+        Prepares the range over the tree.
+
+    ***************************************************************************/
+
+    private void start ()
+    {
+        if (this.tree.root !is null)
+        {
+            this.tree_version = this.tree.content_version;
+            this.item = NodeElement(this.tree.root, 0);
+            this.iterationStep();
+        }
+    }
+
+    /***************************************************************************
+
+        Goes to the next element in the tree.
+
+    ***************************************************************************/
+
+    private void iterationStep ()
+    {
+        while (true)
+        {
+            if (this.item.node.is_leaf)
+            {
+                // Leaf doesn't have subtrees, we can just iterate over it
+                if (this.item.index < this.item.node.number_of_elements)
+                {
+                    this.current_value = this.item.value;
+                    this.current_key = this.item.key;
+                    this.item.index++;
+                    return;
+                }
+            }
+            else
+            {
+                // do we have a subtree in the child_elements[index]?
+                if (this.item.index <= this.item.node.number_of_elements)
+                {
+                    *this.stack ~= NodeElement(this.item.node, this.item.index);
+                    this.item = NodeElement(item.node.child_nodes[this.item.index], 0);
+                    continue;
+                }
+            }
+
+            if ((*this.stack).pop(this.item) == false)
+            {
+                return;
+            }
+
+            // We got the item from the stack, and we should see if we
+            // have any more elements to call the delegate on it
+            if (this.item.index < this.item.node.number_of_elements)
+            {
+                this.current_value = this.item.value;
+                this.current_key = this.item.key;
+                this.item.index++;
+                return;
+            }
+            // There's no more elements, just skip to the next one
+            this.item.index++;
+        }
+    }
+}
+
+version (UnitTest)
+{
+    import ocean.math.random.Random;
+    import ocean.core.Test;
+}
+
+unittest
+{
+    // Build a random tree, and use the range over it
+    auto random = new Random();
+    bool found;
+    int res;
+
+    BTreeMap!(int, int, 3) random_tree = BTreeMap!(int, int, 3).init;
+    random_tree.initialize();
+
+    int removed_count;
+    int total_elements;
+    int to_insert = 10_000;
+    size_t my_index;
+
+    // create completely random tree and remove completely random values
+    for (int i = 0; i < to_insert; i++)
+    {
+        int element = random.uniformR(to_insert);
+        // don't count double elements (they are not inserted)
+        total_elements += random_tree.insert(element, element)? 1 : 0;
+        res = random_tree.get(element, found);
+        test(found);
+        test!("==")(res, element);
+    }
+
+    for (int i = 0; i < to_insert; i++)
+    {
+        int element = random.uniformR(to_insert);
+        removed_count += random_tree.remove(element)? 1 : 0;
+        res = random_tree.get(element, found);
+        test(!found);
+    }
+
+    void testRange(void[]* buffer_ptr)
+    {
+        bool started;
+        int previous_value;
+        int remaining_elements;
+
+        for (
+            auto range = byKeyValue(random_tree, buffer_ptr);
+            !range.empty; range.popFront())
+        {
+            if (!started)
+            {
+                previous_value = range.front.value;
+                started = true;
+                remaining_elements++;
+                continue;
+            }
+
+            // enforce that the order is preserved
+            test!(">")(range.front.value, previous_value);
+            previous_value = range.front.value;
+            test!("==")(range.front.value, range.front.key);
+            remaining_elements++;
+        }
+
+        test!("==")(total_elements - remaining_elements, removed_count);
+    }
+
+    void[] buff;
+    testRange(&buff);
+    testRange(null);
+
+    // test invalidation
+    auto range = byKeyValue(random_tree, &buff);
+    auto first = range.front;
+
+    bool insert_res;
+    do
+    {
+        auto val = random.uniformR(2 * to_insert);
+        insert_res = random_tree.insert(val, val);
+    }
+    while (!insert_res);
+    testThrown!(RangeInvalidatedException)(range.popFront());
+}

--- a/src/ocean/util/container/btree/Implementation.d
+++ b/src/ocean/util/container/btree/Implementation.d
@@ -1,0 +1,1196 @@
+/********************************************************************************
+
+    Internal (non-user facing) implementation of BTreeMap.
+
+    Copyright:
+        Copyright (c) 2017 sociomantic labs GmbH. All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+        Alternatively, this file may be distributed under the terms of the Tango
+        3-Clause BSD License (see LICENSE_BSD.txt for details).
+
+*******************************************************************************/
+
+module ocean.util.container.btree.Implementation;
+
+import ocean.transition;
+
+/*******************************************************************************
+
+    Internal (non-user facing) implementation of BTreeMap.
+
+    Params:
+        KeyType = type of the key
+        ValueType = type of the value
+        tree_degree = degree of the tree.
+
+*******************************************************************************/
+
+package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
+{
+    import ocean.core.array.Mutation;
+    import ocean.core.array.Search;
+    import ocean.core.Enforce;
+    import ocean.core.Traits;
+    import ocean.core.Verify;
+    import ocean.util.container.mem.MemManager;
+
+    /**************************************************************************
+
+        Node of the tree. Contains at most (degree * 2 - 1) elements and
+        (degree * 2) subtrees.
+
+    **************************************************************************/
+
+    package struct BTreeMapNode
+    {
+        /**********************************************************************
+
+            KeyValue structure which binds key and a value to be stored in the
+            node.
+
+            NOTE: In addition of ordering notion, this is really the only thing
+            that makes this an implementation of the map, not of the set. If we're
+            going to add set support, we should probably do it via templating
+            this implementation on the actual content of the node's element
+            (replace KeyValue with just a value) and with the ordering operation
+            inserted as a policy (to compare the values, and not the nodes).
+
+        ***********************************************************************/
+
+        private struct KeyValue
+        {
+            KeyType key;
+            // Storing the unqual ValueType here, as we need to reorder
+            // the elements in the node without creating new nodes. User
+            // facing API never sees unqualed type.
+            Unqual!(ValueType) value;
+        }
+
+        /// Number of the elements currently in the node
+        int number_of_elements;
+
+        /// Indicator if the given node is a leaf
+        bool is_leaf;
+
+        /// Array of the elements
+        package KeyValue[tree_degree * 2 - 1] elements;
+
+        /// Array of the pointers to the subtrees
+        package BTreeMapNode*[tree_degree * 2] child_nodes;
+    }
+
+    /**************************************************************************
+
+        Root of the tree.
+
+    ***************************************************************************/
+
+    package BTreeMapNode* root;
+
+    /***************************************************************************
+
+        Type of the element actually stored in the node. The type stored in the
+        node is unqualed version of the type that's accessible to the user, since
+        the container needs to change the content of the actual array, without
+        a need to always allocate a new one.
+
+    ***************************************************************************/
+
+    private alias typeof(BTreeMapNode.elements[0].value) StoredValueType;
+
+    /***************************************************************************
+
+        Convenience constant describing the tree's degree.
+
+    ***************************************************************************/
+
+    private const degree = tree_degree;
+
+    /***************************************************************************
+
+        Memory manager used for allocating and deallocating memory. Refer to
+        ocean.util.container.mem.MemManager for potential options.
+
+    ***************************************************************************/
+
+    package IMemManager allocator;
+
+
+    /***************************************************************************
+
+        "version" of the tree's state. Will be incremented on any removal/adding
+        the element. On the iteration's start, range will record the current 
+        "version" of the tree, and, and before proceeding with the iteration,
+        it will check if any changes were performed on the tree, to prevent
+        iteration over an undefined region.
+
+     ***************************************************************************/
+
+    package ulong content_version;
+
+    /***************************************************************************
+
+        Constructor-like method (as a workaround of a fact that D1 doesn't provide
+        struct constructors).
+
+        Params:
+            allocator = memory manager to use to allocate/deallocate memory
+
+    ***************************************************************************/
+
+    package void initialize (IMemManager allocator = mallocMemManager)
+    {
+        verify (this.allocator is null);
+        this.allocator = allocator;
+    }
+
+
+    /**************************************************************************
+
+        Inserts the element in the tree.
+
+        Params:
+            key = key to insert
+            value = associated value to insert.
+
+        Returns:
+            true if the element with the given key did not exist and it
+            was inserted, false otherwise
+
+    ***************************************************************************/
+
+    package bool insert (KeyType key, ValueType el)
+    {
+        verify(this.allocator !is null);
+
+        if (this.root is null)
+        {
+            this.root = this.insertNewNode();
+        }
+
+        size_t dummy_index;
+        if (this.get(key, dummy_index))
+        {
+            return false;
+        }
+
+        // unqualed for internal storage only. User will never access it as
+        // unqualed reference.
+        auto unqualed_el = cast(Unqual!(ValueType))el;
+        auto r = this.root;
+        if (this.root.number_of_elements == this.root.elements.length)
+        {
+            auto node = this.insertNewNode();
+            // this is a new root
+            this.root = node;
+            node.is_leaf = false;
+            node.number_of_elements = 0;
+
+            // Old root node is the first child
+            node.child_nodes[0] = r;
+
+            this.splitChild(node, 0, r);
+            auto ret = this.insertNonFull(node, key, unqualed_el);
+            debug (BTreeMapSanity) check_invariants(*this);
+            if (ret)
+                this.content_version++;
+            return ret;
+        }
+        else
+        {
+            auto ret = this.insertNonFull(this.root, key, unqualed_el);
+            debug (BTreeMapSanity) check_invariants(*this);
+            if (ret)
+                this.content_version++;
+            return ret;
+        }
+    }
+
+    /******************************************************************************
+
+        Removes the element with the given key from the BTreeMap.
+
+        Params:
+            key = key associated with the element to delete.
+
+        Returns:
+            true if the element with the given key was found and deleted,
+            false otherwise.
+
+     ******************************************************************************/
+
+    package bool remove (KeyType key)
+    {
+        verify(this.allocator !is null);
+
+        BTreeMapNode* parent = null;
+
+        bool rebalance_parent;
+        auto res = this.deleteFromNode(this.root,
+                parent, key, rebalance_parent);
+
+        // can't rebalance the root node here, as they should all be
+        // rebalanced internally by deleteFromNode
+        verify(rebalance_parent == false);
+
+        debug (BTreeMapSanity) check_invariants(*this);
+
+        if (res)
+            this.content_version++;
+
+        return res;
+    }
+
+    /***************************************************************************
+
+        Returns:
+            true if the tree is empty, false otherwise.
+
+    ***************************************************************************/
+
+    package bool empty ()
+    {
+        return this.root is null;
+    }
+
+    /******************************************************************************
+
+        Searches the tree for the element with the given key and returns its
+        value if found.
+
+        Params:
+            key = key to find in the tree.
+            found = indicator if the element was found
+
+        Returns:
+            value associated with the key, or ValueType.init if not found.
+
+    *******************************************************************************/
+
+    package ValueType get (KeyType key, out bool found_element)
+    {
+        size_t index;
+        auto node = this.get(key, index);
+        if (!node) return ValueType.init;
+
+        found_element = true;
+        return node.elements[index].value;
+    }
+
+    // implementation
+
+    /***************************************************************************
+
+        Finds the requested element in the tree.
+
+        Params:
+          key = key associated with the element to return
+          index = out parameter, holding the index of the element in the node
+
+        Returns:
+            pointer to the node holding `element`, null otherwise
+
+    ***************************************************************************/
+
+    private BTreeMapNode* get (KeyType key,
+        out size_t index)
+    {
+        /// internal function for recursion
+        /// which does the actual search (outer function just accepts the tree)
+        static BTreeMapNode* getImpl (BTreeMapNode* root,
+            KeyType key, out size_t index)
+        {
+            auto pos = 0;
+
+            // TODO: binary search
+            while (pos < root.number_of_elements
+                && key > root.elements[pos].key)
+            {
+                pos++;
+            }
+
+            // now pos is the least index in the key array such
+            // that f < elements[pos]
+            if (pos < root.number_of_elements
+                && key == root.elements[pos].key)
+            {
+                index = pos;
+                return root;
+            }
+
+            // Nowhere to descend
+            if (root.is_leaf)
+            {
+                return null;
+            }
+
+            return getImpl(root.child_nodes[pos], key, index);
+        }
+
+        if (this.root is null)
+        {
+            return null;
+        }
+
+        return getImpl(this.root, key, index);
+    }
+
+    /******************************************************************************
+
+        Does the necessary traversal to delete an element and rebalance parents
+        in the process.
+
+        Params:
+            node = node currently being inspected for the removal (as we go down
+                     the tree, this parameter is being updated).
+            parent = parent of the node (needed when merging the neighbour nodes)
+            to_delete = key of the element to remove
+            rebalance_parent = indicator if while traversing back to the root, the
+                               parent node should be rebalanced
+
+         Returns: true if the current node needs to be rebalanced
+
+    ******************************************************************************/
+
+    private bool deleteFromNode ( BTreeMapNode* node, BTreeMapNode* parent,
+        KeyType to_delete, out bool rebalance_parent)
+    {
+        // does this node contain the element we want to delete? Or is it one of it's children?
+        foreach (i, ref element; node.elements[0..node.number_of_elements])
+        {
+            if (element.key > to_delete)
+            {
+                // not found if it's the leaf
+                if (node.is_leaf)
+                    return false;
+
+                auto delete_result = deleteFromNode(node.child_nodes[i],
+                                                    node, to_delete, rebalance_parent);
+                if (rebalance_parent)
+                {
+                    this.rebalanceAfterDeletion(node, parent, rebalance_parent);
+                }
+
+                return delete_result;
+            }
+            else if (element.key == to_delete)
+            {
+                auto element_index = i;
+                if (node.is_leaf)
+                {
+                    deleteFromLeaf(node, i);
+                    this.rebalanceAfterDeletion(node, parent, rebalance_parent);
+
+                    return true;
+                }
+                else
+                {
+                    // if we have the element in the internal node, then
+                    // the highest element in the left subtree is still
+                    // smaller than this element, so this element could just
+                    // be replaced with it, and then that element in the
+                    // left subtree should be removed.
+                    auto victim_node = node.child_nodes[element_index];
+
+                    // find the highest element:
+                    size_t highest_index;
+                    auto highest_node = findMaximum(victim_node, highest_index);
+                    auto highest_element = &highest_node.elements[highest_index];
+                    node.elements[element_index] = *highest_element;
+
+                    auto delete_result = deleteFromNode(victim_node,
+                                            node, highest_element.key, rebalance_parent);
+
+                    // The deletion of the element in the internal node is very simple:
+                    // we need to find the largest element in the left subtree, put it
+                    // instead of the element we want to delete, remove it from the subtree
+                    // and rebalance the tree starting from that node.
+                    if (rebalance_parent)
+                    {
+                        this.rebalanceAfterDeletion(node, parent, rebalance_parent);
+                    }
+                    return delete_result;
+                }
+            }
+        }
+
+        // no left subtree was found that it could contain this key.
+        // we need to check only for the most-right subtree. If it doesn't
+        // exists, there's no such key
+        if (node.is_leaf)
+        {
+            return false;
+        }
+        else
+        {
+            auto delete_result = deleteFromNode(node.child_nodes[node.number_of_elements],
+                                                 node, to_delete, rebalance_parent);
+
+            if (rebalance_parent)
+
+            {
+                this.rebalanceAfterDeletion(node, parent, rebalance_parent);
+            }
+
+            return delete_result;
+        }
+    }
+
+    /******************************************************************************
+
+        Allocates and initializes new node.
+
+    *******************************************************************************/
+
+    private BTreeMapNode* insertNewNode()
+    {
+        auto node = cast(BTreeMapNode*)this.allocator.create(BTreeMapNode.sizeof).ptr;
+        *node = BTreeMapNode.init;
+
+        node.is_leaf = true;
+        node.number_of_elements = 0;
+        return node;
+    }
+
+    /**************************************************************************
+
+        Insert the element into the non-full node. If the node is leaf and not
+        full, then no spliting will be done, the element will simply be inserted
+        into it.
+
+        If the target node is non-leaf node, we also know that even if the
+        child node is split, there will be bplace to split it.
+
+        Params:
+            node = non-full node to insert the element into
+            key = key to insert
+            value = value to insert
+
+        Returns:
+            true if the element was inserted, false otherwise.
+
+    ***************************************************************************/
+
+    private bool insertNonFull
+        (BTreeMapNode* node, KeyType key, StoredValueType value)
+    {
+        if (node.is_leaf)
+        {
+            return insertIntoLeaf(node, key, value);
+        }
+        else
+        {
+            int i = node.number_of_elements - 1;
+
+            // find the child where new key belongs:
+            while (i >= 0 && key < node.elements[i].key)
+                i--;
+
+            // if the file should be in children[i], then f < elements[i]
+            // Well go back to the last key where we found this to be true,
+            // and get that child node
+            i++;
+
+            if (node.child_nodes[i].number_of_elements == node.child_nodes[i].elements.length)
+            {
+                splitChild(node, i, node.child_nodes[i]);
+
+                // now children[i] and children[i+] are the new
+                // children, and the elements[i] might been changed (we got it from the
+                // split child)
+                // we'll see if k belongs in the first or the second
+                if (key > node.elements[i].key)
+                    i++;
+            }
+
+            // call ourself recursively to do the insertion
+            return insertNonFull(node.child_nodes[i], key, value);
+        }
+    }
+
+    /**************************************************************************
+
+        Splits the full child, so it can accept the new element.
+
+        New node is allocated and it gets the half of the elements from the
+        previous node, and the median element from the old node is moved into
+        the parent, separating these two child nodes.
+
+        Params:
+            parent = parent node
+            child_index = index of the subtree in the parent
+            child = the root of the subtree
+
+    ***************************************************************************/
+
+    private void splitChild (BTreeMapNode* parent,
+        int child_index,
+        BTreeMapNode* child)
+    {
+        auto new_node = this.insertNewNode();
+        // new node is a leaf if old node was
+        new_node.is_leaf = child.is_leaf;
+        moveElementsAt(new_node, 0, child, degree);
+
+        // Now put the median element in the parent, and insert the new
+        // node in the parent
+        shiftElements(parent, child_index, 1);
+        parent.elements[child_index] = child.elements[degree-1];
+        parent.child_nodes[child_index+1] = new_node;
+        child.number_of_elements--;
+    }
+
+    /***************************************************************************
+
+
+        Rebalances the tree after removal of the element.
+        Makes sure that the tree is still holding the invariants.
+
+        Params:
+            node = node from where the element was removed
+            parent = parent of the node.
+            rebalance_parent = indicator if the parent is now due to rebalancing.
+
+    ***************************************************************************/
+
+    private void rebalanceAfterDeletion (
+        BTreeMapNode* node, BTreeMapNode* parent, out bool rebalance_parent)
+    {
+        // check for the underflow. If the node now contains
+        // less than `degree-1` entries, we need to borrow the
+        // element from the neighbouring nodes
+        // note that the root is the only node which is allowed to have
+        // more than a minimum elements, so we will never rebalance it
+        if (node != this.root && node.number_of_elements < this.degree - 1)
+        {
+            long position_in_parent = -1;
+
+            for (auto i = 0; i < parent.number_of_elements + 1; i++)
+            {
+                if (parent.child_nodes[i] == node)
+                {
+                    position_in_parent = i;
+                    break;
+                }
+            }
+
+            verify (position_in_parent >= 0);
+
+            // case 1 - the neighbouring node contains more than
+            // (2 * degree - 1) - can't have less because of the invariant
+            // - in which case we join the node into the new one,
+            // and split it into the two, where the median element
+            // goes into the parent node.
+            if (parent.number_of_elements > position_in_parent)
+            {
+                auto next_neighbour =
+                    parent.child_nodes[position_in_parent+1];
+
+                // Now, either this exists or not, and if it exists,
+                // it has the spare elements, or it does't (in which case
+                // it's merged with the parent
+
+                if (next_neighbour && next_neighbour.number_of_elements > this.degree -1)
+                {
+                    // copy the separator from the parent node
+                    // into the deficient node
+                    node.elements[node.number_of_elements] = parent.elements[position_in_parent];
+                    node.number_of_elements++;
+                    node.child_nodes[node.number_of_elements] = next_neighbour.child_nodes[0];
+
+                    // replace the separator in the parent with the first
+                    // element of the right sibling
+                   parent.elements[position_in_parent] = popFromNode(next_neighbour, 0);
+
+                    return;
+                }
+            }
+
+            // let's try with the left sibling
+            if (position_in_parent > 0)
+            {
+                // do the same thing but with the left sibling
+                auto previous_neighbour =
+                    parent.child_nodes[position_in_parent-1];
+
+                // Now, either this exists or not, and if it exists,
+                // it has the spare elements, or it does't (in which case
+                // it's merged with the parent
+
+                if (previous_neighbour.number_of_elements > this.degree -1)
+                {
+                    shiftElements(node, 0, 1);
+                    // copy the separator from the parent node
+                    // into the deficient node
+                    //
+                    node.elements[0] = parent.elements[position_in_parent-1];
+
+                    // replace the separator in the parent with the last
+                    // element of the left sibling
+                    parent.elements[position_in_parent-1] =
+                        previous_neighbour.elements[previous_neighbour.number_of_elements-1];
+
+                    // and move the top-right child of the left neighbourhood as the first
+                    // child of the new one
+                    node.child_nodes[0] = previous_neighbour.child_nodes[previous_neighbour.number_of_elements];
+
+                    previous_neighbour.number_of_elements--;
+                    return;
+                }
+            }
+
+            // both immediate siblings have the only the minimum
+            // number of elements. Merge with a sibling then.
+            // this merging causes the parent to loose the element
+            // (because there will be no need for separating) two nodes,
+            // so we need to rebalance it with the neighbouring nodes
+
+            // Node that will accept everything afer the merge
+            BTreeMapNode* remaining_node;
+
+            // The edge cases are top-left or top-right nodes
+            // Note: Although these two cases are very same,
+            // it's easier to follow them if the code is slightly duplicated
+            if (position_in_parent < parent.number_of_elements)
+            {
+                auto next_neighbour =
+                    parent.child_nodes[position_in_parent+1];
+
+                node.elements[node.number_of_elements] = popFromNode(parent, position_in_parent);
+                node.number_of_elements++;
+
+                // parent.pop removed the node from it's list, put it now there
+                parent.child_nodes[position_in_parent] = node;
+
+                moveElementsAt(node,
+                    node.number_of_elements, next_neighbour, 0);
+
+                remaining_node = node;
+
+                this.allocator.destroy(cast(ubyte[])(next_neighbour[0..1]));
+            }
+            else
+            {
+                auto previous_neighbour =
+                    parent.child_nodes[position_in_parent-1];
+
+                previous_neighbour.elements[previous_neighbour.number_of_elements] = popFromNode(parent, position_in_parent-1);
+                previous_neighbour.number_of_elements++;
+
+                // parent.pop removed the node from it's list, put it now there
+                parent.child_nodes[position_in_parent-1] = previous_neighbour;
+
+                moveElementsAt(previous_neighbour,
+                    previous_neighbour.number_of_elements, node, 0);
+
+                remaining_node = previous_neighbour;
+
+                this.allocator.destroy(cast(ubyte[])((node)[0..1]));
+            }
+
+            // TODO: comment this
+            if (parent == this.root && parent.number_of_elements == 0)
+            {
+                this.allocator.destroy(cast(ubyte[])(parent[0..1]));
+                this.root = remaining_node;
+                return;
+            }
+            else if (parent != this.root && parent.number_of_elements < this.degree - 1)
+            {
+                rebalance_parent = true;
+                return;
+            }
+            else
+            {
+                // either is root, or it has enough elements
+                return;
+            }
+
+            assert(false);
+        }
+        // else - nothing to rebalance, node from which we've removed
+        // the element still has the right amount of the elements
+    }
+
+    /***************************************************************************
+
+        Inserts the element into the leaf.
+
+        The simpliest version of the insertion - it just moves the elements
+        to create space for the new one and inserts it.
+
+        Params:
+            node = leaf node to insert the element into
+            key = key to insert
+            value = value to insert
+
+    ***************************************************************************/
+
+    private static bool insertIntoLeaf(BTreeMapNode* node, KeyType key,
+            StoredValueType value)
+    {
+        verify(node.is_leaf);
+
+        // shift all elements to make space for it
+        auto i = node.number_of_elements;
+
+        // shift everything over to the "right", up to the
+        // point where the new element should go
+        for (; i > 0 && key < node.elements[i-1].key; i--)
+        {
+            node.elements[i] = node.elements[i-1];
+        }
+
+        node.elements[i].key = key;
+        node.elements[i].value = value;
+        node.number_of_elements++;
+
+        return true;
+    }
+
+    /***************************************************************************
+
+        Removes the element from the leaf.
+
+        The simpliest version of the removal - it just removes the element
+        by moving all the elements next to it by one step.
+
+        Params:
+            node = pointer to the leaf node to remove the element from.
+            element_index = index of the element in the node to remove.
+
+    ***************************************************************************/
+
+    private static void deleteFromLeaf(BTreeMapNode* node, size_t element_index)
+    {
+        verify(node.is_leaf);
+
+        // deletion from the leaf is easy - just remove it
+        // and shift all the ones left
+        foreach (j, ref el; node.elements[element_index..node.number_of_elements-1])
+        {
+            el = node.elements[element_index + j + 1];
+        }
+
+        node.number_of_elements--;
+    }
+
+    /***************************************************************************
+
+        Shifts the element and subtree pointers inside a node starting from
+        `position` by `count`.
+
+        Params:
+            node = node to edit.
+            position = position to start shifting on
+            count = count of the shifts to perform.;
+
+    ***************************************************************************/
+
+    private static void shiftElements (BTreeMapNode* node, int position, int count)
+    {
+        for (auto i = node.number_of_elements+count; i > position; i--)
+        {
+            node.child_nodes[i] = node.child_nodes[i-count];
+        }
+
+        for (auto i = node.number_of_elements+count-1; i > position; i--)
+        {
+            node.elements[i] = node.elements[i-count];
+        }
+
+        node.number_of_elements += count;
+    }
+
+    /***************************************************************************
+
+        Moves the elements from one node to another.
+
+        In case we need to merge/split the nodes, we need to move the elements
+        and their subtrees to the new node. Remember that each element in the
+        node is dividing the subtrees to the one less than it is and the other
+        that's higher than it, so simply moving elements is not possible.
+
+        Params:
+            dest = destination node
+            destination_start = first index in the dest. node to copy to
+            source = source node
+            source_start = first index in the source node to copy from.
+
+    ***************************************************************************/
+
+    private static void moveElementsAt (BTreeMapNode* dest, int destination_start,
+        BTreeMapNode* source, int source_start)
+    {
+        int end = source.number_of_elements;
+        verify(source.number_of_elements >= end - source_start);
+
+        auto old_number = dest.number_of_elements;
+        dest.number_of_elements += end - source_start;
+
+        // Move the elements from the source to this
+        foreach (i, ref el; dest.elements[old_number..dest.number_of_elements])
+        {
+            el = source.elements[source_start + i];
+        }
+
+        if (!dest.is_leaf)
+        {
+            // TODO: assert (!souce.is_leaf)
+            foreach (i, ref child_node;
+                    dest.child_nodes[old_number..dest.number_of_elements+1])
+            {
+                child_node = source.child_nodes[source_start + i];
+            }
+        }
+
+        source.number_of_elements = source_start;
+    }
+
+    /***************************************************************************
+
+        Removes the element from the node. This removes the element from the node
+        and reorganizes the subtrees.
+
+        Params:
+            node = node to remove from
+            position = position of the element to remove.
+
+        Returns:
+            the removed element.
+
+    ***************************************************************************/
+
+    private static BTreeMapNode.KeyValue popFromNode (BTreeMapNode* node, size_t position)
+    {
+        auto element = node.elements[position];
+
+        // rotate the next neighbour elements
+        for (auto i = position; i < node.number_of_elements-1; i++)
+        {
+            node.elements[i] = node.elements[i+1];
+        }
+
+        if (!node.is_leaf)
+        {
+            for (auto i = position; i < node.number_of_elements; i++)
+            {
+                node.child_nodes[i] = node.child_nodes[i+1];
+            }
+        }
+
+        node.number_of_elements--;
+        return element;
+    }
+
+    /******************************************************************************
+
+        Finds the maxima in the subtree.
+
+        Params:
+            node = root of the (sub)tree
+            index = element index in the node.
+
+        Returns:
+            pointer to the node containing the maximum element
+
+    ******************************************************************************/
+
+    private static BTreeMapNode* findMaximum (BTreeMapNode* node,
+        out size_t index)
+    {
+        if (node.is_leaf)
+        {
+            index = node.number_of_elements - 1;
+            return node;
+        }
+        else
+        {
+            return findMaximum(node.child_nodes[node.number_of_elements], index);
+        }
+    }
+
+    /******************************************************************************
+
+        Visits the tree in the inorder order.
+
+        Params:
+            tree = tree to visit
+            dg = delegate to call for each visited element. Delegate should return
+                 non-zero value if the visiting should be aborted.
+
+        Returns:
+            return value of the last dg call.
+
+    ******************************************************************************/
+
+    package int inorder (int delegate(ref KeyType key, ref ValueType value) dg)
+    {
+        if (this.root is null)
+        {
+            return 0;
+        }
+
+        return inorderImpl(this.content_version, *this.root, dg);
+    }
+
+    /******************************************************************************
+
+        Visits the tree in the inorder order.
+
+        Params:
+            tree = tree to visit
+            dg = delegate to call for each visited element. Delegate should return
+                 non-zero value if the visiting should be aborted.
+
+        Returns:
+            return value of the last dg call.
+
+    ******************************************************************************/
+
+    package int inorder (int delegate(ref ValueType value) dg)
+    {
+        if (this.root is null)
+        {
+            return 0;
+        }
+
+        return inorderImpl(this.content_version, *this.root, dg);
+    }
+
+    /***************************************************************************
+
+        Traverses the BTreeMap in the inorder, starting from the root.
+
+        Params:
+            version = "version" of the tree at the time of starting the visit
+            root = root of a (sub)tree to visit
+            dg = delegate to call with the key/value
+
+        Returns:
+            return value of the delegate dg
+
+    ***************************************************************************/
+
+    private int inorderImpl (UserDg)(ulong start_version, ref BTreeMapNode root,
+                UserDg dg)
+        {
+            for (int i = 0; i < root.number_of_elements; i++)
+            {
+                int res;
+                if (!root.is_leaf)
+                {
+                    res = inorderImpl(start_version, *root.child_nodes[i], dg);
+                    if (res) return res;
+                }
+
+                static if (is(ReturnAndArgumentTypesOf!(UserDg) ==
+                            Tuple!(int, ValueType)))
+                {
+                    res = dg (root.elements[i].value);
+                }
+                else static if (is(ReturnAndArgumentTypesOf!(UserDg) ==
+                            Tuple!(int, KeyType, ValueType)))
+                {
+                    res = dg (root.elements[i].key, root.elements[i].value);
+                }
+                else
+                {
+                    static assert(false);
+                }
+
+                // check if the tree is valid
+                if (start_version != this.content_version) return 1;
+
+                if (res)
+                    return res;
+            }
+
+            if (!root.is_leaf)
+            {
+                auto res = inorderImpl(start_version,
+                       *root.child_nodes[root.number_of_elements], dg);
+                if (res)
+                    return res;
+            }
+
+            return 0;
+        }
+}
+
+/// Checks if all invariants of the tree are still valid
+debug (BTreeMapSanity)
+{
+    /// Confirms if the invariants of btree stands:
+    /// 1. All leaves have the same height - h
+    /// 2. Every node other than the root must have at least degree - 1
+    ///    keys. If the tree is nonempty, the root must have at least one
+    ///    key.
+    /// 3. Every node may contain at most 2degree - 1 keys - enforced through
+    ///    the array range exception
+    /// 4. The root must have at least two keys if it's not a leaf.
+    /// 5. The elements stored in a given subtree all have keys that are
+    ///    between the keys in the parent node on either side of the subtree
+    ///    pointer.
+
+    void check_invariants(BTreeMap)(ref BTreeMap tree)
+    {
+        verify(tree.root.is_leaf || tree.root.number_of_elements >= 1);
+
+        /// Traverses the BTreeMap in the inorder, starting from root,
+        /// and returns the btree's node.
+        static void traverse (BTreeMap.BTreeMapNode* root, ref int current_height,
+                            void delegate(BTreeMap.BTreeMapNode* b, int current_height) dg)
+        {
+            for (int i = 0; i < root.number_of_elements; i++)
+            {
+                if (!root.is_leaf)
+                {
+                    current_height += 1;
+                    traverse(root.child_nodes[i], current_height, dg);
+                    current_height -= 1;
+                }
+            }
+
+            dg (root, current_height);
+        }
+
+        int tree_height = -1;
+        int current_height;
+
+        // traverse the tree and inspect other invariants
+        traverse(tree.root, current_height,
+            (BTreeMap.BTreeMapNode* node, int height)
+            {
+                if (node.is_leaf)
+                {
+                    // all leaves must have the same level
+                    if (tree_height == -1)
+                    {
+                        tree_height = height;
+                    }
+                    verify(tree_height == height);
+                }
+                else
+                {
+                    // every node must have at least degree - 1 keys
+                    if (node != tree.root)
+                    {
+                        verify(node.number_of_elements >= tree.degree - 1);
+                    }
+
+                    // and if we get into each one of them, we will not find keys
+                    // equal or larger/smaller (depending on the side) of the keys
+                    for (int i = 0; i < node.number_of_elements; i++)
+                    {
+                        auto current_value = &node.elements[i];
+
+                        // let's traverse into each the left one and assert they are
+                        // all smaller
+                        int dummy;
+
+                        traverse(node.child_nodes[i], dummy, (BTreeMap.BTreeMapNode* b, int height){
+                            for (int j = 0; j < b.number_of_elements; j++)
+                            {
+                                verify(b.elements[j] < *current_value);
+                            }
+                        });
+
+                        // and traverse to the right subtree and inspect it
+                        traverse(node.child_nodes[i+1], dummy, (BTreeMap.BTreeMapNode* b, int height){
+                            for (int j = 0; j < b.number_of_elements; j++)
+                            {
+                                verify(b.elements[j] > *current_value);
+                            }
+                        });
+                    }
+                }
+            });
+    }
+}
+
+unittest
+{
+    foreach (allocator; [mallocMemManager, gcMemManager])
+    {
+        testRandomTree(allocator);
+    }
+}
+
+version (UnitTest)
+{
+    import ocean.util.container.mem.MemManager;
+    import ocean.math.random.Random;
+    import ocean.core.Test;
+    import ocean.core.Tuple;
+
+    // Workaround for the D1 issue where we can't have the
+    // delegate used in the static foreach
+    private void testRandomTree(IMemManager allocator)
+    {
+        auto random = new Random();
+        bool found;
+
+        for (int count = 0; count < 5; count++)
+        {
+            auto random_tree = BTreeMapImplementation!(int, int, 3).init;
+            random_tree.initialize(allocator);
+
+            int removed_count;
+            int remaining_elements;
+            int total_elements;
+            int to_insert = 10_000;
+            size_t my_index;
+
+            // create completely random tree and remove completely random values
+            for (int i = 0; i < to_insert; i++)
+            {
+                int element = random.uniformR(to_insert);
+                // don't count double elements (they are not inserted)
+                total_elements += random_tree.insert(element, element)? 1 : 0;
+                auto res = random_tree.get(element, found);
+                test(found);
+                test!("==")(res, element);
+            }
+
+            // reseed, so that the difference two random number generated sets
+            // is not zero
+
+            for (int i = 0; i < to_insert; i++)
+            {
+                int element = random.uniformR(to_insert);
+                removed_count += random_tree.remove(element)? 1 : 0;
+                test(random_tree.get(element, found) == int.init && !found);
+            }
+
+            int previous_value;
+            bool started;
+
+            random_tree.inorder((ref int value)
+            {
+                if (!started)
+                {
+                    previous_value = value;
+                    started = true;
+                    remaining_elements++;
+                    return 0;
+                }
+
+                // enforce that the order is preserved
+                test!(">")(value, previous_value);
+                previous_value = value;
+                remaining_elements++;
+                return 0;
+            });
+
+            test!("==")(total_elements - remaining_elements, removed_count);
+
+            // Test the iterative version
+            started = false;
+            previous_value = previous_value.init;
+            remaining_elements = 0;
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces BTree data structure and algorithms over it to the ocean. This implementation of a BTree is templated on the type it carries, on the tree's degree, and on the allocation policy that should be used for the allocating the internal nodes (it is useful if the extending the BTree is done once in a while, but when we shouldn't give chance to GC to do mark&sweep). Additionally, GC tracking of the memory can be turned of, so the GC will not (somewhat expensively) traverse the tree, which is useful if we're storing value types, or the reference types for which we're storing the reference somewhere else.  In addition to basic functionality, inorder traversal of the tree, either via opApply or InputRange is supported.


