### PR TITLE
Produce coverage report only if asked

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
 
 install: beaver dlang install
 
-script: beaver dlang make
+script: BEAVER_DOCKER_VARS=AFTER_SCRIPT beaver dlang make
 
 after_success:
     - test "$AFTER_SCRIPT" = "1" && beaver run ci/codecov.sh

--- a/Build.mak
+++ b/Build.mak
@@ -7,14 +7,17 @@ override DFLAGS += -w -version=GLIBC
 # but we -or course- don't have Ocean as a submodule, so we set it explicitly.
 TEST_RUNNER_MODULE := ocean.core.UnitTestRunner
 
+# Do we want coverage report?
+ifeq ($(AFTER_SCRIPT),1)
+COVFLAG:=-cov
+endif
+
 ifeq ($(DVER),1)
 override DFLAGS := $(filter-out -di,$(DFLAGS)) -v2 -v2=-static-arr-params -v2=-volatile
-COVFLAG:=-cov
 else
 # Open source Makd uses dmd by default
 DC ?= dmd
 override DFLAGS += -de
-COVFLAG:=
 endif
 
 # Remove coverage files


### PR DESCRIPTION
By default build should not generate coverage report. This allows
one to produce them by passing COVERAGE=1 to make.