### PR TITLE
Version out TypeInfo_Typedef references in D2

### DIFF
--- a/src/ocean/core/RuntimeTraits.d
+++ b/src/ocean/core/RuntimeTraits.d
@@ -34,7 +34,7 @@ TypeInfo realType (TypeInfo type)
         // makes use of realType to strip away qualifiers instead of adding
         // workaround to all other functions
 
-        auto def = cast(TypeInfo_Typedef) type;
+        auto def = cast(TypeInfo_Enum) type;
         if (def !is null)
         {
             return def.base;

--- a/src/ocean/text/convert/Layout_tango.d
+++ b/src/ocean/text/convert/Layout_tango.d
@@ -822,8 +822,12 @@ class Layout(T)
         if (cast(TypeInfo_Enum) tinfo)
             return dispatch (result, format, (cast(TypeInfo_Enum) tinfo).base, p);
 
-        if (cast(TypeInfo_Typedef) tinfo)
-            return dispatch (result, format, (cast(TypeInfo_Typedef) tinfo).base, p);
+        version (D_Version2) {}
+        else
+        {
+            if (cast(TypeInfo_Typedef) tinfo)
+                return dispatch (result, format, (cast(TypeInfo_Typedef) tinfo).base, p);
+        }
 
         if (auto s = cast(TypeInfo_Struct) tinfo)
         {


### PR DESCRIPTION
It was removed from D2 in 2.076.1.
Since TypeInfo_Enum inherited from it, the fix in RuntimeTraits is just to keep things working.
RuntimeTraits is only used by Layout_Tango and will be killed with it.