### PR TITLE
Remove lst files in make clean, no matter if they are hidden

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -18,7 +18,7 @@ COVFLAG:=
 endif
 
 # Remove coverage files
-clean += *.lst
+clean += .*.lst
 
 # Remove deprecated modules from testing:
 TEST_FILTER_OUT += \


### PR DESCRIPTION
*.lst files generated by the compiler are hidden and simple `rm *.lst`
will not remove them. `rm .*.lst` will.