### PR TITLE
Don't write the log output to stderr in unittest

### DIFF
--- a/src/ocean/util/log/Logger.d
+++ b/src/ocean/util/log/Logger.d
@@ -976,7 +976,7 @@ unittest
     scope appender = new Buffer();
     char[32] log_buffer;
     Logger log = Log.lookup("ocean.util.log.Logger.TestLogTrim")
-        .add(appender).buffer(log_buffer);
+        .additive(false).add(appender).buffer(log_buffer);
     log.info("{}", TestStr);
     log.error(TestStr);
     test!("==")(appender.result.length, 2);


### PR DESCRIPTION
By default, the logger used for testing is additive, so it will use
its ancestors Appenders as well. We don't want that, we just want to use
the test Appender.