### PR TITLE
Rework logger test to not rely on state

### DIFF
--- a/src/ocean/util/log/Logger.d
+++ b/src/ocean/util/log/Logger.d
@@ -988,7 +988,7 @@ unittest
     const TestStr = "Ce qui se conçoit bien s'énonce clairement - Et les mots pour le dire arrivent aisément";
     scope appender = new Buffer();
     char[32] log_buffer;
-    Logger log = Log.lookup("ocean.util.log.Logger.TestLogTrim")
+    Logger log = (new Logger(Log.hierarchy(), "dummy"))
         .add(appender).buffer(log_buffer);
     log.info("{}", TestStr);
     log.error(TestStr);


### PR DESCRIPTION
Previosuly test case would fail if some other module configures log
system in module constructor in some incompatible way.