### PR TITLE
VersionArgExt: Print unknown version items

### DIFF
--- a/relnotes/version-arg.feature.md
+++ b/relnotes/version-arg.feature.md
@@ -1,0 +1,7 @@
+* `ocean.util.app.ext.VersionArgsExt`
+
+  The `getLibsVersionsString()` method learned a new optional argument `pop`
+  that will pop any library version found while generating the string.
+
+  Also the version string now will include unknown items present in the
+  `version_info`. See the migration notes for details on the format.

--- a/relnotes/version-arg.migration.md
+++ b/relnotes/version-arg.migration.md
@@ -1,0 +1,9 @@
+* `ocean.util.app.ext.VersionArgsExt`
+
+  The version string generated will now also print any unknown item found in the
+  `version_info` with the following format: ` [key='val', ...]` after the
+  library versions. If there are no unknown items, nothing changes compared to
+  the previous behaviour.
+
+  Even when this is not strictly an API change, you should be careful if you
+  have any scripts that parse the version string or stuff like that.

--- a/src/ocean/util/app/ext/VersionArgsExt.d
+++ b/src/ocean/util/app/ext/VersionArgsExt.d
@@ -453,3 +453,25 @@ unittest
     auto app = new MyApp;
     app.main(["app_name", "--version"]);
 }
+
+/*******************************************************************************
+
+    Test the built version string
+
+*******************************************************************************/
+
+unittest
+{
+    VersionInfo info;
+    info["version"] = "v1.0";
+    info["build_author"] = "me";
+    info["build_date"] = "today";
+    info["compiler"] = "dmd3";
+    info["lib_awesome"] = "v10.0";
+    info["lib_sucks"] = "v0.5";
+    info["unknown"] = "hidden";
+    auto v = new VersionArgsExt(info);
+    test!("==")(v.getVersionString("test", info),
+            "test version v1.0 (compiled by 'me' on today with dmd3 using " ~
+            "awesome:v10.0 sucks:v0.5)");
+}


### PR DESCRIPTION
Unknown version items present in the `version_info` are not printed, but
if they exist, is probably because the app author thinks is a valuable
piece of information to the user.

This commit prints any unknown version items found.

Related to https://github.com/sociomantic-tsunami/makd/pull/98.