### PR TITLE
Make DeserializationException a ReusableException.

### DIFF
--- a/relnotes/deserializer-exception.md
+++ b/relnotes/deserializer-exception.md
@@ -1,0 +1,4 @@
+* `ocean.util.serialize.contiguous.Deserializer`
+
+  `DeserializationException` is now a reusable exception to prevent allocations
+  when thrown from `Deserializer`.

--- a/relnotes/formatter-buff.feature.md
+++ b/relnotes/formatter-buff.feature.md
@@ -1,0 +1,4 @@
+* `ocean.text.convert.Formatter`
+
+   Both `sformat` and `snformat` now also have overload that accepts `Buffer`
+   argument as a target.

--- a/relnotes/reusable-fmt.feature.md
+++ b/relnotes/reusable-fmt.feature.md
@@ -1,0 +1,4 @@
+* `ocean.core.Exception`
+
+  `ReusableExceptionImpl` now mixes in new method, `fmtAppend`, which allows
+  to append formatted string using `Formatter` without any temporary allocations.

--- a/src/ocean/core/Exception.d
+++ b/src/ocean/core/Exception.d
@@ -100,9 +100,10 @@ unittest
 public template ReusableExceptionImplementation()
 {
     import ocean.transition;
-    static import ocean.text.convert.Integer_tango;
     import ocean.core.Buffer;
     static import ocean.core.array.Mutation;
+    static import ocean.text.convert.Formatter;
+    static import ocean.text.convert.Integer_tango;
 
     static assert (is(typeof(this) : Exception));
 
@@ -247,6 +248,25 @@ public template ReusableExceptionImplementation()
                 ocean.text.convert.Integer_tango.format(buff, num));
         return this;
     }
+
+    /**************************************************************************
+
+        Appends formatted string
+
+        Params:
+            fmt = string format to use
+            args = variadic args list to format
+
+        Returns:
+            this instance
+
+    **************************************************************************/
+
+    public typeof (this) fmtAppend ( Args... ) ( cstring fmt, Args args )
+    {
+        ocean.text.convert.Formatter.sformat(this.reused_msg, fmt, args);
+        return this;
+    }
 }
 
 ///
@@ -281,6 +301,13 @@ unittest
     catch (SomeReusableException) { }
     assert (getMsg(e) == "Wrong name (NAME) 0x2A 42");
     assert (old_ptr is e.reused_msg[].ptr);
+}
+
+unittest
+{
+    auto e = new SomeReusableException;
+    e.set("aaa").fmtAppend("{0}{0}", 42);
+    test!("==")(getMsg(e), "aaa4242");
 }
 
 version (UnitTest)

--- a/src/ocean/text/convert/Formatter.d
+++ b/src/ocean/text/convert/Formatter.d
@@ -24,6 +24,7 @@ module ocean.text.convert.Formatter;
 
 import ocean.transition;
 import ocean.core.Traits;
+import ocean.core.Buffer;
 import Integer = ocean.text.convert.Integer_tango;
 import Float = ocean.text.convert.Float;
 import UTF = ocean.text.convert.Utf;
@@ -119,6 +120,16 @@ public mstring sformat (Args...) (ref mstring buffer, cstring fmt, Args args)
     return buffer;
 }
 
+/// ditto
+public mstring sformat (Args...) (ref Buffer!(char) buffer, cstring fmt, Args args)
+{
+    scope FormatterSink sink = (cstring s)
+    {
+        buffer ~= s;
+    };
+    sformat(sink, fmt, args);
+    return buffer[];
+}
 
 /*******************************************************************************
 
@@ -159,6 +170,11 @@ public mstring snformat (Args...) (mstring buffer, cstring fmt, Args args)
     return buffer[0 .. start];
 }
 
+/// ditto
+public mstring snformat (Args...) (ref Buffer!(char) buffer, cstring fmt, Args args)
+{
+    return snformat(buffer[], fmt, args);
+}
 
 /*******************************************************************************
 

--- a/src/ocean/text/convert/Formatter_test.d
+++ b/src/ocean/text/convert/Formatter_test.d
@@ -16,6 +16,7 @@
 module ocean.text.convert.Formatter_test;
 
 import ocean.core.Test;
+import ocean.core.Buffer;
 import ocean.text.convert.Formatter;
 import ocean.transition;
 
@@ -50,4 +51,14 @@ unittest
 
     Bar b;
     test!("==")(format("{}", b), "Hello void");
+}
+
+/// Test for Buffer overloads
+unittest
+{
+    Buffer!(char) buff;
+    sformat(buff, "{}", 42);
+    test!("==")(buff[], "42");
+    snformat(buff, "{}", 1000);
+    test!("==")(buff[], "10");
 }


### PR DESCRIPTION
Previously the formatting call would allocate a new buffer every time the enforce triggered. 