### PR TITLE
Start adding v3 based versions to LibFeatures

### DIFF
--- a/src/ocean/LibFeatures.d
+++ b/src/ocean/LibFeatures.d
@@ -17,6 +17,7 @@
 
 module ocean.LibFeatures;
 
+const has_features_3_3 = true;
 const has_features_2_9 = true;
 const has_features_2_8 = true;
 const has_features_2_7 = true;


### PR DESCRIPTION
Now that v2.x.x is not supported anymore, having few versio
overlap should simplify things for downstream.