### PR TITLE
Don't unregister TimerExt if exception is thrown from DaemonApp.onSta…

### DIFF
--- a/src/ocean/util/app/DaemonApp.d
+++ b/src/ocean/util/app/DaemonApp.d
@@ -60,6 +60,7 @@ public abstract class DaemonApp : Application,
         ISignalExtExtension
 {
     import ocean.io.select.EpollSelectDispatcher;
+    import ocean.io.Stdout;
     import ocean.sys.Stats;
     import ocean.task.Scheduler;
     import ocean.text.Arguments : Arguments;
@@ -563,7 +564,23 @@ public abstract class DaemonApp : Application,
 
     private bool statsTimer ( )
     {
-        this.onStatsTimer();
+        try
+        {
+            this.onStatsTimer();
+        }
+        catch (Exception e)
+        {
+            try
+            {
+                Stderr.formatln(
+                        "Exception caught in DaemonApp.statsTimer: {}", e);
+            }
+            catch (Exception)
+            {
+                // ignore the failed stderr output, keep the timer registered
+            }
+        }
+
         return true;
     }
 


### PR DESCRIPTION
…tsTimer

In case the exception is thrown from DaemonApp.onStatsTimer (for
example, if there's no disk space left on device), we don't want to
unregister timer and never to write stats again. Instead, we should keep
trying.