### PR TITLE
Deprecate Buffer-accepting snformat

### DIFF
--- a/relnotes/snformat-buffer.deprecation.md
+++ b/relnotes/snformat-buffer.deprecation.md
@@ -1,0 +1,4 @@
+* `ocean.text.convert.Formatter : snformat`
+
+  The `Buffer` accepting overload was deprecated, as it doesn't bring anything useful.
+  Instead of calling `snformat(buffer, "fmt")`, use `snformat(buffer[], fmt)`.

--- a/src/ocean/text/convert/Formatter.d
+++ b/src/ocean/text/convert/Formatter.d
@@ -171,6 +171,7 @@ public mstring snformat (Args...) (mstring buffer, cstring fmt, Args args)
 }
 
 /// ditto
+deprecated("Pass a slice of your buffer instead")
 public mstring snformat (Args...) (ref Buffer!(char) buffer, cstring fmt, Args args)
 {
     return snformat(buffer[], fmt, args);

--- a/src/ocean/text/convert/Formatter_test.d
+++ b/src/ocean/text/convert/Formatter_test.d
@@ -53,12 +53,19 @@ unittest
     test!("==")(format("{}", b), "Hello void");
 }
 
-/// Test for Buffer overloads
+/// Test for Buffer overload
 unittest
 {
     Buffer!(char) buff;
     sformat(buff, "{}", 42);
     test!("==")(buff[], "42");
+}
+
+/// Ditto
+deprecated unittest
+{
+    Buffer!(char) buff;
+    buff.length = 2;
     snformat(buff, "{}", 1000);
     test!("==")(buff[], "10");
 }


### PR DESCRIPTION
The overload doesn't make sense as it only saves the user 2 characters.
For Buffer-users, it also draws a clearer barrier between sformat and snformat, reducing the chance of misusing them.