### PR TITLE
Remove redundant scope around enforce

### DIFF
--- a/src/ocean/task/util/StreamProcessor.d
+++ b/src/ocean/task/util/StreamProcessor.d
@@ -169,32 +169,27 @@ class StreamProcessor ( TaskT : Task )
 
         if (throttler_config.suspend_point == size_t.max)
             throttler_config.suspend_point = total / 3 * 2;
-        else
-        {
-            enforce(
-                this.throttler_failure_e,
-                throttler_config.suspend_point < total,
-                format(
-                    "Trying to configure StreamProcessor with suspend point ({}) " ~
-                        "larger or equal to task queue size {}",
-                    throttler_config.suspend_point, total
-                )
-            );
-        }
+        enforce(
+            this.throttler_failure_e,
+            throttler_config.suspend_point < total,
+            format(
+                "Trying to configure StreamProcessor with suspend point ({}) " ~
+                    "larger or equal to task queue size {}",
+                throttler_config.suspend_point, total
+            )
+        );
 
         if (throttler_config.resume_point == size_t.max)
             throttler_config.resume_point = total / 5;
-        {
-            enforce(
-                this.throttler_failure_e,
-                throttler_config.resume_point < total,
-                format(
-                    "Trying to configure StreamProcessor with resume point ({}) " ~
-                        "larger or equal to task queue size {}",
-                    throttler_config.resume_point, total
-                )
-            );
-        }
+        enforce(
+            this.throttler_failure_e,
+            throttler_config.resume_point < total,
+            format(
+                "Trying to configure StreamProcessor with resume point ({}) " ~
+                    "larger or equal to task queue size {}",
+                throttler_config.resume_point, total
+            )
+        );
 
         this.task_pool = new ThrottledTaskPool!(TaskT)(throttler_config.suspend_point, throttler_config.resume_point);
     }


### PR DESCRIPTION
<s>This change adds the else branch which seems missing in the code.
Supposedly an else branch was intended here because of the introduced
scope for the enforce statement. The original code is not buggy. It only
executed the enforce statement when the if branch was taken. In this
case the enforce statement is redundant since its condition is always
true. With the added else branch the code looks as it was originally
intended especially with respect to similar code a few lines above.
It also seems cleaner.</s>
Right after an if statement an enforce is placed inside its own scope.
This is a leftover from old code. The intention here is to always
enforce. For clarity the scope is removed since otherwise one might
think an else branch is missing. The changed code should be easier to
understand raising less questions about its intentions.