### PR TITLE
Convert assert to verify/test in math

### DIFF
--- a/src/ocean/math/Bessel.d
+++ b/src/ocean/math/Bessel.d
@@ -19,6 +19,7 @@ module ocean.math.Bessel;
 
 import ocean.math.Math;
 import ocean.math.IEEE;
+import ocean.core.Verify;
 
 version(UnitTest) import ocean.core.Test;
 
@@ -267,11 +268,10 @@ real cylBessel_j1(real x)
  * zero, of the argument.
  */
 real cylBessel_y1(real x)
-in {
-    assert(x>=0.0);
-    // TODO: should it return -infinity for x<0 ?
-}
-body {
+{
+verify(x>=0.0);
+
+// TODO: should it return -infinity for x<0 ?
 /* The domain is divided into the intervals [0, 4.5>, [4.5,9> and
  * [9, infinity). In the first interval a rational approximation
  * R(x) is employed to compute y0(x)  = R(x) + 2/pi * log(x) * j0(x).
@@ -446,10 +446,9 @@ real cylBessel_jn(int n, real x )
  * directly.
  */
 real cylBessel_yn(int n, real x)
-in {
-    assert(x>0); // TODO: should it return -infinity for x<=0 ?
-}
-body {
+{
+    verify(x>0); // TODO: should it return -infinity for x<=0 ?
+
     real an, r;
     int k, sign;
 

--- a/src/ocean/math/BigInt.d
+++ b/src/ocean/math/BigInt.d
@@ -179,7 +179,7 @@ public:
     }
     ///
     BigInt opDiv(T:int)(T y) {
-        assert(y!=0, "Division by zero");
+        verify(y!=0, "Division by zero");
         BigInt r;
         uint u = y < 0 ? -y : y;
         r.data = BigUint.divInt(data, u);
@@ -188,7 +188,7 @@ public:
     }
     ///
     BigInt opDivAssign(T: int)(T y) {
-        assert(y!=0, "Division by zero");
+        verify(y!=0, "Division by zero");
         uint u = y < 0 ? -y : y;
         data = BigUint.divInt(data, u);
         sign = data.isZero()? false : sign ^ (y<0);
@@ -205,7 +205,7 @@ public:
     }
     ///
     int opMod(T:int)(T y) {
-        assert(y!=0);
+        verify(y!=0);
         uint u = y < 0 ? -y : y;
         int rem = BigUint.modInt(data, u);
         // x%y always has the same sign as x.
@@ -214,7 +214,7 @@ public:
     }
     ///
     BigInt opModAssign(T:int)(T y) {
-        assert(y!=0);
+        verify(y!=0);
         uint u = y < 0 ? -y : y;
         data = BigUint.modInt(data, u);
         // x%y always has the same sign as x.
@@ -352,7 +352,7 @@ public:
 package:
     /// BUG: For testing only, this will be removed eventually
     BigInt sliceHighestBytes(uint numbytes) {
-        assert(numbytes<=numBytes());
+        verify(numbytes<=numBytes());
         BigInt x;
         x.sign = sign;
         x.data = data.sliceHighestBytes(numbytes);

--- a/src/ocean/math/BigInt.d
+++ b/src/ocean/math/BigInt.d
@@ -62,7 +62,7 @@ public:
         } else {
             ok = r.data.fromDecimalString(s);
         }
-        assert(ok);
+        verify(ok);
         if (r.isZero()) neg = false;
         r.sign = neg;
         return r;

--- a/src/ocean/math/Bracket.d
+++ b/src/ocean/math/Bracket.d
@@ -19,6 +19,7 @@ import ocean.transition;
 static import tsm = core.stdc.math;
 import ocean.math.Math;
 import ocean.math.IEEE;
+import ocean.core.Verify;
 
 version(UnitTest) import ocean.core.Test;
 
@@ -80,12 +81,11 @@ private:
  */
 BracketResult!(T, R) findRoot(T,R)(R delegate(T) f, T ax, T bx, R fax, R fbx,
     bool delegate(BracketResult!(T,R) r) tolerance)
-in {
-    assert(ax<=bx, "Parameters ax and bx out of order.");
-    assert(!tsm.isnan(ax) && !tsm.isnan(bx), "Limits must not be NaN");
-    assert(oppositeSigns(fax,fbx), "Parameters must bracket the root.");
-}
-body {
+{
+    verify(ax<=bx, "Parameters ax and bx out of order.");
+    verify(!tsm.isnan(ax) && !tsm.isnan(bx), "Limits must not be NaN");
+    verify(oppositeSigns(fax,fbx), "Parameters must bracket the root.");
+
 // This code is (heavily) modified from TOMS748 (www.netlib.org). Some ideas
 // were borrowed from the Boost Mathematics Library.
 
@@ -321,13 +321,12 @@ public:
  */
 T findMinimum(T,R)(R delegate(T) func, T xlo, T xhi, T xinitial,
      out R funcMin)
-in {
-    assert(xlo <= xhi);
-    assert(xinitial >= xlo);
-    assert(xinitial <= xhi);
-    assert(func(xinitial) <= func(xlo) && func(xinitial) <= func(xhi));
-}
-body{
+{
+    verify(xlo <= xhi);
+    verify(xinitial >= xlo);
+    verify(xinitial <= xhi);
+    verify(func(xinitial) <= func(xlo) && func(xinitial) <= func(xhi));
+
     // Based on the original Algol code by R.P. Brent.
     const real GOLDENRATIO = 0.3819660112501051; // (3 - sqrt(5))/2 = 1 - 1/phi
 

--- a/src/ocean/math/Convert.d
+++ b/src/ocean/math/Convert.d
@@ -135,29 +135,29 @@ private void testConversions ( T ) ( )
     long long_result;
 
     // Check that converting a NaN always fails
-    assert(!roundToInt(T.nan, int_result), "Error converting NaN");
-    assert(!roundToLong(T.nan, long_result), "Error converting NaN");
+    test(!roundToInt(T.nan, int_result), "Error converting NaN");
+    test(!roundToLong(T.nan, long_result), "Error converting NaN");
 
     // Check conversion of a negative number (should fail for the unsigneds)
-    assert(roundToInt(cast(T)-4.2, int_result), "Error converting " ~ T.stringof);
-    assert(int_result == -4, "Incorrect " ~ T.stringof ~ " conversion");
+    test(roundToInt(cast(T)-4.2, int_result), "Error converting " ~ T.stringof);
+    test!("==")(int_result, -4, "Incorrect " ~ T.stringof ~ " conversion");
 
-    assert(roundToLong(cast(T)-4.2, long_result), "Error converting " ~ T.stringof);
-    assert(int_result == -4, "Incorrect " ~ T.stringof ~ " conversion");
+    test(roundToLong(cast(T)-4.2, long_result), "Error converting " ~ T.stringof);
+    test!("==")(int_result, -4, "Incorrect " ~ T.stringof ~ " conversion");
 
     // Check conversion of x.5, should round up
-    assert(roundToInt(cast(T)6.5, int_result), "Error converting " ~ T.stringof);
-    assert(int_result == 7, "Incorrect " ~ T.stringof ~ " conversion");
+    test(roundToInt(cast(T)6.5, int_result), "Error converting " ~ T.stringof);
+    test!("==")(int_result, 7, "Incorrect " ~ T.stringof ~ " conversion");
 
-    assert(roundToLong(cast(T)6.5, long_result), "Error converting " ~ T.stringof);
-    assert(long_result == 7, "Incorrect " ~ T.stringof ~ " conversion");
+    test(roundToLong(cast(T)6.5, long_result), "Error converting " ~ T.stringof);
+    test!("==")(long_result, 7, "Incorrect " ~ T.stringof ~ " conversion");
 
     // Check conversion of x.4 should round down
-    assert(roundToInt(cast(T)9.49, int_result), "Error converting " ~ T.stringof);
-    assert(int_result == 9, "Incorrect " ~ T.stringof ~ " conversion");
+    test(roundToInt(cast(T)9.49, int_result), "Error converting " ~ T.stringof);
+    test!("==")(int_result, 9, "Incorrect " ~ T.stringof ~ " conversion");
 
-    assert(roundToLong(cast(T)9.49, long_result), "Error converting " ~ T.stringof);
-    assert(long_result == 9, "Incorrect " ~ T.stringof ~ " conversion");
+    test(roundToLong(cast(T)9.49, long_result), "Error converting " ~ T.stringof);
+    test!("==")(long_result, 9, "Incorrect " ~ T.stringof ~ " conversion");
 }
 
 

--- a/src/ocean/math/Distribution.d
+++ b/src/ocean/math/Distribution.d
@@ -295,13 +295,6 @@ public class Distribution ( T )
 
         auto index = cast(size_t)(fraction * (this.values.length - 1));
 
-        assert(index < this.values.length, "index greater than or equal to length of value list");
-
-        if ( index >= this.values.length )
-        {
-            index = this.values.length - 1;
-        }
-
         return this.values[index];
     }
 

--- a/src/ocean/math/Distribution.d
+++ b/src/ocean/math/Distribution.d
@@ -110,6 +110,7 @@ import ocean.core.Array : bsearch, sort;
 
 import ocean.util.container.AppendBuffer;
 
+version(UnitTest) import ocean.core.Test;
 
 
 /*******************************************************************************
@@ -474,7 +475,7 @@ private void appendDist ( T ) ( Distribution!(T) dist, T[] values )
     Params:
         dg = a delegate that calls an error throwing function
         error = whether an error should have been thrown or not
-        msg = the error message should the assert fail
+        msg = the error message should the test fail
 
 *******************************************************************************/
 
@@ -492,7 +493,7 @@ private void testForError ( bool dummy = false )
         caught = true;
     }
 
-    assert(error == caught, "Error " ~ (!error ? "not " : "")  ~ "expected: " ~ msg);
+    test(error == caught, "Error " ~ (!error ? "not " : "")  ~ "expected: " ~ msg);
 }
 
 
@@ -515,7 +516,7 @@ private void percentValueTests ( T ) ( T[] values, T middle_value )
     auto dist = new Distribution!(T);
 
     // test that percentValue always returns 0 for empty distributions regardless of type
-    assert(dist.percentValue(0.25) == 0, "percentValue should always return 0 for an empty distribution");
+    test!("==")(dist.percentValue(0.25), 0, "percentValue should always return 0 for an empty distribution");
 
     appendDist!(T)(dist, values);
 
@@ -524,7 +525,7 @@ private void percentValueTests ( T ) ( T[] values, T middle_value )
     testForError({ dist.percentValue(2.0); }, true, "fraction > 1 is out of bounds");
 
     // test middle value
-    assert(dist.percentValue(0.5) == middle_value, "");
+    test!("==")(dist.percentValue(0.5), middle_value);
 }
 
 
@@ -547,12 +548,12 @@ private void meanTests ( T ) ( T[] values, T average_value )
     auto dist = new Distribution!(T);
 
     // test that mean always returns 0 for empty distributions regardless of type
-    assert(dist.mean() == 0, "mean should always return 0 for an empty distribution");
+    test!("==")(dist.mean(), 0, "mean should always return 0 for an empty distribution");
 
     appendDist!(T)(dist, values);
 
     // test average value
-    assert(dist.mean() == average_value, "mean returned the wrong average value");
+    test!("==")(dist.mean(), average_value, "mean returned the wrong average value");
 }
 
 
@@ -575,10 +576,10 @@ private void medianTests ( T ) ( T[] values, double median_value )
     auto dist = new Distribution!(T);
 
     // test that median always returns 0 for empty distributions regardless of type
-    assert(dist.median() == 0, "median should always return 0 for an empty distribution");
+    test!("==")(dist.median(), 0, "median should always return 0 for an empty distribution");
 
     appendDist!(T)(dist, values);
 
     // test median value
-    assert(dist.median() == median_value, "median returned the wrong median value");
+    test!("==")(dist.median(), median_value, "median returned the wrong median value");
 }

--- a/src/ocean/math/Elliptic.d
+++ b/src/ocean/math/Elliptic.d
@@ -53,6 +53,7 @@ module ocean.math.Elliptic;
 
 import ocean.math.Math;
 import ocean.math.IEEE;
+import ocean.core.Verify;
 
 version(UnitTest) import ocean.core.Test;
 
@@ -237,10 +238,8 @@ done:
  */
 
 real ellipticKComplete(real x)
-in {
-//    assert(x>=0.0L && x<=1.0L);
-}
-body{
+{
+//    verify(x>=0.0L && x<=1.0L);
 
 const real [] P = [
    0x1.62e42fefa39ef35ap+0, // 1.3862943611198906189
@@ -301,10 +300,8 @@ const real [] Q = [
  */
 
 real ellipticEComplete(real x)
-in {
- assert(x>=0 && x<=1.0);
-}
-body {
+{
+verify(x>=0 && x<=1.0);
 const real [] P = [
    0x1.c5c85fdf473f78f2p-2, // 0.44314718055994670505
    0x1.d1591f9e9a66477p-5,  // 0.056805192715569305834
@@ -404,9 +401,7 @@ real ellipticPi(real phi, real m, real n)
  *  Complete elliptic integral of the third kind
  */
 real ellipticPiComplete(real m, real n)
-in {
- assert(m>=-1.0 && m<=1.0);
-}
-body {
+{
+    verify(m>=-1.0 && m<=1.0);
     return ellipticPi(PI_2, m, n);
 }

--- a/src/ocean/math/ErrorFunction.d
+++ b/src/ocean/math/ErrorFunction.d
@@ -34,6 +34,7 @@ module ocean.math.ErrorFunction;
 
 import ocean.math.Math;
 import ocean.math.IEEE;
+import ocean.core.Verify;
 
 version(UnitTest)
 {
@@ -358,11 +359,9 @@ package {
  * where w = p - 0.5 .
  */
 real normalDistributionInvImpl(real p)
-in {
-  assert(p>=0.0L && p<=1.0L, "Domain error");
-}
-body
 {
+verify(p>=0.0L && p<=1.0L, "Domain error");
+
 const real[] P0 = [ -0x1.758f4d969484bfdcp-7, 0x1.53cee17a59259dd2p-3,
    -0x1.ea01e4400a9427a2p-1,  0x1.61f7504a0105341ap+1, -0x1.09475a594d0399f6p+2,
     0x1.7c59e7a0df99e3e2p+1, -0x1.87a81da52edcdf14p-1,  0x1.1fb149fd3f83600cp-7

--- a/src/ocean/math/GammaFunction.d
+++ b/src/ocean/math/GammaFunction.d
@@ -29,6 +29,7 @@ import ocean.transition;
 import ocean.math.Math;
 import ocean.math.IEEE;
 import ocean.math.ErrorFunction;
+import ocean.core.Verify;
 
 version(UnitTest) import ocean.core.Test;
 
@@ -1094,11 +1095,10 @@ real betaDistPowerSeries(real a, real b, real x )
  * values of a and x.
  */
 real gammaIncomplete(real a, real x )
-in {
-   assert(x >= 0);
-   assert(a > 0);
-}
-body {
+{
+    verify(x >= 0);
+    verify(a > 0);
+
     /* left tail of incomplete gamma function:
      *
      *          inf.      k
@@ -1137,11 +1137,10 @@ body {
 
 /** ditto */
 real gammaIncompleteCompl(real a, real x )
-in {
-   assert(x >= 0);
-   assert(a > 0);
-}
-body {
+{
+    verify(x >= 0);
+    verify(a > 0);
+
     if (x==0)
        return 1.0L;
     if ( (x < 1.0L) || (x < a) )
@@ -1217,11 +1216,10 @@ body {
  * root of incompleteGammaCompl(a,x) - p = 0.
  */
 real gammaIncompleteComplInv(real a, real p)
-in {
-  assert(p>=0 && p<= 1);
-  assert(a>0);
-}
-body {
+{
+    verify(p>=0 && p<= 1);
+    verify(a>0);
+
     if (p==0) return real.infinity;
 
     real y0 = p;

--- a/src/ocean/math/IEEE.d
+++ b/src/ocean/math/IEEE.d
@@ -36,6 +36,7 @@
 module ocean.math.IEEE;
 
 import ocean.transition;
+import ocean.core.Verify;
 
 version(UnitTest) import ocean.core.Test;
 
@@ -321,7 +322,7 @@ private:
               tmpval &=0xFFFF_FC00;
               asm { ld tmpval, %fsr; }
             */
-           assert(0, "Not yet supported");
+           throw new SanityException("Not yet supported");
         }
     }
 public:
@@ -380,7 +381,7 @@ RoundingMode setIeeeRounding(RoundingMode roundingmode) {
             fldcw cont;
         }
     } else {
-           assert(0, "Not yet supported");
+           throw new SanityException("Not yet supported");
     }
 }
 
@@ -397,7 +398,7 @@ RoundingMode getIeeeRounding() {
             and AX, cont;
         }
     } else {
-           assert(0, "Not yet supported");
+           throw new SanityException("Not yet supported");
     }
 }
 
@@ -451,7 +452,7 @@ PrecisionControl reduceRealPrecision(PrecisionControl prec) {
             fldcw cont;
         }
     } else {
-           assert(0, "Not yet supported");
+           throw new SanityException("Not yet supported");
     }
 }
 

--- a/src/ocean/math/IEEE.d
+++ b/src/ocean/math/IEEE.d
@@ -309,13 +309,11 @@ private:
     }
     static void resetIeeeFlags()
     {
-        version(InlineAsm_X86_Any)
-        {
-            asm
-            {
-                fnclex;
-            }
-        } else {
+        version (D_InlineAsm_X86)
+            asm {fnclex;}
+        else version (D_InlineAsm_X86_64)
+            asm {fnclex;}
+        else {
             /* SPARC:
               int tmpval;
               asm { st %fsr, tmpval; }
@@ -402,25 +400,25 @@ RoundingMode getIeeeRounding() {
     }
 }
 
-version(D_InlineAsm_X86) { // Won't work for anything else yet
-    unittest {
-        real a = 3.5;
-        resetIeeeFlags();
-        test(!ieeeFlags.divByZero);
-        a /= 0.0L;
-        test(ieeeFlags.divByZero);
-        test(a == real.infinity);
-        a *= 0.0L;
-        test(ieeeFlags.invalid);
-        test(isNaN(a));
-        a = real.max;
-        a *= 2;
-        test(ieeeFlags.overflow);
-        a = min_normal!(real) * real.epsilon;
-        a /= 99;
-        test(ieeeFlags.underflow);
-        test(ieeeFlags.inexact);
+unittest {
+    real a = 3.5;
+    resetIeeeFlags();
+    test(!ieeeFlags.divByZero);
+    a /= 0.0L;
+    test(ieeeFlags.divByZero);
+    test(a == real.infinity);
+    a *= 0.0L;
+    test(ieeeFlags.invalid);
+    test(isNaN(a));
+    a = real.max;
+    a *= 2;
+    test(ieeeFlags.overflow);
+    a = min_normal!(real) * real.epsilon;
+    a /= 99;
+    test(ieeeFlags.underflow);
+    test(ieeeFlags.inexact);
 
+    version(D_InlineAsm_X86) { // Won't work for anything else yet
         int r = getIeeeRounding;
         test(r == RoundingMode.ROUNDTONEAREST);
     }

--- a/src/ocean/math/IEEE.d
+++ b/src/ocean/math/IEEE.d
@@ -1639,12 +1639,11 @@ unittest
  *
  */
 T ieeeMean(T)(T x, T y)
-in {
+{
     // both x and y must have the same sign, and must not be NaN.
-    assert(signbit(x) == signbit(y));
-    assert(!tsm.isnan(x) && !tsm.isnan(y));
-}
-body {
+    verify(signbit(x) == signbit(y));
+    verify(!tsm.isnan(x) && !tsm.isnan(y));
+
     // Runtime behaviour for contract violation:
     // If signs are opposite, or one is a NaN, return 0.
     if (!((x>=0 && y>=0) || (x<=0 && y<=0))) return 0.0;
@@ -1812,7 +1811,7 @@ real NaN(ulong payload)
  */
 ulong getNaNPayload(real x)
 {
-    assert(isNaN(x));
+    verify(!!isNaN(x));
     static if (real.mant_dig == 53) {
         ulong m = *cast(ulong *)(&x);
         // Make it look like an 80-bit significand.

--- a/src/ocean/math/IEEE.d
+++ b/src/ocean/math/IEEE.d
@@ -303,7 +303,7 @@ private:
                asm { st %fsr, retval; }
                return retval;
             */
-           assert(0, "Not yet supported");
+           static assert(0, "Not yet supported");
        }
     }
     static void resetIeeeFlags()
@@ -567,7 +567,7 @@ real frexp(real value, out int exp)
     }
     return value;
   }else { //static if(real.mant_dig==106) // doubledouble
-        assert(0, "Unsupported");
+        static assert(0, "Unsupported");
   }
 }
 
@@ -1221,7 +1221,7 @@ real nextUp(real x)
         }
         return x;
     } else { // doubledouble
-        assert(0, "Not implemented");
+        static assert(0, "Not implemented");
     }
 }
 
@@ -1515,7 +1515,7 @@ int feqrel(X)(X x, X y)
         return (bitsdiff == 0 && !((pa[F.EXPPOS_SHORT] ^ pb[F.EXPPOS_SHORT])& F.EXPMASK)) ? 1 : 0;
      }
  } else {
-    assert(0, "Unsupported");
+    static assert(0, "Unsupported");
  }
 }
 
@@ -1711,7 +1711,7 @@ body {
         m |= ((*xl) & 0x8000_0000);
         *ul = m;
     } else {
-        assert(0, "Not implemented");
+        static assert(0, "Not implemented");
     }
     return u;
 }

--- a/src/ocean/math/IEEE.d
+++ b/src/ocean/math/IEEE.d
@@ -346,6 +346,7 @@ void resetIeeeFlags() { IeeeFlags.resetIeeeFlags; }
 /** IEEE rounding modes.
  * The default mode is ROUNDTONEAREST.
  */
+deprecated
 enum RoundingMode : short {
     ROUNDTONEAREST = 0x0000,
     ROUNDDOWN      = 0x0400,
@@ -364,6 +365,7 @@ enum RoundingMode : short {
     scope (exit) setIeeeRounding(oldrounding);
 ---
  */
+deprecated
 RoundingMode setIeeeRounding(RoundingMode roundingmode) {
    version(D_InlineAsm_X86) {
         // TODO: For SSE/SSE2, do we also need to set the SSE rounding mode?
@@ -386,6 +388,7 @@ RoundingMode setIeeeRounding(RoundingMode roundingmode) {
 /** Get the IEEE rounding mode which is in use.
  *
  */
+deprecated
 RoundingMode getIeeeRounding() {
    version(D_InlineAsm_X86) {
         // TODO: For SSE/SSE2, do we also need to check the SSE rounding mode?
@@ -425,6 +428,7 @@ unittest {
 }
 
 // Note: Itanium supports more precision options than this. SSE/SSE2 does not support any.
+deprecated
 enum PrecisionControl : short {
     PRECISION80 = 0x300,
     PRECISION64 = 0x200,
@@ -436,6 +440,7 @@ enum PrecisionControl : short {
  * Returns: the old precision.
  * This is not supported on all platforms.
  */
+deprecated
 PrecisionControl reduceRealPrecision(PrecisionControl prec) {
    version(D_InlineAsm_X86) {
         short cont;

--- a/src/ocean/math/IncrementalAverage.d
+++ b/src/ocean/math/IncrementalAverage.d
@@ -17,6 +17,7 @@
 
 module ocean.math.IncrementalAverage;
 
+import ocean.core.Verify;
 
 /*******************************************************************************
 
@@ -165,7 +166,7 @@ public struct IncrementalAverage
         if (this.count_ < 2)
             return 0;
 
-        assert(this.count_ > correction_factor, "Correction factor is same "
+        verify(this.count_ > correction_factor, "Correction factor is same "
                ~ "size or bigger than the number of elements added.");
 
         return this.mean_of_square / (this.count_ - correction_factor);

--- a/src/ocean/math/IrregularMovingAverage.d
+++ b/src/ocean/math/IrregularMovingAverage.d
@@ -31,6 +31,8 @@ import ocean.math.IEEE;
 import ocean.math.Math;
 import core.stdc.time;
 
+import ocean.core.Verify;
+
 version(UnitTest) import ocean.core.Test;
 
 /*******************************************************************************
@@ -182,33 +184,31 @@ public struct IrregularMovingAverage (Time = time_t, Value = real)
 
     public static This opCall (Value beta, Time expected_time_interval,
                                Value first_value, Time first_value_time)
-    in
-    {
-        assert(!isNaN(beta));
-        assert(!isInfinity(beta));
-        assert(0.0 < beta);
-        assert(beta < 1.0);
-
-        assert(!isNaN(first_value));
-        assert(!isInfinity(first_value));
-
-        static if (isFloatingPointType!(Time))
-        {
-            assert(!isNaN(expected_time_interval));
-            assert(!isInfinity(expected_time_interval));
-
-            assert(!isNaN(first_value_time));
-            assert(!isInfinity(first_value_time));
-        }
-
-        assert(expected_time_interval > 0);
-    }
     out (ima)
     {
         assert(&ima); // confirm the invariant holds
     }
     body
     {
+        verify(!isNaN(beta));
+        verify(!isInfinity(beta));
+        verify(0.0 < beta);
+        verify(beta < 1.0);
+
+        verify(!isNaN(first_value));
+        verify(!isInfinity(first_value));
+
+        static if (isFloatingPointType!(Time))
+        {
+            verify(!isNaN(expected_time_interval));
+            verify(!isInfinity(expected_time_interval));
+
+            verify(!isNaN(first_value_time));
+            verify(!isInfinity(first_value_time));
+        }
+
+        verify(expected_time_interval > 0);
+
         // cast to real is necessary to satisfy 'pow' overrides
         Value beta_pow = pow(beta, cast(real) expected_time_interval);
         Value alpha_start = 1.0 - beta_pow;
@@ -244,19 +244,16 @@ public struct IrregularMovingAverage (Time = time_t, Value = real)
     ***************************************************************************/
 
     public void update (Value value, Time value_time)
-    in
     {
-        assert(!isNaN(value));
-        assert(!isInfinity(value));
+        verify(!isNaN(value));
+        verify(!isInfinity(value));
 
         static if (isFloatingPointType!(Time))
         {
-            assert(!isNaN(value_time));
-            assert(!isInfinity(value_time));
+            verify(!isNaN(value_time));
+            verify(!isInfinity(value_time));
         }
-    }
-    body
-    {
+
         enforce(value_time > this.update_time,
                 "Cannot incorporate data point from the past!");
 
@@ -363,18 +360,15 @@ public struct IrregularMovingAverage (Time = time_t, Value = real)
     ***************************************************************************/
 
     private Time update_time (Time t)
-    in
     {
         static if (isFloatingPointType!(Time))
         {
-            assert(!isNaN(value_time));
-            assert(!isInfinity(value_time));
+            verify(!isNaN(value_time));
+            verify(!isInfinity(value_time));
         }
 
-        assert(t > this.update_time_);
-    }
-    body
-    {
+        verify(t > this.update_time_);
+
         return this.update_time_ = t;
     }
 
@@ -410,15 +404,12 @@ public struct IrregularMovingAverage (Time = time_t, Value = real)
     ***************************************************************************/
 
     public Value beta (Value b)
-    in
     {
-        assert(!isNaN(b));
-        assert(!isInfinity(b));
-        assert(0 < b);
-        assert(b < 1);
-    }
-    body
-    {
+        verify(!isNaN(b));
+        verify(!isInfinity(b));
+        verify(0 < b);
+        verify(b < 1);
+
         return this.beta_ = b;
     }
 }

--- a/src/ocean/math/Math.d
+++ b/src/ocean/math/Math.d
@@ -49,6 +49,7 @@ import ocean.transition;
 
 static import core.stdc.math;
 import ocean.math.IEEE;
+import ocean.core.Verify;
 
 version(UnitTest) import ocean.core.Test;
 
@@ -1866,12 +1867,9 @@ unittest
  *      x =  point in which to evaluate polynomial
  */
 T poly(T)(T x, T[] A)
-in
 {
-    assert(A.length > 0);
-}
-body
-{
+    verify(A.length > 0);
+
   version (Naked_D_InlineAsm_X86) {
       const bool Use_D_InlineAsm_X86 = true;
   } else const bool Use_D_InlineAsm_X86 = false;

--- a/src/ocean/math/Probability.d
+++ b/src/ocean/math/Probability.d
@@ -38,6 +38,7 @@ static import ocean.math.ErrorFunction;
 import ocean.math.GammaFunction;
 import ocean.math.Math;
 import ocean.math.IEEE;
+import ocean.core.Verify;
 
 version(UnitTest) import ocean.core.Test;
 
@@ -126,10 +127,9 @@ unittest {
  * with -t instead of t.
  */
 real studentsTDistribution(int nu, real t)
-in{
-   assert(nu>0);
-}
-body{
+{
+   verify(nu>0);
+
   /* Based on code from Cephes Math Library Release 2.3:  January, 1995
      Copyright 1984, 1995 by Stephen L. Moshier
  */
@@ -203,12 +203,10 @@ body{
  * p  = probability. 0 < p < 1
  */
 real studentsTDistributionInv(int nu, real p )
-in {
-   assert(nu>0);
-   assert(p>=0.0L && p<=1.0L);
-}
-body
 {
+    verify(nu>0);
+    verify(p>=0.0L && p<=1.0L);
+
     if (p==0) return -real.infinity;
     if (p==1) return real.infinity;
 
@@ -300,11 +298,10 @@ unittest {
  *  x  = Must be >= 0
  */
 real fDistribution(int df1, int df2, real x)
-in {
- assert(df1>=1 && df2>=1);
- assert(x>=0);
-}
-body{
+{
+    verify(df1>=1 && df2>=1);
+    verify(x>=0);
+
     real a = cast(real)(df1);
     real b = cast(real)(df2);
     real w = a * x;
@@ -314,11 +311,10 @@ body{
 
 /** ditto */
 real fDistributionCompl(int df1, int df2, real x)
-in {
- assert(df1>=1 && df2>=1);
- assert(x>=0);
-}
-body{
+{
+    verify(df1>=1 && df2>=1);
+    verify(x>=0);
+
     real a = cast(real)(df1);
     real b = cast(real)(df2);
     real w = b / (b + a * x);
@@ -347,11 +343,10 @@ body{
 
 /** ditto */
 real fDistributionComplInv(int df1, int df2, real p )
-in {
- assert(df1>=1 && df2>=1);
- assert(p>=0 && p<=1.0);
-}
-body{
+{
+    verify(df1>=1 && df2>=1);
+    verify(p>=0 && p<=1.0);
+
     real a = df1;
     real b = df2;
     /* Compute probability for x = 0.5.  */
@@ -398,21 +393,19 @@ unittest {
  *
  */
 real chiSqrDistribution(real v, real x)
-in {
- assert(x>=0);
- assert(v>=1.0);
-}
-body{
+{
+   verify(x>=0);
+   verify(v>=1.0);
+
    return gammaIncomplete( 0.5*v, 0.5*x);
 }
 
 /** ditto */
 real chiSqrDistributionCompl(real v, real x)
-in {
- assert(x>=0);
- assert(v>=1.0);
-}
-body{
+{
+    verify(x>=0);
+    verify(v>=1.0);
+
     return gammaIncompleteCompl( 0.5L*v, 0.5L*x );
 }
 
@@ -429,12 +422,10 @@ body{
  *
  */
 real chiSqrDistributionComplInv(real v, real p)
-in {
-  assert(p>=0 && p<=1.0L);
-  assert(v>=1.0L);
-}
-body
 {
+   verify(p>=0 && p<=1.0L);
+   verify(v>=1.0L);
+
    return  2.0 * gammaIncompleteComplInv( 0.5*v, p);
 }
 
@@ -455,19 +446,17 @@ unittest {
  * x must be greater than 0.
  */
 real gammaDistribution(real a, real b, real x)
-in {
-   assert(x>=0);
-}
-body {
+{
+   verify(x>=0);
+
    return gammaIncomplete(b, a*x);
 }
 
 /** ditto */
 real gammaDistributionCompl(real a, real b, real x )
-in {
-   assert(x>=0);
-}
-body {
+{
+   verify(x>=0);
+
    return gammaIncompleteCompl( b, a * x );
 }
 
@@ -544,31 +533,28 @@ unittest {
  * The arguments must both be positive.
  */
 real poissonDistribution(int k, real m )
-in {
-  assert(k>=0);
-  assert(m>0);
-}
-body {
+{
+    verify(k>=0);
+    verify(m>0);
+
     return gammaIncompleteCompl( k+1.0, m );
 }
 
 /** ditto */
 real poissonDistributionCompl(int k, real m )
-in {
-  assert(k>=0);
-  assert(m>0);
-}
-body {
+{
+  verify(k>=0);
+  verify(m>0);
+
   return gammaIncomplete( k+1.0, m );
 }
 
 /** ditto */
 real poissonDistributionInv( int k, real p )
-in {
-  assert(k>=0);
-  assert(p>=0.0 && p<=1.0);
-}
-body {
+{
+    verify(k>=0);
+    verify(p>=0.0 && p<=1.0);
+
     return gammaIncompleteComplInv(k+1, p);
 }
 
@@ -599,11 +585,10 @@ unittest {
  * The arguments must be positive, with p ranging from 0 to 1, and k<=n.
  */
 real binomialDistribution(int k, int n, real p )
-in {
-   assert(p>=0 && p<=1.0); // domain error
-   assert(k>=0 && k<=n);
-}
-body{
+{
+    verify(p>=0 && p<=1.0); // domain error
+    verify(k>=0 && k<=n);
+
     real dk, dn, q;
     if( k == n )
         return 1.0L;
@@ -628,11 +613,10 @@ unittest {
 
  /** ditto */
 real binomialDistributionCompl(int k, int n, real p )
-in {
-   assert(p>=0 && p<=1.0); // domain error
-   assert(k>=0 && k<=n);
-}
-body{
+{
+    verify(p>=0 && p<=1.0); // domain error
+    verify(k>=0 && k<=n);
+
     if ( k == n ) {
         return 0;
     }
@@ -672,11 +656,10 @@ unittest {
  * The arguments must be positive, with 0 <= y <= 1, and k <= n.
  */
 real binomialDistributionInv( int k, int n, real y )
-in {
-   assert(y>=0 && y<=1.0); // domain error
-   assert(k>=0 && k<=n);
-}
-body{
+{
+    verify(y>=0 && y<=1.0); // domain error
+    verify(k>=0 && k<=n);
+
     real dk, p;
     real dn = n - k;
     if ( k == 0 ) {
@@ -731,22 +714,20 @@ unittest {
  */
 
 real negativeBinomialDistribution(int k, int n, real p )
-in {
-   assert(p>=0 && p<=1.0); // domain error
-   assert(k>=0);
-}
-body{
+{
+    verify(p>=0 && p<=1.0); // domain error
+    verify(k>=0);
+
     if ( k == 0 ) return pow( p, n );
     return betaIncomplete( n, k + 1, p );
 }
 
 /** ditto */
 real negativeBinomialDistributionInv(int k, int n, real p )
-in {
-   assert(p>=0 && p<=1.0); // domain error
-   assert(k>=0);
-}
-body{
+{
+    verify(p>=0 && p<=1.0); // domain error
+    verify(k>=0);
+
     return betaIncompleteInv(n, k + 1, p);
 }
 

--- a/src/ocean/math/Range.d
+++ b/src/ocean/math/Range.d
@@ -28,6 +28,7 @@ module ocean.math.Range;
 *******************************************************************************/
 
 import ocean.transition;
+import ocean.core.Verify;
 
 version ( UnitTest )
 {
@@ -328,13 +329,13 @@ public struct Range ( T )
 
         static if (boundaries[0] == '(')
         {
-            assert(min < T.max);
+            verify(min < T.max);
             ++min;
         }
 
         static if (boundaries[1] == ')')
         {
-            assert(max > T.min);
+            verify(max > T.min);
             --max;
         }
 
@@ -1298,14 +1299,11 @@ public struct Range ( T )
 
     private static void sortEndpoints ( This first, This second,
                                         RangeEndpoint[] array )
-    in
     {
-        assert(!first.is_empty);
-        assert(!second.is_empty);
-        assert(array.length == 4);
-    }
-    body
-    {
+        verify(!first.is_empty);
+        verify(!second.is_empty);
+        verify(array.length == 4);
+
         // N.B!  the initial order is sufficient
         // being that stable sort preserve order of equal elements
         array[0] = RangeEndpoint(first.min_, 0);

--- a/src/ocean/math/SlidingAverage.d
+++ b/src/ocean/math/SlidingAverage.d
@@ -30,6 +30,7 @@
 module ocean.math.SlidingAverage;
 
 
+import ocean.core.Verify;
 
 /*******************************************************************************
 
@@ -88,12 +89,9 @@ public class SlidingAverage ( T )
     ***************************************************************************/
 
     public this ( size_t window_size )
-    in
     {
-        assert(window_size > 1, "SlidingAverage, window_size parameter must be > 1");
-    }
-    body
-    {
+        verify(window_size > 1, "SlidingAverage, window_size parameter must be > 1");
+
         this.window = new T[window_size];
         this.index = this.index.max;
     }

--- a/src/ocean/math/SlidingAverage.d
+++ b/src/ocean/math/SlidingAverage.d
@@ -202,6 +202,8 @@ public class SlidingAverage ( T )
 version (UnitTest)
 {
     import ocean.util.Convert: to;
+    import ocean.core.Test;
+    import ocean.transition;
 
     /*******************************************************************************
 
@@ -216,47 +218,47 @@ version (UnitTest)
 
     void runTests ( T ) ( uint size, int test_iteration )
     {
-        assert(size > 2, "can only test SlidingAverages with at least 2 values");
+        test!(">")(size, 2, "can only test SlidingAverages with at least 2 values");
 
         auto avg = new SlidingAverage!(T)(size);
 
-        char[] err_prefix = "SlidingAverage assertion failed for iteration " ~
-            to!(char[])(test_iteration) ~ ": ";
+        istring err_prefix = "SlidingAverage assertion failed for iteration " ~
+            to!(istring)(test_iteration) ~ ": ";
 
         ulong sum;
 
         for ( int i = 1; i <= size; i++ )
         {
             avg.push(i);
-            assert ( avg.last == i, "last() didn't return last added value" ); // #220
+            test!("==")( avg.last, i, "last() didn't return last added value" ); // #220
             sum += i;
         }
 
         // Test a full SlidingAverage
-        assert(avg.average == cast(double)sum / size, err_prefix ~ "test 1");
-        assert ( avg.last == size, "last() didn't return last added value" ); // #220
+        test!("==")(avg.average, cast(double)sum / size, err_prefix ~ "test 1");
+        test!("==")( avg.last, size, "last() didn't return last added value" ); // #220
 
         // Add size + 1 to the average, but only size to the sum
         // Because at this point the first value of the average will be pushed out
         avg.push(size + 1);
-        assert ( avg.last == size+1, "last() didn't return last added value" ); // #220
+        test!("==")( avg.last, size+1, "last() didn't return last added value" ); // #220
         sum += size;
 
         // Test a SlidingAverage where the oldest value has been replaced
-        assert(avg.average == cast(double)sum / size, err_prefix ~ "test 2");
+        test!("==")(avg.average, cast(double)sum / size, err_prefix ~ "test 2");
 
         avg.clear;
 
         // Test if average is 0 upon clearing after filling it with values
-        assert(avg.average == 0, err_prefix ~ "test 3");
+        test!("==")(avg.average, 0, err_prefix ~ "test 3");
 
         avg.push(2);
-        assert ( avg.last == 2 , "last() didn't return last added value" ); // #220
+        test!("==")( avg.last, 2 , "last() didn't return last added value" ); // #220
         avg.push(4);
-        assert ( avg.last == 4 , "last() didn't return last added value" ); // #220
+        test!("==")( avg.last, 4 , "last() didn't return last added value" ); // #220
 
         // Test a partially filled SlidingAverage
-        assert(avg.average == 3, err_prefix ~ "test 4");
+        test!("==")(avg.average, 3, err_prefix ~ "test 4");
     }
 }
 

--- a/src/ocean/math/WideUInt.d
+++ b/src/ocean/math/WideUInt.d
@@ -20,6 +20,7 @@ module ocean.math.WideUInt;
 import ocean.transition;
 import ocean.core.Test;
 import ocean.core.Enforce;
+import ocean.core.Verify;
 
 import core.stdc.math;
 import ocean.math.IEEE : feqrel;
@@ -382,11 +383,11 @@ public struct WideUInt ( size_t N )
             remainder = (remainder << 32) + this.payload[idx];
             ulong result = remainder / rhs;
             remainder -= rhs * result;
-            assert(result <= uint.max);
+            verify(result <= uint.max);
             this.payload[idx] = cast(uint) result;
         }
 
-        assert(remainder <= uint.max);
+        verify(remainder <= uint.max);
         return cast(uint) remainder;
     }
 

--- a/src/ocean/math/internal/BignumNoAsm.d
+++ b/src/ocean/math/internal/BignumNoAsm.d
@@ -25,6 +25,7 @@
 module ocean.math.internal.BignumNoAsm;
 
 import ocean.transition;
+import ocean.core.Verify;
 
 version(UnitTest) import ocean.core.Test;
 
@@ -178,7 +179,7 @@ unittest
  */
 uint multibyteMul(uint[] dest, Const!(uint)[] src, uint multiplier, uint carry)
 {
-    assert(dest.length==src.length);
+    verify(dest.length==src.length);
     ulong c = carry;
     for(int i=0; i<src.length; ++i){
         c += cast(ulong)(src[i]) * multiplier;
@@ -201,7 +202,7 @@ unittest
  */
 uint multibyteMulAdd(char op)(uint [] dest, Const!(uint)[] src, uint multiplier, uint carry)
 {
-    assert(dest.length == src.length);
+    verify(dest.length == src.length);
     ulong c = carry;
     for(int i = 0; i < src.length; ++i){
         static if(op=='+') {

--- a/src/ocean/math/internal/BiguintCore.d
+++ b/src/ocean/math/internal/BiguintCore.d
@@ -294,7 +294,7 @@ bool fromHexString(cstring s)
     uint partcount = 0;
     verify(s.length>0);
     for (long i = s.length - 1; i>=firstNonZero; --i) {
-        assert(i>=0);
+        verify(i>=0);
         char c = s[i];
         if (s[i]=='_') continue;
         uint x = (c>='0' && c<='9') ? c - '0'
@@ -599,7 +599,7 @@ static BigUint pow(BigUint x, ulong y)
     ulong estimatelength = singledigit ? firstnonzero*y + y0*1 + 2 + ((evenbits*y) >> LG2BIGDIGITBITS)
         : x.data.length * y; // estimated length in BigDigits
     // (Estimated length can overestimate by a factor of 2, if x.data.length ~ 2).
-    if (estimatelength > uint.max/(4*BigDigit.sizeof)) assert(0, "Overflow in BigInt.pow");
+    if (estimatelength > uint.max/(4*BigDigit.sizeof)) verify(0, "Overflow in BigInt.pow");
 
     // The result buffer includes space for all the trailing zeros
     BigDigit [] resultBuffer = new BigDigit[cast(size_t)estimatelength];
@@ -999,14 +999,14 @@ void mulInternal(BigDigit[] result, Const!(BigDigit)[] x, Const!(BigDigit)[] y)
             // Every chunk will either have size chunksize, or chunksize+1.
             maxchunk = chunksize + 1;
             paddingY = true;
-            assert(chunksize + extra + chunksize *(numchunks-1) == x.length );
+            verify(chunksize + extra + chunksize *(numchunks-1) == x.length );
         } else  {
             // the extra bit is large enough that it's worth making a new chunk.
             // (This means we're padding x with zeros, when doing the first one).
             maxchunk = chunksize;
             ++numchunks;
             paddingY = false;
-            assert(extra + chunksize *(numchunks-1) == x.length );
+            verify(extra + chunksize *(numchunks-1) == x.length );
         }
         // We make the buffer a bit bigger so we have space for the partial sums.
         BigDigit [] scratchbuff =

--- a/src/ocean/math/internal/BiguintCore.d
+++ b/src/ocean/math/internal/BiguintCore.d
@@ -33,6 +33,7 @@
 module ocean.math.internal.BiguintCore;
 
 import ocean.transition;
+import ocean.core.Verify;
 
 version(UnitTest) import ocean.core.Test;
 
@@ -291,7 +292,7 @@ bool fromHexString(cstring s)
     uint part = 0;
     uint sofar = 0;
     uint partcount = 0;
-    assert(s.length>0);
+    verify(s.length>0);
     for (long i = s.length - 1; i>=firstNonZero; --i) {
         assert(i>=0);
         char c = s[i];
@@ -351,7 +352,7 @@ bool fromDecimalString(cstring s)
 // return x >> y
 BigUint opShr(ulong y)
 {
-    assert(y>0);
+    verify(y>0);
     uint bits = cast(uint)y & BIGDIGITSHIFTMASK;
     if ((y>>LG2BIGDIGITBITS) >= data.length) return BigUint(ZERO);
     uint words = cast(uint)(y >> LG2BIGDIGITBITS);
@@ -368,10 +369,10 @@ BigUint opShr(ulong y)
 // return x << y
 BigUint opShl(ulong y)
 {
-    assert(y>0);
+    verify(y>0);
     if (isZero()) return *this;
     uint bits = cast(uint)y & BIGDIGITSHIFTMASK;
-    assert ((y>>LG2BIGDIGITBITS) < cast(ulong)(uint.max));
+    verify ((y>>LG2BIGDIGITBITS) < cast(ulong)(uint.max));
     uint words = cast(uint)(y >> LG2BIGDIGITBITS);
     BigDigit [] result = new BigDigit[data.length + words+1];
     result[0..words] = 0;
@@ -473,7 +474,7 @@ static BigUint mul(BigUint x, BigUint y)
 static BigUint divInt(BigUint x, uint y) {
     uint [] result = new BigDigit[x.data.length];
     if ((y&(-y))==y) {
-        assert(y!=0, "BigUint division by zero");
+        verify(y!=0, "BigUint division by zero");
         // perfect power of 2
         uint b = 0;
         for (;y!=1; y>>=1) {
@@ -489,7 +490,7 @@ static BigUint divInt(BigUint x, uint y) {
 
 // return x%y
 static uint modInt(BigUint x, uint y) {
-    assert(y!=0);
+    verify(y!=0);
     if ((y & (-y)) == y) { // perfect power of 2
         return x.data[0]&(y-1);
     } else {
@@ -549,7 +550,7 @@ static BigUint pow(BigUint x, ulong y)
     bool singledigit = ((x.data.length - firstnonzero) == 1);
     // If true, then x0 is that digit, and we must calculate x0 ^^ y0.
     BigDigit x0 = x.data[firstnonzero];
-    assert(x0 !=0);
+    verify(x0 !=0);
     size_t xlength = x.data.length;
     ulong y0;
     uint evenbits = 0; // number of even bits in the bottom of x
@@ -780,7 +781,7 @@ T intpow(T)(T x, ulong n)
 //  returns the maximum power of x that will fit in a uint.
 int highestPowerBelowUintMax(uint x)
 {
-     assert(x>1);
+     verify(x>1);
      const maxpwr = [31, 20, 15, 13, 12, 11, 10, 10, 9, 9,
                                  8, 8, 8, 8, 7, 7, 7, 7, 7, 7, 7, 7];
      if (x<24) return maxpwr[x-2];
@@ -795,7 +796,7 @@ int highestPowerBelowUintMax(uint x)
 //  returns the maximum power of x that will fit in a ulong.
 int highestPowerBelowUlongMax(uint x)
 {
-     assert(x>1);
+     verify(x>1);
      const maxpwr = [63, 40, 31, 27, 24, 22, 21, 20, 19, 18,
                                  17, 17, 16, 16, 15, 15, 15, 15, 14, 14,
                                  14, 14, 13, 13, 13, 13, 13, 13, 13, 12,
@@ -938,9 +939,9 @@ BigDigit [] subInt(Const!(BigDigit)[] x, ulong y)
  */
 void mulInternal(BigDigit[] result, Const!(BigDigit)[] x, Const!(BigDigit)[] y)
 {
-    assert( result.length == x.length + y.length );
-    assert( y.length > 0 );
-    assert( x.length >= y.length);
+    verify( result.length == x.length + y.length );
+    verify( y.length > 0 );
+    verify( x.length >= y.length);
     if (y.length <= KARATSUBALIMIT) {
         // Small multiplier, we'll just use the asm classic multiply.
         if (y.length==1) { // Trivial case, no cache effects to worry about
@@ -1052,7 +1053,7 @@ void squareInternal(BigDigit[] result, Const!(BigDigit)[] x)
 {
   // TODO: Squaring is potentially half a multiply, plus add the squares of
   // the diagonal elements.
-  assert(result.length == 2*x.length);
+  verify(result.length == 2*x.length);
   if (x.length <= KARATSUBASQUARELIMIT) {
       if (x.length==1) {
          result[1] = multibyteMul(result[0..1], x, x[0], 0);
@@ -1073,10 +1074,10 @@ import ocean.core.BitManip : bsr;
 void divModInternal(BigDigit [] quotient, BigDigit[] remainder, Const!(BigDigit)[] u,
     Const!(BigDigit)[] v)
 {
-    assert(quotient.length == u.length - v.length + 1);
-    assert(remainder==null || remainder.length == v.length);
-    assert(v.length > 1);
-    assert(u.length >= v.length);
+    verify(quotient.length == u.length - v.length + 1);
+    verify(remainder==null || remainder.length == v.length);
+    verify(v.length > 1);
+    verify(u.length >= v.length);
 
     // Normalize by shifting v left just enough so that
     // its high-order bit is on, and shift u left the
@@ -1274,22 +1275,20 @@ private:
 
 // Classic 'schoolbook' multiplication.
 void mulSimple(BigDigit[] result, Const!(BigDigit)[] left, Const!(BigDigit)[] right)
-in {
-    assert(result.length == left.length + right.length);
-    assert(right.length>1);
-}
-body {
+{
+    verify(result.length == left.length + right.length);
+    verify(right.length>1);
+
     result[left.length] = multibyteMul(result[0..left.length], left, right[0], 0);
     multibyteMultiplyAccumulate(result[1..$], left, right[1..$]);
 }
 
 // Classic 'schoolbook' squaring
 void squareSimple(BigDigit[] result, Const!(BigDigit)[] x)
-in {
-    assert(result.length == 2*x.length);
-    assert(x.length>1);
-}
-body {
+{
+    verify(result.length == 2*x.length);
+    verify(x.length>1);
+
     multibyteSquare(result, x);
 }
 
@@ -1298,12 +1297,11 @@ body {
 // as the larger length.
 // Returns carry (0 or 1).
 uint addSimple(BigDigit [] result, BigDigit [] left, BigDigit [] right)
-in {
-    assert(result.length == left.length);
-    assert(left.length >= right.length);
-    assert(right.length>0);
-}
-body {
+{
+    verify(result.length == left.length);
+    verify(left.length >= right.length);
+    verify(right.length>0);
+
     uint carry = multibyteAdd(result[0..right.length],
             left[0..right.length], right, 0);
     if (right.length < left.length) {
@@ -1316,12 +1314,11 @@ body {
 //  result = left - right
 // returns carry (0 or 1)
 BigDigit subSimple(BigDigit [] result, BigDigit [] left, BigDigit [] right)
-in {
-    assert(result.length == left.length);
-    assert(left.length >= right.length);
-    assert(right.length>0);
-}
-body {
+{
+    verify(result.length == left.length);
+    verify(left.length >= right.length);
+    verify(right.length>0);
+
     BigDigit carry = multibyteSub(result[0..right.length],
             left[0..right.length], right, 0);
     if (right.length < left.length) {
@@ -1337,7 +1334,7 @@ body {
 */
 BigDigit subAssignSimple(BigDigit [] result, BigDigit [] right)
 {
-    assert(result.length >= right.length);
+    verify(result.length >= right.length);
     uint c = multibyteSub(result[0..right.length], result[0..right.length], right, 0);
     if (c && result.length > right.length) c = multibyteIncrementAssign!('-')(result[right.length .. $], c);
     return c;
@@ -1347,7 +1344,7 @@ BigDigit subAssignSimple(BigDigit [] result, BigDigit [] right)
 */
 BigDigit addAssignSimple(BigDigit [] result, BigDigit [] right)
 {
-    assert(result.length >= right.length);
+    verify(result.length >= right.length);
     uint c = multibyteAdd(result[0..right.length], result[0..right.length], right, 0);
     if (c && result.length > right.length) {
        c = multibyteIncrementAssign!('+')(result[right.length .. $], c);
@@ -1367,7 +1364,7 @@ BigDigit addOrSubAssignSimple(BigDigit [] result, BigDigit [] right, bool wantSu
 // return true if x<y, considering leading zeros
 bool less(Const!(BigDigit)[] x, Const!(BigDigit)[] y)
 {
-    assert(x.length >= y.length);
+    verify(x.length >= y.length);
     long k = x.length-1;
     while(x[k]==0 && k>=y.length) --k;
     if (k>=y.length) return false;
@@ -1378,7 +1375,7 @@ bool less(Const!(BigDigit)[] x, Const!(BigDigit)[] y)
 // Set result = abs(x-y), return true if result is negative(x<y), false if x<=y.
 bool inplaceSub(BigDigit[] result, Const!(BigDigit)[] x, Const!(BigDigit)[] y)
 {
-    assert(result.length == (x.length >= y.length) ? x.length : y.length);
+    verify(!!(result.length == (x.length >= y.length) ? x.length : y.length));
 
     size_t minlen;
     bool negative;
@@ -1423,14 +1420,14 @@ uint karatsubaRequiredBuffSize(uint xlen)
 void mulKaratsuba(BigDigit [] result, Const!(BigDigit)[] x,
     Const!(BigDigit)[] y, BigDigit[] scratchbuff)
 {
-    assert(x.length >= y.length);
-	  assert(result.length < uint.max, "Operands too large");
-    assert(result.length == x.length + y.length);
+    verify(x.length >= y.length);
+	  verify(result.length < uint.max, "Operands too large");
+    verify(result.length == x.length + y.length);
     if (x.length <= KARATSUBALIMIT) {
         return mulSimple(result, x, y);
     }
     // Must be almost square (otherwise, a schoolbook iteration is better)
-    assert(2L * y.length * y.length > (x.length-1) * (x.length-1),
+    verify(2L * y.length * y.length > (x.length-1) * (x.length-1),
         "Bigint Internal Error: Asymmetric Karatsuba");
 
     // The subtractive version of Karatsuba multiply uses the following result:
@@ -1523,8 +1520,8 @@ void squareKaratsuba(BigDigit [] result, Const!(BigDigit)[] x, BigDigit [] scrat
 {
     // See mulKaratsuba for implementation comments.
     // Squaring is simpler, since it never gets asymmetric.
-	  assert(result.length < uint.max, "Operands too large");
-    assert(result.length == 2*x.length);
+	  verify(result.length < uint.max, "Operands too large");
+    verify(result.length == 2*x.length);
     if (x.length <= KARATSUBASQUARELIMIT) {
         return squareSimple(result, x);
     }
@@ -1576,11 +1573,11 @@ void squareKaratsuba(BigDigit [] result, Const!(BigDigit)[] x, BigDigit [] scrat
  */
 void schoolbookDivMod(BigDigit [] quotient, BigDigit [] u, in BigDigit [] v)
 {
-    assert(quotient.length == u.length - v.length);
-    assert(v.length > 1);
-    assert(u.length >= v.length);
-    assert((v[$-1]&0x8000_0000)!=0);
-    assert(u[$-1] < v[$-1]);
+    verify(quotient.length == u.length - v.length);
+    verify(v.length > 1);
+    verify(u.length >= v.length);
+    verify((v[$-1]&0x8000_0000)!=0);
+    verify(u[$-1] < v[$-1]);
     // BUG: This code only works if BigDigit is uint.
     uint vhi = v[$-1];
     uint vlo = v[$-2];
@@ -1667,7 +1664,7 @@ private:
 // or 0 if left[]==right[]
 ptrdiff_t highestDifferentDigit(Const!(BigDigit)[] left, Const!(BigDigit)[] right)
 {
-    assert(left.length == right.length);
+    verify(left.length == right.length);
     for (ptrdiff_t i=left.length-1; i>0; --i) {
         if (left[i]!=right[i]) return i;
     }
@@ -1680,7 +1677,7 @@ ptrdiff_t firstNonZeroDigit(Const!(BigDigit)[] x)
     ptrdiff_t k = 0;
     while (x[k]==0) {
         ++k;
-        assert(k<x.length);
+        verify(k<x.length);
     }
     return k;
 }
@@ -1699,16 +1696,15 @@ Returns:
 */
 void recursiveDivMod(BigDigit[] quotient, BigDigit[] u, in BigDigit[] v,
                      BigDigit[] scratch)
-in {
-    assert(quotient.length == u.length - v.length);
-    assert(u.length <= 2 * v.length, "Asymmetric division"); // use base-case division to get it to this situation
-    assert(v.length > 1);
-    assert(u.length >= v.length);
-    assert((v[$ - 1] & 0x8000_0000) != 0);
-    assert(scratch.length >= quotient.length);
+{
+    verify(quotient.length == u.length - v.length);
+    verify(u.length <= 2 * v.length, "Asymmetric division"); // use base-case division to get it to this situation
+    verify(v.length > 1);
+    verify(u.length >= v.length);
+    verify((v[$ - 1] & 0x8000_0000) != 0);
+    verify(scratch.length >= quotient.length);
 
-}
-body {
+
     if(quotient.length < FASTDIVLIMIT) {
         return schoolbookDivMod(quotient, u, v);
     }
@@ -1729,7 +1725,7 @@ body {
 void adjustRemainder(BigDigit[] quot, BigDigit[] rem, in BigDigit[] v, int k,
                      BigDigit[] scratch)
 {
-    assert(rem.length == v.length);
+    verify(rem.length == v.length);
     mulInternal(scratch, quot, v[0 .. k]);
     uint carry = subAssignSimple(rem, scratch);
     while(carry) {
@@ -1741,10 +1737,10 @@ void adjustRemainder(BigDigit[] quot, BigDigit[] rem, in BigDigit[] v, int k,
 // Cope with unbalanced division by performing block schoolbook division.
 void fastDivMod(BigDigit [] quotient, BigDigit [] u, in BigDigit [] v)
 {
-    assert(quotient.length == u.length - v.length);
-    assert(v.length > 1);
-    assert(u.length >= v.length);
-    assert((v[$-1] & 0x8000_0000)!=0);
+    verify(quotient.length == u.length - v.length);
+    verify(v.length > 1);
+    verify(u.length >= v.length);
+    verify((v[$-1] & 0x8000_0000)!=0);
     BigDigit [] scratch = new BigDigit[v.length];
 
     // Perform block schoolbook division, with 'v.length' blocks.

--- a/src/ocean/math/random/Random.d
+++ b/src/ocean/math/random/Random.d
@@ -188,6 +188,7 @@ import ocean.math.random.NormalSource;
 import ocean.math.random.ExpSource;
 import ocean.math.Math;
 import ocean.core.Traits;
+import ocean.core.Verify;
 
 // ----- templateFu begin --------
 /// compile time integer power
@@ -440,8 +441,8 @@ final class RandomG(SourceT=DefaultEngine)
     /// uniform distribution on the range [0;to$(RPAREN) for integer types, and on
     /// the (0;to) range for floating point types. Same caveat as uniform(T) apply
     T uniformR(T,bool boundCheck=true)(T to)
-    in { assert(to>0,"empty range");}
-    body {
+    {
+        verify(to>0,"empty range");
         static if (is(T==uint) || is(T==int) || is(T==short) || is(T==ushort)
             || is(T==char) || is(T==byte) || is(T==ubyte))
         {
@@ -488,8 +489,8 @@ final class RandomG(SourceT=DefaultEngine)
     /// In here there is probably one of the few cases where c handling of modulo of negative
     /// numbers is handy
     T uniformRSymm(T,bool boundCheck=true, bool excludeZero=isFloat!(T))(T to,int iter=2000)
-    in { assert(to>0,"empty range");}
-    body {
+    {
+        verify(to>0,"empty range");
         static if (is(T==int)|| is(T==short) || is(T==byte)){
             int d=int.max/to,dTo=to*d;
             int nV=cast(int)source.next;
@@ -665,13 +666,11 @@ final class RandomG(SourceT=DefaultEngine)
     /// (it could be worked around using long aritmethic for int, and doing a carry by hand for long,
     /// but I think it is seldomly needed, for int you are better off using long when needed)
     T uniformR2(T,bool boundCheck=true)(T from,T to)
-    in {
-        assert(to>from,"empy range in uniformR2");
+    {
+        verify(to>from,"empy range in uniformR2");
         static if (is(T==int) || is(T==long)){
-            assert(from>T.min/2&&to<T.max/2," from..to range too big");
+            verify(from>T.min/2&&to<T.max/2," from..to range too big");
         }
-    }
-    body {
         static if (is(T==int)||is(T==long)||is(T==uint)||is(T==ulong)){
             return from+uniformR(to-from);
         } else static if (is(T==char) || is(T==byte) || is(T==ubyte) || is(T==short) || is(T==ushort)){
@@ -690,7 +689,7 @@ final class RandomG(SourceT=DefaultEngine)
     }
     /// returns a random element of the given array (which must be non empty)
     T uniformEl(T)(T[] arr){
-        assert(arr.length>0,"array has to be non empty");
+        verify(arr.length>0,"array has to be non empty");
         return arr[uniformR(arr.length)];
     }
 
@@ -750,8 +749,8 @@ final class RandomG(SourceT=DefaultEngine)
     *************************************************************************/
 
     U randomizeUniformR(U,V,bool boundCheck=true)(ref U a,V to)
-    in { assert((cast(BaseTypeOfArrays!(U))to)>0,"empty range");}
-    body {
+    {
+        verify((cast(BaseTypeOfArrays!(U))to)>0,"empty range");
         alias BaseTypeOfArrays!(U) T;
         static assert(is(V:T),"incompatible a and to type "~U.stringof~" "~V.stringof);
         static if (is(U S:S[])){
@@ -808,14 +807,12 @@ final class RandomG(SourceT=DefaultEngine)
     *************************************************************************/
 
     U randomizeUniformR2(U,V,W,bool boundCheck=true)(ref U a,V from, W to)
-    in {
+    {
         alias BaseTypeOfArrays!(U) T;
-        assert((cast(T)to)>(cast(T)from),"empy range in uniformR2");
+        verify((cast(T)to)>(cast(T)from),"empy range in uniformR2");
         static if (is(T==int) || is(T==long)){
-            assert(from>T.min/2&&to<T.max/2," from..to range too big");
+            verify(from>T.min/2&&to<T.max/2," from..to range too big");
         }
-    }
-    body {
         alias BaseTypeOfArrays!(U) T;
         static assert(is(V:T),"incompatible a and from type "~U.stringof~" "~V.stringof);
         static assert(is(W:T),"incompatible a and to type "~U.stringof~" "~W.stringof);
@@ -857,9 +854,9 @@ final class RandomG(SourceT=DefaultEngine)
     /// random numbers and speedwise)
     U randomizeUniformRSymm(U,V,bool boundCheck=true, bool excludeZero=isFloat!(BaseTypeOfArrays!(U)))
         (ref U a,V to)
-    in { assert((cast(BaseTypeOfArrays!(U))to)>0,"empty range");}
-    body {
+    {
         alias BaseTypeOfArrays!(U) T;
+        verify((cast(T)to)>0,"empty range");
         static assert(is(V:T),"incompatible a and to type "~U.stringof~" "~V.stringof);
         static if (is(U S:S[])){
             static if (is(T==int)|| is(T==byte)){
@@ -1043,7 +1040,7 @@ final class RandomG(SourceT=DefaultEngine)
             res.r=r;
             res.alpha=alpha;
             res.theta=theta;
-            assert(alpha>=cast(T)1,"implemented only for alpha>=1");
+            verify(alpha>=cast(T)1,"implemented only for alpha>=1");
             return res;
         }
         /// chainable call style initialization of variables (thorugh a call to randomize)
@@ -1053,8 +1050,8 @@ final class RandomG(SourceT=DefaultEngine)
         }
         /// returns a single random number
         T getRandom(T a=alpha,T t=theta)
-        in { assert(a>=cast(T)1,"implemented only for alpha>=1"); }
-        body {
+        {
+            verify(a>=cast(T)1,"implemented only for alpha>=1");
             T d=a-(cast(T)1)/(cast(T)3);
             T c=(cast(T)1)/sqrt(d*cast(T)9);
             auto n=r.normalSource!(T)();
@@ -1207,8 +1204,8 @@ final class RandomG(SourceT=DefaultEngine)
     /// from Marsaglia and Tsang, ACM Transaction on Mathematical Software, Vol. 26, N. 3
     /// 2000, p 363-372
     T gamma(T)(T alpha=cast(T)1,T sigma=cast(T)1)
-    in { assert(alpha>=cast(T)1,"implemented only for alpha>=1"); }
-    body {
+    {
+        verify(alpha>=cast(T)1,"implemented only for alpha>=1");
         auto n=normalSource!(T);
         T d=alpha-(cast(T)1)/(cast(T)3);
         T c=(cast(T)1)/sqrt(d*cast(T)9);

--- a/src/ocean/math/random/Random.d
+++ b/src/ocean/math/random/Random.d
@@ -453,7 +453,7 @@ final class RandomG(SourceT=DefaultEngine)
                     nV=source.next;
                     if (nV<dTo) break;
                 }
-                assert(nV<dTo,"this is less probable than 1.e-301, something is wrong with the random number generator");
+                verify(nV<dTo,"this is less probable than 1.e-301, something is wrong with the random number generator");
             }
             return cast(T)(nV%to);
         } else static if (is(T==ulong) || is(T==long)){
@@ -464,7 +464,7 @@ final class RandomG(SourceT=DefaultEngine)
                     nV=source.nextL;
                     if (nV<dTo) break;
                 }
-                assert(nV<dTo,"this is less probable than 1.e-301, something is wrong with the random number generator");
+                verify(nV<dTo,"this is less probable than 1.e-301, something is wrong with the random number generator");
             }
             return cast(T)(nV%to);
         } else static if (is(T==float)|| is(T==double)||is(T==real)){
@@ -506,7 +506,7 @@ final class RandomG(SourceT=DefaultEngine)
                     nV=cast(int)source.next;
                     if (nV<dTo && nV>-dTo) break;
                 }
-                assert(nV<dTo && nV>-dTo,"this is less probable than 1.e-301, something is wrong with the random number generator");
+                verify(nV<dTo && nV>-dTo,"this is less probable than 1.e-301, something is wrong with the random number generator");
                 return cast(T)(nV%to);
             }
         } else static if (is(T==long)){
@@ -524,7 +524,7 @@ final class RandomG(SourceT=DefaultEngine)
                     nV=source.nextL;
                     if (nV<dTo && nV>-dTo) break;
                 }
-                assert(nV<dTo && nV>-dTo,"this is less probable than 1.e-301, something is wrong with the random number generator");
+                verify(nV<dTo && nV>-dTo,"this is less probable than 1.e-301, something is wrong with the random number generator");
                 return nV%to;
             }
         } else static if (is(T==float)||is(T==double)||is(T==real)){
@@ -538,7 +538,7 @@ final class RandomG(SourceT=DefaultEngine)
                     static if (boundCheck){
                         if (res!=to) return (1-2*cast(int)(nV&1u))*res;
                         // to due to rounding (~3.e-8), 0 impossible with normal to values
-                        assert(iter>0,"error with the generator, probability < 10^(-8*2000)");
+                        verify(iter>0,"error with the generator, probability < 10^(-8*2000)");
                         return uniformRSymm(to,iter-1);
                     } else {
                         return (1-2*cast(int)(nV&1u))*res;
@@ -553,7 +553,7 @@ final class RandomG(SourceT=DefaultEngine)
                     T res=(cast(T)nV+cast(T)nV2*fact32)*scale*to;
                     static if (excludeZero){
                         if (res!=cast(T)0) return (1-2*cast(int)(nV&1u))*res;
-                        assert(iter>0,"error with the generator, probability < 10^(-8*2000)");
+                        verify(iter>0,"error with the generator, probability < 10^(-8*2000)");
                         return uniformRSymm(to,iter-1); // 0 due to underflow (<1.e-38), 1 impossible
                     } else {
                         return (1-2*cast(int)(nV&1u))*res;
@@ -569,7 +569,7 @@ final class RandomG(SourceT=DefaultEngine)
                     static if (boundCheck){
                         if (res!=to) return (1-2*cast(int)(nV&1UL))*res;
                         // to due to rounding (<1.e-16), 0 impossible with normal to values
-                        assert(iter>0,"error with the generator, probability < 10^(-16*2000)");
+                        verify(iter>0,"error with the generator, probability < 10^(-16*2000)");
                         return uniformRSymm(to,iter-1);
                     } else {
                         return (1-2*cast(int)(nV&1UL))*res;
@@ -592,7 +592,7 @@ final class RandomG(SourceT=DefaultEngine)
                         static if (excludeZero){
                             if (res!=cast(T)0) return (1-2*cast(int)(nV2&1UL))*res;
                             // 0 due to underflow (<1.e-307)
-                            assert(iter>0,"error with the generator, probability < 10^(-16*2000)");
+                            verify(iter>0,"error with the generator, probability < 10^(-16*2000)");
                             return uniformRSymm(to,iter-1);
                         } else {
                             return (1-2*cast(int)(nV2&1UL))*res;
@@ -610,7 +610,7 @@ final class RandomG(SourceT=DefaultEngine)
                     static if (boundCheck){
                         if (res!=to) return (1-2*cast(int)(nL&1UL))*res;
                         // 1 due to rounding (<1.e-16), 0 impossible with normal to values
-                        assert(iter>0,"error with the generator, probability < 10^(-16*2000)");
+                        verify(iter>0,"error with the generator, probability < 10^(-16*2000)");
                         return uniformRSymm(to,iter-1);
                     } else {
                         return (1-2*cast(int)(nL&1UL))*res;
@@ -627,7 +627,7 @@ final class RandomG(SourceT=DefaultEngine)
                     static if (excludeZero){
                         if (res!=cast(T)0) return ((nL&1UL)?res:-res);
                         // 0 due to underflow (<1.e-4932), 1 impossible
-                        assert(iter>0,"error with the generator, probability < 10^(-16*2000)");
+                        verify(iter>0,"error with the generator, probability < 10^(-16*2000)");
                         return uniformRSymm(to,iter-1);
                     } else {
                         return ((nL&1UL)?res:-res);
@@ -652,7 +652,7 @@ final class RandomG(SourceT=DefaultEngine)
                 static if (boundCheck){
                     if (res!=to && res!=cast(T)0) return ((nL&1UL)?res:-res);
                     // 1 due to rounding (<1.e-16), 0 impossible with normal to values
-                    assert(iter>0,"error with the generator, probability < 10^(-16*2000)");
+                    verify(iter>0,"error with the generator, probability < 10^(-16*2000)");
                     return uniformRSymm(to,iter-1);
                 } else {
                     return ((nL&1UL)?res:-res);
@@ -766,7 +766,7 @@ final class RandomG(SourceT=DefaultEngine)
                             nV=source.next;
                             if (nV<dTo) break;
                         }
-                        assert(nV<dTo,"this is less probable than 1.e-301, something is wrong with the random number generator");
+                        verify(nV<dTo,"this is less probable than 1.e-301, something is wrong with the random number generator");
                         *aPtr=cast(T)(nV % cast(uint)to);
                     }
                 }
@@ -782,7 +782,7 @@ final class RandomG(SourceT=DefaultEngine)
                             nV=source.nextL;
                             if (nV<dTo) break;
                         }
-                        assert(nV<dTo,"this is less probable than 1.e-301, something is wrong with the random number generator");
+                        verify(nV<dTo,"this is less probable than 1.e-301, something is wrong with the random number generator");
                         el=cast(T)(nV% cast(ulong)to);
                     }
                 }
@@ -876,7 +876,7 @@ final class RandomG(SourceT=DefaultEngine)
                             nV=cast(int)source.next;
                             if (nV<dTo&&nV>-dTo) break;
                         }
-                        assert(nV<dTo && nV>-dTo,"this is less probable than 1.e-301, something is wrong with the random number generator");
+                        verify(nV<dTo && nV>-dTo,"this is less probable than 1.e-301, something is wrong with the random number generator");
                         *aPtr=cast(T)(nV% cast(int)to);
                     }
                 }
@@ -897,7 +897,7 @@ final class RandomG(SourceT=DefaultEngine)
                             nV=source.nextL;
                             if (nV<dTo && nV>-dTo) break;
                         }
-                        assert(nV<dTo && nV>-dTo,"this is less probable than 1.e-301, something is wrong with the random number generator");
+                        verify(nV<dTo && nV>-dTo,"this is less probable than 1.e-301, something is wrong with the random number generator");
                         *aPtr=nV% cast(T)to;
                     }
                 }

--- a/src/ocean/math/random/Random.d
+++ b/src/ocean/math/random/Random.d
@@ -1293,6 +1293,7 @@ version (UnitTest)
     import ocean.math.random.engines.KISS;
     import ocean.math.random.engines.CMWC;
     import core.stdc.stdio:printf;
+    import ocean.core.Test;
 
     /// very simple statistal test, mean within maxOffset, and maximum/minimum at least minmax/maxmin
     bool checkMean(T)(T[] a, real maxmin, real minmax, real expectedMean, real maxOffset,bool alwaysPrint=false,bool checkB=false){
@@ -1302,7 +1303,7 @@ version (UnitTest)
             minV=a[0];
             maxV=a[0];
             foreach (el;a){
-                assert(!checkB || (cast(T)0<el && el<cast(T)1),"el out of bounds");
+                test(!checkB || (cast(T)0<el && el<cast(T)1),"el out of bounds");
                 if (el<minV) minV=el;
                 if (el>maxV) maxV=el;
                 meanV+=cast(real)el;
@@ -1352,11 +1353,11 @@ version (UnitTest)
             int count=10_000;
             for (int i=count;i!=0;--i){
                 float f=r.uniform!(float);
-                assert(0<f && f<1,"float out of bounds");
+                test(0<f && f<1,"float out of bounds");
                 double d=r.uniform!(double);
-                assert(0<d && d<1,"double out of bounds");
+                test(0<d && d<1,"double out of bounds");
                 real rr=r.uniform!(real);
-                assert(0<rr && rr<1,"double out of bounds");
+                test(0<rr && rr<1,"double out of bounds");
             }
             // checkpoint status (str)
             auto status=r.toString();
@@ -1468,13 +1469,13 @@ version (UnitTest)
             r.seed({ return 2*(seed++); });
             auto v2 = r.uniform!(int)();
 
-            assert(v1 == v2, "Re-seed failure: " ~ RandS.stringof);
+            test!("==")(v1, v2, "Re-seed failure: " ~ RandS.stringof);
 
             r.fromString(status);
-            assert(r.uniform!(uint)==tVal,"restoring of status from str failed");
-            assert(r.uniform!(ubyte)==t2Val,"restoring of status from str failed");
-            assert(r.uniform!(ulong)==t3Val,"restoring of status from str failed");
-            assert(!gFail,"Random.d failure");
+            test!("==")(r.uniform!(uint),tVal,"restoring of status from str failed");
+            test!("==")(r.uniform!(ubyte),t2Val,"restoring of status from str failed");
+            test!("==")(r.uniform!(ulong),t3Val,"restoring of status from str failed");
+            test(!gFail,"Random.d failure");
         } catch(Exception e) {
             throw e;
         }

--- a/src/ocean/math/random/Ziggurat.d
+++ b/src/ocean/math/random/Ziggurat.d
@@ -19,6 +19,7 @@ import ocean.math.Bracket:findRoot;
 import ocean.math.Math:abs;
 import ocean.math.ErrorFunction:erfc;
 import ocean.core.Traits;
+import ocean.core.Verify;
 
 /// ziggurat method for decreasing distributions.
 /// Marsaglia, Tsang, Journal of Statistical Software, 2000
@@ -46,7 +47,7 @@ struct Ziggurat(RandG,T,alias probDensityF,alias tailGenerator,bool hasNegative=
                 fAtt+=v/pAtt;
                 if (fAtt>fMax) return fAtt+(i-1)*fMax;
                 pAtt=invProbDensityF(fAtt);
-                assert(pAtt>=0,"invProbDensityF is supposed to return positive values");
+                verify(pAtt>=0,"invProbDensityF is supposed to return positive values");
             }
             return fAtt+v/pAtt-fMax;
         }
@@ -84,21 +85,21 @@ struct Ziggurat(RandG,T,alias probDensityF,alias tailGenerator,bool hasNegative=
             fVal[1]=cast(T)fAtt;
             for (int i=2;i<nBlocks;++i){
                 fAtt+=v/pAtt;
-                assert(fAtt<=fMax,"Ziggurat contruction shoot out");
+                verify(fAtt<=fMax,"Ziggurat contruction shoot out");
                 pAtt=invProbDensityF(fAtt);
-                assert(pAtt>=0,"invProbDensityF is supposed to return positive values");
+                verify(pAtt>=0,"invProbDensityF is supposed to return positive values");
                 posBlock[i]=cast(T)pAtt;
                 fVal[i]=cast(T)fAtt;
             }
             posBlock[nBlocks]=0.0L;
             fVal[nBlocks]=cast(T)probDensityF(0.0L);
             real error=fAtt+v/pAtt-probDensityF(0.0L);
-            assert((!check_error) || error<real.epsilon*10000.0,"Ziggurat error larger than expected");
+            verify((!check_error) || error<real.epsilon*10000.0,"Ziggurat error larger than expected");
             posBlock[0]=cast(T)(xLast*(1.0L+cumProbDensityFCompl(xLast)/probDensityF(xLast)));
             fVal[0]=0.0L;
             for (int i=0;i<nBlocks;++i){
-                assert(posBlock[i]>=posBlock[i+1],"decresing posBlock");
-                assert(fVal[i]<=fVal[i+1],"increasing probabilty density function");
+                verify(posBlock[i]>=posBlock[i+1],"decresing posBlock");
+                verify(fVal[i]<=fVal[i+1],"increasing probabilty density function");
             }
         }
         return res;

--- a/src/ocean/math/random/engines/ArraySource.d
+++ b/src/ocean/math/random/engines/ArraySource.d
@@ -16,6 +16,8 @@
 *******************************************************************************/
 module ocean.math.random.engines.ArraySource;
 
+import ocean.core.Verify;
+
 /*******************************************************************************
 
     very simple array based source (use with care, some methods in non uniform
@@ -30,15 +32,15 @@ struct ArraySource{
     const int canSeed=false;
 
     static ArraySource opCall(uint[] a,size_t i=0)
-    in { assert(a.length>0,"array needs at least one element"); }
-    body {
+    {
+        verify(a.length>0,"array needs at least one element");
         ArraySource res;
         res.a=a;
         res.i=i;
         return res;
     }
     uint next(){
-        assert(a.length>i,"error, array out of bounds");
+        verify(a.length>i,"error, array out of bounds");
         uint el=a[i];
         i=(i+1)%a.length;
         return el;

--- a/src/ocean/math/random/engines/CMWC.d
+++ b/src/ocean/math/random/engines/CMWC.d
@@ -17,6 +17,7 @@
 module ocean.math.random.engines.CMWC;
 import ocean.transition;
 import Integer=ocean.text.convert.Integer_tango;
+import ocean.core.Verify;
 
 /+ CMWC a random number generator,
 + Marisaglia, Journal of Modern Applied Statistical Methods (2003), vol.2,No.1,p 2-13
@@ -120,7 +121,7 @@ struct CMWC(uint cmwc_r=1024U,ulong cmwc_a=987769338UL){
             Integer.format(res[i..i+8],val,"x8");
             i+=8;
         }
-        assert(i==res.length,"unexpected size");
+        verify(i==res.length,"unexpected size");
         return assumeUnique(res);
     }
     /// reads the current status from a string (that should have been trimmed)
@@ -128,28 +129,28 @@ struct CMWC(uint cmwc_r=1024U,ulong cmwc_a=987769338UL){
     size_t fromString(cstring s){
         char[16] tmpC;
         size_t i=0;
-        assert(s[i..i+4]=="CMWC","unexpected kind, expected CMWC");
+        verify(s[i..i+4]=="CMWC","unexpected kind, expected CMWC");
         i+=4;
-        assert(s[i..i+16]==Integer.format(tmpC,cmwc_a,"x16"),"unexpected cmwc_a");
+        verify(s[i..i+16]==Integer.format(tmpC,cmwc_a,"x16"),"unexpected cmwc_a");
         i+=16;
-        assert(s[i]=='_',"unexpected format, expected _");
+        verify(s[i]=='_',"unexpected format, expected _");
         i++;
-        assert(s[i..i+8]==Integer.format(tmpC,cmwc_r,"x8"),"unexpected cmwc_r");
+        verify(s[i..i+8]==Integer.format(tmpC,cmwc_r,"x8"),"unexpected cmwc_r");
         i+=8;
         foreach (ref val;cmwc_q){
-            assert(s[i]=='_',"no separator _ found");
+            verify(s[i]=='_',"no separator _ found");
             ++i;
             uint ate;
             val=cast(uint)Integer.convert(s[i..i+8],16,&ate);
-            assert(ate==8,"unexpected read size");
+            verify(ate==8,"unexpected read size");
             i+=8;
         }
         foreach (val;[&cmwc_i,&cmwc_c,&nBytes,&restB]){
-            assert(s[i]=='_',"no separator _ found");
+            verify(s[i]=='_',"no separator _ found");
             ++i;
             uint ate;
             *val=cast(uint)Integer.convert(s[i..i+8],16,&ate);
-            assert(ate==8,"unexpected read size");
+            verify(ate==8,"unexpected read size");
             i+=8;
         }
         return i;

--- a/src/ocean/math/random/engines/KISS.d
+++ b/src/ocean/math/random/engines/KISS.d
@@ -17,6 +17,7 @@
 module ocean.math.random.engines.KISS;
 import ocean.transition;
 import Integer = ocean.text.convert.Integer_tango;
+import ocean.core.Verify;
 
 /+ Kiss99 random number generator, by Marisaglia
 + a simple RNG that passes all statistical tests
@@ -91,22 +92,22 @@ struct Kiss99{
             Integer.format(res[i..i+8],val,"x8");
             i+=8;
         }
-        assert(i==res.length,"unexpected size");
+        verify(i==res.length,"unexpected size");
         return assumeUnique(res);
     }
     /// reads the current status from a string (that should have been trimmed)
     /// returns the number of chars read
     size_t fromString(cstring s){
         size_t i=0;
-        assert(s[i..i+4]=="KISS","unexpected kind, expected KISS");
-        assert(s[i+4..i+7]=="99_","unexpected version, expected 99");
+        verify(s[i..i+4]=="KISS","unexpected kind, expected KISS");
+        verify(s[i+4..i+7]=="99_","unexpected version, expected 99");
         i+=6;
         foreach (val;[&kiss_x,&kiss_y,&kiss_z,&kiss_c,&nBytes,&restB]){
-            assert(s[i]=='_',"no separator _ found");
+            verify(s[i]=='_',"no separator _ found");
             ++i;
             uint ate;
             *val=cast(uint)Integer.convert(s[i..i+8],16,&ate);
-            assert(ate==8,"unexpected read size");
+            verify(ate==8,"unexpected read size");
             i+=8;
         }
         return i;

--- a/src/ocean/math/random/engines/KissCmwc.d
+++ b/src/ocean/math/random/engines/KissCmwc.d
@@ -18,6 +18,7 @@
 module ocean.math.random.engines.KissCmwc;
 import ocean.transition;
 import Integer = ocean.text.convert.Integer_tango;
+import ocean.core.Verify;
 
 /+ CMWC and KISS random number generators combined, for extra security wrt. plain CMWC and
 + Marisaglia, Journal of Modern Applied Statistical Methods (2003), vol.2,No.1,p 2-13
@@ -151,7 +152,7 @@ struct KissCmwc(uint cmwc_r=1024U,ulong cmwc_a=987769338UL){
             Integer.format(res[i..i+8],val,"x8");
             i+=8;
         }
-        assert(i==res.length,"unexpected size");
+        verify(i==res.length,"unexpected size");
         return assumeUnique(res);
     }
     /// reads the current status from a string (that should have been trimmed)
@@ -159,28 +160,28 @@ struct KissCmwc(uint cmwc_r=1024U,ulong cmwc_a=987769338UL){
     size_t fromString(cstring s){
         char[16] tmpC;
         size_t i=0;
-        assert(s[i..i+11]=="CMWC+KISS99","unexpected kind, expected CMWC+KISS99");
+        verify(s[i..i+11]=="CMWC+KISS99","unexpected kind, expected CMWC+KISS99");
         i+=11;
-        assert(s[i..i+16]==Integer.format(tmpC,cmwc_a,"x16"),"unexpected cmwc_a");
+        verify(s[i..i+16]==Integer.format(tmpC,cmwc_a,"x16"),"unexpected cmwc_a");
         i+=16;
-        assert(s[i]=='_',"unexpected format, expected _");
+        verify(s[i]=='_',"unexpected format, expected _");
         i++;
-        assert(s[i..i+8]==Integer.format(tmpC,cmwc_r,"x8"),"unexpected cmwc_r");
+        verify(s[i..i+8]==Integer.format(tmpC,cmwc_r,"x8"),"unexpected cmwc_r");
         i+=8;
         foreach (ref val;cmwc_q){
-            assert(s[i]=='_',"no separator _ found");
+            verify(s[i]=='_',"no separator _ found");
             ++i;
             uint ate;
             val=cast(uint)Integer.convert(s[i..i+8],16,&ate);
-            assert(ate==8,"unexpected read size");
+            verify(ate==8,"unexpected read size");
             i+=8;
         }
         foreach (val;[&cmwc_i,&cmwc_c,&nBytes,&restB,&kiss_x,&kiss_y,&kiss_z,&kiss_c]){
-            assert(s[i]=='_',"no separator _ found");
+            verify(s[i]=='_',"no separator _ found");
             ++i;
             uint ate;
             *val=cast(uint)Integer.convert(s[i..i+8],16,&ate);
-            assert(ate==8,"unexpected read size");
+            verify(ate==8,"unexpected read size");
             i+=8;
         }
         return i;

--- a/src/ocean/math/random/engines/Twister.d
+++ b/src/ocean/math/random/engines/Twister.d
@@ -21,6 +21,7 @@
 module ocean.math.random.engines.Twister;
 import ocean.transition;
 import Integer = ocean.text.convert.Integer_tango;
+import ocean.core.Verify;
 
 /*******************************************************************************
 
@@ -169,26 +170,26 @@ struct Twister
             Integer.format(res[i..i+8],val,"x8");
             i+=8;
         }
-        assert(i==res.length,"unexpected size");
+        verify(i==res.length,"unexpected size");
         return assumeUnique(res);
     }
     /// reads the current status from a string (that should have been trimmed)
     /// returns the number of chars read
     size_t fromString(cstring s){
         size_t i;
-        assert(s[0..7]=="Twister","unexpected kind, expected Twister");
+        verify(s[0..7]=="Twister","unexpected kind, expected Twister");
         i+=7;
-        assert(s[i]=='_',"no separator _ found");
+        verify(s[i]=='_',"no separator _ found");
         ++i;
         uint ate;
         mti=cast(uint)Integer.convert(s[i..i+8],16,&ate);
-        assert(ate==8,"unexpected read size");
+        verify(ate==8,"unexpected read size");
         i+=8;
         foreach (ref val;mt){
-            assert(s[i]=='_',"no separator _ found");
+            verify(s[i]=='_',"no separator _ found");
             ++i;
             val=cast(uint)Integer.convert(s[i..i+8],16,&ate);
-            assert(ate==8,"unexpected read size");
+            verify(ate==8,"unexpected read size");
             i+=8;
         }
         return i;

--- a/src/ocean/math/random/engines/URandom.d
+++ b/src/ocean/math/random/engines/URandom.d
@@ -25,6 +25,7 @@ version(solaris){ version=has_urandom; }
 version(has_urandom) {
     import Integer = ocean.text.convert.Integer_tango;
     import ocean.io.device.File; // use stdc read/write?
+    import ocean.core.Verify;
 
     /// basic source that takes data from system random device
     /// This is an engine, do not use directly, use RandomG!(Urandom)
@@ -91,7 +92,7 @@ version(has_urandom) {
         /// returns the number of chars read
         size_t fromString(cstring s){
             auto r="URandom";
-            assert(s[0.. r.length]==r,"unxepected string instad of URandom:"~s);
+            verify(s[0.. r.length]==r,"unxepected string instad of URandom:"~idup(s));
             return r.length;
         }
     }


### PR DESCRIPTION
I grouped them by topic:
- Function argument validation and unittests are straight-forward.
- Internal sanity checking are cases where `assert` might actually be correct but I'm not perfectly sure.
- Conversion of `assert(0)` to `static assert(0)` is for functions that support x86-64 but had an `assert(0)` for some other unsupported architecture.
- Conversion of `assert(0)` to `throw new SanityException` for disabled functions is for functions that don't support x86-64. `static assert(0)` cannot be used because the module wouldn't compile then. These functions are useless for us and should be removed (or fixed/extended to support x86-64 if it's worth it).
- Extremely unlikely RNG conditions are obscure, take a look yourself.