### PR TITLE
Move the SmartUnion's active member enforcement into method body

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
     matrix:
         - DMD=1.081.1 DIST=xenial F=production AFTER_SCRIPT=1
         - DMD=1.081.1 DIST=xenial F=devel
+        - DMD=1.081.1 DIST=xenial F=production DFLAGS=-release
         - DMD=2.070.2.s12 DIST=xenial F=production
         - DMD=2.070.2.s12 DIST=xenial F=devel
         - DMD=2.071.2.s1 DIST=xenial F=production
@@ -28,7 +29,7 @@ env:
 
 install: beaver dlang install
 
-script: BEAVER_DOCKER_VARS=AFTER_SCRIPT beaver dlang make
+script: BEAVER_DOCKER_VARS="AFTER_SCRIPT DFLAGS" beaver dlang make
 
 after_success:
     - test "$AFTER_SCRIPT" = "1" && beaver run ci/codecov.sh

--- a/src/ocean/core/SmartUnion.d
+++ b/src/ocean/core/SmartUnion.d
@@ -20,6 +20,7 @@ import ocean.transition;
 import ocean.core.ExceptionDefinitions;
 import ocean.core.Test;
 import ocean.core.Traits;
+import ocean.core.Verify;
 
 
 
@@ -503,7 +504,7 @@ private template Methods ( U, uint i )
     const type = "typeof(" ~ member_access ~ ")";
 
     const get = type ~ ' ' ~  member ~ "() "
-        ~ "{ enforce(_.active == _.active." ~ member ~ ", "
+        ~ "{ verify(_.active == _.active." ~ member ~ ", "
         ~ `"SmartUnion: '` ~ member ~ `' not active"); `
         ~ "return " ~ member_access ~ "; }";
 

--- a/src/ocean/core/SmartUnion.d
+++ b/src/ocean/core/SmartUnion.d
@@ -503,9 +503,9 @@ private template Methods ( U, uint i )
     const type = "typeof(" ~ member_access ~ ")";
 
     const get = type ~ ' ' ~  member ~ "() "
-        ~ "in { enforce(_.active == _.active." ~ member ~ ", "
-        ~ `"SmartUnion: '` ~ member ~ `' not active"); } `
-        ~ "body { return " ~ member_access ~ "; }";
+        ~ "{ enforce(_.active == _.active." ~ member ~ ", "
+        ~ `"SmartUnion: '` ~ member ~ `' not active"); `
+        ~ "return " ~ member_access ~ "; }";
 
     const set = type ~ ' ' ~  member ~ '(' ~ type ~ ' ' ~ member ~ ")"
         ~ "{ _.active = _.active." ~ member ~ ";"


### PR DESCRIPTION
The enforcement which was used to confirm that the active member
has been accessed was omitted in the `-release` build. Now it's moved
in the method's body and it still active, no matter if compiled with
`-release`.

Fixes #96