### PR TITLE
Add SmartUnion.handleInvalidCases

### DIFF
--- a/relnotes/smartunion.feature.md
+++ b/relnotes/smartunion.feature.md
@@ -1,0 +1,5 @@
+* `ocean.core.SmartUnion`
+
+  Helper mixin string `handleInvalidCases` in `SmartUnion` is added as the support
+  for the `final switch`. It covers `case none` and `default:` so the actual
+  switch body is as clean as possible.


### PR DESCRIPTION
Helper const `handleInvalidCases` in `SmartUnion` is added as the support
for the `final switch`. It covers `case none` and `default:` so the actual
switch body is as clean as possible.