### PR TITLE
Add opIn and pointer-returning `BTreeMap.insert`.

### DIFF
--- a/relnotes/btree.feature.md
+++ b/relnotes/btree.feature.md
@@ -1,0 +1,4 @@
+* `ocean.util.container.BTreeMap`
+
+  `BTreeMap` now provides `opIn` to get the pointer to the stored
+  value based on key.

--- a/relnotes/btree.feature.md
+++ b/relnotes/btree.feature.md
@@ -2,3 +2,11 @@
 
   `BTreeMap` now provides `opIn` to get the pointer to the stored
   value based on key.
+
+* `ocean.util.container.BTreeMap`
+
+  `BTreeMap` now provides overload of `insert` which returns the pointer
+  to the either existing or new value and passes the information if the
+  insertion has been successful via out parameter. This is handy if the
+  user needs a stored pointed immediately after inserting it into the
+  tree (it saves one lookup per insert).

--- a/src/ocean/util/container/btree/BTreeMap.d
+++ b/src/ocean/util/container/btree/BTreeMap.d
@@ -197,6 +197,28 @@ struct BTreeMap(TreeKeyType, TreeValueType, int tree_degree)
         return this.impl.get(key, found_element);
     }
 
+    /**************************************************************************
+
+        Searches the tree for the element with the given key and returns the
+        pointer to the associated value.
+
+        Params:
+            key =  key to find in a tree.
+
+        Returns:
+            pointer to the value associated with the key, if found, null otherwise.
+
+        Complexity:
+            CPU: O(degree * log_degree(n))
+            Memory:O(log_degree(n))
+
+    ***************************************************************************/
+
+    public ValueType* opIn_r (KeyType key)
+    {
+        return this.impl.get(key);
+    }
+
     /***********************************************************************
 
         Recursive inorder iteration over keys and values. Note that, in case
@@ -320,6 +342,12 @@ unittest
 
     // Let's check that the memory is ready to be reused
     test(buff.ptr !is null);
+
+
+    // Use pointer-returning methods
+    auto x = 5 in map;
+    test(x !is null);
+    test!("==")(*x, MyVal(10));
 }
 
 /*

--- a/src/ocean/util/container/btree/BTreeMap.d
+++ b/src/ocean/util/container/btree/BTreeMap.d
@@ -148,8 +148,44 @@ struct BTreeMap(TreeKeyType, TreeValueType, int tree_degree)
 
     public bool insert (KeyType key, ValueType value)
     {
-        return this.impl.insert(key, value);
+        bool added;
+        this.impl.insert(key, value, added);
+        return added;
     }
+
+    /***************************************************************************
+
+        Inserts the (key, value) in the tree. This is passing the copy of the
+        value into the tree, so it's not necessary to manually create copy of
+        it.  Note that for the reference types, this will just copy the
+        reference.
+
+        Params:
+            key = key to insert
+            value = value associated to the key to insert.
+            added = indicator if the value has been added, or the value
+                associated with the key was already in the map
+
+        Returns:
+            pointer to the element associated with the given key (either existing
+            or new value).
+
+        Complexity:
+            CPU: O(degree * log_degree(n))
+            Memory:O(log_degree(n))
+
+    ***************************************************************************/
+
+    public ValueType* insert (KeyType key, ValueType value, out bool added)
+    out (ptr)
+    {
+        assert(ptr !is null);
+    }
+    body
+    {
+        return this.impl.insert(key, value, added);
+    }
+
 
     /******************************************************************************
 
@@ -348,6 +384,19 @@ unittest
     auto x = 5 in map;
     test(x !is null);
     test!("==")(*x, MyVal(10));
+
+    // insert overload that returns the flag if the value was added
+    bool added;
+    auto ptr = map.insert(20, MyVal(40), added);
+    test(ptr !is null);
+    test(added);
+    test!("==")(*ptr, MyVal(40));
+
+    // Doesn't insert duplicate
+    auto old_ptr = map.insert(9, MyVal(60), added);
+    test(old_ptr !is null);
+    test(!added);
+    test!("==")(*old_ptr, MyVal(18));
 }
 
 /*

--- a/src/ocean/util/container/btree/Implementation.d
+++ b/src/ocean/util/container/btree/Implementation.d
@@ -280,6 +280,29 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
         return node.elements[index].value;
     }
 
+    /******************************************************************************
+
+        Searches the tree for the element with the given key and returns pointer
+        to it's value, or null if not found.
+
+        Params:
+            key = key to find in the tree.
+
+        Returns:
+            pointer to the value associated with the key, or null if not found.
+
+    *******************************************************************************/
+
+    package ValueType* get (KeyType key)
+    {
+        size_t index;
+
+        if (auto node = this.get(key, index))
+            return &node.elements[index].value;
+        else
+            return null;
+    }
+
     // implementation
 
     /***************************************************************************

--- a/src/ocean/util/container/btree/Implementation.d
+++ b/src/ocean/util/container/btree/Implementation.d
@@ -33,6 +33,7 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
     import ocean.core.array.Search;
     import ocean.core.Enforce;
     import ocean.core.Traits;
+    import ocean.core.Tuple;
     import ocean.core.Verify;
     import ocean.util.container.mem.MemManager;
 


### PR DESCRIPTION
This adds a missing part of the API which allows accessing the stored values by pointer. Any change to these items will not affect the integrity of the map, since the map is ordered by keys, not by values.