### PR TITLE
Import core.stdc.stdarg in Layout[_tango]

### DIFF
--- a/src/ocean/text/convert/Layout.d
+++ b/src/ocean/text/convert/Layout.d
@@ -50,6 +50,7 @@ import ocean.util.container.AppendBuffer;
 
 import TangoLayout = ocean.text.convert.Layout_tango;
 
+import core.stdc.stdarg;
 
 /*******************************************************************************
 

--- a/src/ocean/text/convert/Layout_tango.d
+++ b/src/ocean/text/convert/Layout_tango.d
@@ -46,6 +46,7 @@ import Float = ocean.text.convert.Float,
 
 import ocean.io.model.IConduit : OutputStream;
 
+import core.stdc.stdarg;
 
 /*******************************************************************************
 


### PR DESCRIPTION
```
Some application failed to compile in a D2 production build.
It was traced to StatsLog, which still calls Layout.opCall, which uses typesafe variadic args.
Importing this module unconditionally should fix it.
```

This was broken somewhere in there: https://github.com/sociomantic-tsunami/ocean/compare/72435ad82ba68ca4e29f4362c15449dd9905d35d...88affe5b74eecd8f548de0555990eb6f8ac8725c
My guess is either [this commit](https://github.com/sociomantic-tsunami/ocean/commit/e460041f199c4691258058861eeb4d9749b5c1ca) or [this one](https://github.com/sociomantic-tsunami/ocean/commit/0b237fd1c8139d69e302c02c3d531d0e3f695b1c#diff-49c6afdbaf097650e380809fa3a6be59), which changed a lot of imports.