### PR TITLE
Attempt shutdown of scheduler on SIGTERM by default

### DIFF
--- a/relnotes/cleanup.feature.md
+++ b/relnotes/cleanup.feature.md
@@ -1,0 +1,7 @@
+* `ocean.util.app.ext.SignalExt`
+
+  Now instead of empty default implementation, the one that catches `SIGTERM`
+  and tries shutting down scheduler/epoll system is used. It should result in
+  same observable behaviour but with runtime finalizers being run. Applications
+  that already implement their own `onSignal` don't need to do anything either
+  (not even call `super.onSignal`).

--- a/relnotes/is-scheduler.feature.md
+++ b/relnotes/is-scheduler.feature.md
@@ -1,0 +1,4 @@
+* `ocean.task.Scheduler`
+
+  New `isSchedulerUsed` global function allows to check if scheduler was
+  initialized previously in the application.

--- a/src/ocean/task/Scheduler.d
+++ b/src/ocean/task/Scheduler.d
@@ -933,6 +933,18 @@ body
 
 /*******************************************************************************
 
+    Returns:
+        'true' if scheduler system was initialized, 'false' otherwise
+
+*******************************************************************************/
+
+public bool isSchedulerUsed ( )
+{
+    return _scheduler !is null;
+}
+
+/*******************************************************************************
+
     Creates or re-creates the scheduler instance.
 
     Re-creating of scheduler is only allowed if previous one doesn't have


### PR DESCRIPTION
If not handled, signal will just kill the application, which will circumvent
runtime finalization step and thus make impossible to see things like GC stats
which are calculated during that step.