### PR TITLE
Fixes and unit tests for the XML generator

### DIFF
--- a/relnotes/document.feature.md
+++ b/relnotes/document.feature.md
@@ -1,0 +1,4 @@
+* `ocean.text.xml.Document`
+
+  Copy the names and values to the node arrays rather than using slices. This
+  prevents accidental overwriting of values.

--- a/relnotes/document.feature.md
+++ b/relnotes/document.feature.md
@@ -2,3 +2,6 @@
 
   Copy the names and values to the node arrays rather than using slices. This
   prevents accidental overwriting of values.
+
+  Added a new `header` method that uses a constant string as the header string
+  which means the method does not allocate memory.

--- a/src/ocean/text/xml/Document.d
+++ b/src/ocean/text/xml/Document.d
@@ -17,6 +17,7 @@
 
 module ocean.text.xml.Document;
 
+import Array = ocean.core.Array;
 import ocean.transition;
 
 package import ocean.text.xml.PullParser;
@@ -409,9 +410,12 @@ else
                 p.lastChild =
                 p.firstAttr =
                 p.lastAttr = null;
-                p.rawValue =
-                p.localName =
-                p.prefixed = null;
+                p.rawValue.length = 0;
+                enableStomping(p.rawValue);
+                p.localName.length = 0;
+                enableStomping(p.localName);
+                p.prefixed.length = 0;
+                enableStomping(p.prefixed);
 }
                 return p;
         }
@@ -588,9 +592,9 @@ version (Filter)
                 public void*            user;           /// open for usage
                 package Document        doc;            // owning document
                 package XmlNodeType     id;             // node type
-                package T[]             prefixed;       // namespace
-                package T[]             localName;      // name
-                package T[]             rawValue;       // data value
+                package MutT[]          prefixed;       // namespace
+                package MutT[]          localName;      // name
+                package MutT[]          rawValue;       // data value
 
                 package Node            host,           // parent node
                                         prevSibling,    // prior
@@ -688,7 +692,7 @@ version (Filter)
 
                 Node prefix (T[] replace)
                 {
-                        prefixed = replace;
+                        Array.copy(this.prefixed, replace);
                         return this;
                 }
 
@@ -711,7 +715,7 @@ version (Filter)
 
                 Node name (T[] replace)
                 {
-                        localName = replace;
+                        Array.copy(this.localName, replace);
                         return this;
                 }
 
@@ -749,7 +753,7 @@ version(discrete)
                                      if (child.id is XmlNodeType.Data)
                                          return child.value (val);
 }
-                        rawValue = val;
+                        Array.copy(this.rawValue, val);
                         mutate;
                 }
 
@@ -992,7 +996,7 @@ version(discrete)
 }
 else
 {
-                        node.rawValue = value;
+                        Array.copy(node.rawValue, value);
 }
                         return node;
                 }
@@ -1141,8 +1145,8 @@ else
 
                 private Node set (T[] prefix, T[] local)
                 {
-                        this.localName = local;
-                        this.prefixed = prefix;
+                        Array.copy(this.localName, local);
+                        Array.copy(this.prefixed, prefix);
                         return this;
                 }
 
@@ -1155,7 +1159,7 @@ else
                 private Node create (XmlNodeType type, T[] value)
                 {
                         auto node = document.allocate;
-                        node.rawValue = value;
+                        Array.copy(node.rawValue, value);
                         node.id = type;
                         return node;
                 }

--- a/src/ocean/text/xml/Document.d
+++ b/src/ocean/text/xml/Document.d
@@ -272,7 +272,24 @@ version(d)
 
         ***********************************************************************/
 
-        final Document header (Immut!(T)[] encoding = null)
+        final Document header ()
+        {
+                const header = `xml version="1.0" encoding="UTF-8"`;
+                root.prepend (root.create(XmlNodeType.PI, header));
+                return this;
+        }
+
+        /***********************************************************************
+
+                Prepend an XML header to the document tree. Note that this
+                method currently allocates.
+
+                Params:
+                    encoding = the encoding of the xml document
+
+        ***********************************************************************/
+
+        final Document header (Immut!(T)[] encoding)
         {
                 if (encoding.length)
                     encoding = `xml version="1.0" encoding="`~encoding~`"`;

--- a/src/ocean/text/xml/Document.d
+++ b/src/ocean/text/xml/Document.d
@@ -2111,13 +2111,13 @@ unittest
     auto printer = new DocPrinter!(char);
     mstring buffer;
 
-    auto doc1 = `
+    auto doc1 = `<?xml version="1.0" encoding="UTF-8"?>
 <root>123456789
   <second>second</second>
   <third>third</third>
 </root>`;
 
-    auto doc2 = `
+    auto doc2 = `<?xml version="1.0" encoding="UTF-8"?>
 <root>12345
   <one>one</one>
   <two>two</two>
@@ -2130,6 +2130,8 @@ unittest
         // elements do not just slice the input but actually copy it to the
         // elements.
         Array.copy(buffer, root_value);
+
+        doc.header();
 
         auto root = doc.tree.element(null, "root", buffer);
 


### PR DESCRIPTION
Previously the XML generator would slice the values that were passed through for each node. This meant that if you added multiple nodes with different strings from the same buffer the values would be over written.

Additionally the module was missing any unit tests that were actually run.