### PR TITLE
Always import ocean.math.IEEE in ocean.math.ErrorFunction

### DIFF
--- a/src/ocean/math/ErrorFunction.d
+++ b/src/ocean/math/ErrorFunction.d
@@ -33,11 +33,11 @@
 module ocean.math.ErrorFunction;
 
 import ocean.math.Math;
+import ocean.math.IEEE;
 
 version(UnitTest)
 {
     import ocean.core.Test;
-    import ocean.math.IEEE;
 }
 
 


### PR DESCRIPTION
The ocean.math.IEEE module was imported inside `version(UnitTest)`
block, but it was used outside it
(ocean.math.ErrorFunction.normalDistributionInvImpl), making only
unittests pass, but not the actual build.