### PR TITLE
UnitTestRunner: Fix C string handling in D2

### DIFF
--- a/src/ocean/core/UnitTestRunner.d
+++ b/src/ocean/core/UnitTestRunner.d
@@ -764,8 +764,9 @@ private scope class UnitTestRunner
     {
         // we don't care about freeing anything, is just a few bytes and the program
         // will quite after we are done using these variables
-        char* bin_c = strdup(args[0].ptr);
-        char* prog_c = basename(bin_c);
+        auto prog = args[0].dup;
+        prog ~= '\0'; // Make sure is null-terminated
+        char* prog_c = basename(prog.ptr);
         this.prog = prog_c[0..strlen(prog_c)];
 
         cstring[] unknown;


### PR DESCRIPTION
In D2 apparently command-line arguments don't come with a null-terminator as in D1, so we need to make sure to add one before sending the string to C functions.