### PR TITLE
UnitTestRunner: improve -p option

### DIFF
--- a/relnotes/utrunner.migration.md
+++ b/relnotes/utrunner.migration.md
@@ -1,0 +1,7 @@
+* `core.UnitTestRunner`
+
+  There is a minor breaking bug fix in the `--package` / `-p` option; now it can't be used as some sort of wildcard.
+
+  The `PKG` argument will only match fully qualified names that start with `PKG.` or the exact module `PKG`. Before using `PKG` as argument would have matched `PKG*`, so `PKGfoo` was also a match.
+
+  As a transitional step, `PKG.` will also be accepted as a package specification, although it will match both `PKG` (exact match) and `PKG.*`.

--- a/src/ocean/core/UnitTestRunner.d
+++ b/src/ocean/core/UnitTestRunner.d
@@ -90,6 +90,7 @@ import ocean.text.xml.Document: Document;
 import ocean.text.xml.DocPrinter: DocPrinter;
 import ocean.text.convert.Formatter;
 import ocean.core.Test: TestException, test;
+import ocean.core.array.Mutation: uniq;
 import core.memory;
 
 
@@ -212,8 +213,8 @@ private scope class UnitTestRunner
             {
                 no_match++;
                 if (this.verbose > 1)
-                    Stdout.formatln("{}: {}: skipped (not in packages to test)",
-                            this.prog, m.name);
+                    Stdout.formatln("{}: {}: skipped (not in " ~
+                            "modules to test)", this.prog, m.name);
                 continue;
             }
 
@@ -312,7 +313,7 @@ private scope class UnitTestRunner
             if (!this.keep_going && failed)
                 Stdout.format(", {} skipped", skipped);
             if (this.verbose > 1)
-                Stdout.format(", {} didn't match --package", no_match);
+                Stdout.format(", {} didn't match -p/--package", no_match);
             Stdout.formatln(" [{}]", this.toHumanTime(total_time));
         }
 
@@ -736,8 +737,13 @@ private scope class UnitTestRunner
 
         foreach (pkg; this.packages)
         {
-            if (name.length >= pkg.length &&
-                    strncmp(pkg.ptr, name.ptr, pkg.length) == 0)
+            // It matches as a module
+            if (name == pkg)
+                return true;
+            // If name is part of the package, it must start with "pkg."
+            if (name.length > pkg.length &&
+                    strncmp(pkg.ptr, name.ptr, pkg.length) == 0 &&
+                    name[pkg.length] == '.')
                 return true;
         }
 
@@ -827,8 +833,18 @@ private scope class UnitTestRunner
             case "-p":
             case "--package":
                 auto opt_arg = getOptArg(i);
-                if (opt_arg is null)
+                if (opt_arg.length == 0)
                     return false;
+                // FIXME: This is just a compatibility-mode because at some
+                //        point this worked implicitly as some sort of pattern
+                //        matching ARG*, so to specify a strict package it was
+                //        common to use "pkg.". Now we just remove the trailing
+                //        "." if we find one, it's not a valid package name
+                //        anyway. This was introduced in v3, so it should be
+                //        safe to remove it in v4 or maybe v5 go make sure all
+                //        dependencies were updated.
+                if (opt_arg[$-1] == '.')
+                    opt_arg = opt_arg[0..$-1];
                 this.packages ~= opt_arg;
                 break;
 
@@ -863,6 +879,9 @@ private scope class UnitTestRunner
             Stderr.newline();
             return false;
         }
+
+        // Remove any package duplicates
+        this.packages = uniq(this.packages);
 
         return true;
     }
@@ -909,10 +928,8 @@ optional arguments:
   -s, --summary     print a summary with the passed, skipped and failed number
                     of tests
   -k, --keep-going  don't stop after the first module unittest failed
-  -p, --package PKG
-                    only run tests in the PKG package (effectively any module
-                    which fully qualified name starts with PKG), can be
-                    specified multiple times to indicate more packages to test
+  -p, --package PKG only run tests in package (or module) PKG (can be specified
+                    multiple times)
   -x, --xml-file FILE
                     write test results in FILE in a XML format that Jenkins
                     understands.


### PR DESCRIPTION
The --package / -p option behaved a bit weird. Instead of really meaning
"test only modules in package PKG" it meant "test only modules with
fully qualified names starting with PKG". So if you used `-p ocean`,
a top-level module `ocean` would be tested (which is not probably what
you want) and even an entire package `oceanic`would be tested
too (anything matching `^ocean.*` would be tested)..

This commit makes `-p` only test modules strictly in the PKG package
(i.e. the module fully qualified name must match `^PKG\..*`) and a new
options `--module MOD` / `-m MOD` was added to be able to specify single
modules.

Related to https://github.com/sociomantic-tsunami/makd/pull/86.