### PR TITLE
 Deprecate thin wrappers in ocean.core and VersionIdentifiers

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -27,7 +27,11 @@ clean += .*.lst
 TEST_FILTER_OUT += \
 	$C/src/ocean/io/Stdout_tango.d \
 	$C/src/ocean/io/FilePath_tango.d \
+	$C/src/ocean/core/Runtime.d \
+	$C/src/ocean/core/Thread.d \
 	$C/src/ocean/core/Traits_tango.d \
+	$C/src/ocean/core/Vararg.d \
+	$C/src/ocean/core/VersionIdentifiers.d \
 	$C/src/ocean/core/Exception_tango.d \
 	$C/src/ocean/io/device/SerialPort.d \
 	$C/src/ocean/io/device/ProgressFile.d \

--- a/relnotes/core-wrapper.deprecation.md
+++ b/relnotes/core-wrapper.deprecation.md
@@ -1,0 +1,10 @@
+* `ocean.core.Runtime`, `ocean.core.Thread`, `ocean.core.Vararg`
+
+  Those modules were deprecated, as they are nothing but thin wrapper around runtime modules.
+  Import `core.runtime`, `core.thread` or `core.stdc.stdarg` instead.
+
+* `ocean.core.VersionIdentifiers`
+
+  This module holds a functionality which was MakD specific and has long been moved there.
+  It's not expected to be of any interest to application, and if needed MakD's `Version`
+  module can be imported, or if not suitable, it can be trivially replicated.

--- a/src/ocean/core/MessageFiber.d
+++ b/src/ocean/core/MessageFiber.d
@@ -58,10 +58,10 @@ module ocean.core.MessageFiber;
 
 import ocean.transition;
 import ocean.core.Verify;
-import ocean.core.Thread : Fiber;
 import ocean.core.Array: copy;
 import ocean.core.SmartUnion;
 import ocean.io.digest.Fnv1;
+import core.thread : Fiber;
 
 debug ( MessageFiber )
 {

--- a/src/ocean/core/MessageFiber.d
+++ b/src/ocean/core/MessageFiber.d
@@ -73,7 +73,7 @@ debug ( MessageFiberDump )
 {
     import ocean.time.Clock;
     import ocean.core.Array;
-    import ocean.core.Memory;
+    import core.memory;
     import ocean.io.Stdout;
     debug = MessageFiberToken;
 }

--- a/src/ocean/core/Runtime.d
+++ b/src/ocean/core/Runtime.d
@@ -13,6 +13,8 @@
  * Authors: Sean Kelly
  *
  */
-module ocean.core.Runtime;
+deprecated module ocean.core.Runtime;
+
+pragma(msg, "Import core.runtime instead of ocean.core.Runtime");
 
 public import core.runtime;

--- a/src/ocean/core/Thread.d
+++ b/src/ocean/core/Thread.d
@@ -20,7 +20,8 @@
  * Authors: Sean Kelly, Fawzi Mohamed
  *
  */
-module ocean.core.Thread;
+deprecated module ocean.core.Thread;
+
+pragma(msg, "Import core.thread instead of ocean.core.Thread");
 
 public import core.thread;
-

--- a/src/ocean/core/UnitTestRunner.d
+++ b/src/ocean/core/UnitTestRunner.d
@@ -77,7 +77,6 @@ else
     import core.sys.posix.sys.time: timersub;
 }
 
-import ocean.core.Runtime: Runtime;
 import ocean.core.ExceptionDefinitions : AssertException;
 import ocean.io.Stdout: Stdout, Stderr;
 import ocean.io.stream.Format: FormatOutput;
@@ -87,7 +86,7 @@ import ocean.text.xml.DocPrinter: DocPrinter;
 import ocean.text.convert.Formatter;
 import ocean.core.Test: TestException, test;
 import core.memory;
-
+import core.runtime: Runtime;
 
 
 /******************************************************************************

--- a/src/ocean/core/Vararg.d
+++ b/src/ocean/core/Vararg.d
@@ -18,22 +18,5 @@
  */
 module ocean.core.Vararg;
 
-version (DigitalMars) version (X86_64) version = DigitalMarsX64;
-version (X86)
-{
-    alias void* va_list;
 
-    template va_arg(T)
-    {
-        T va_arg(ref va_list _argptr)
-        {
-            T arg = *cast(T*)_argptr;
-            _argptr = _argptr + ((T.sizeof + int.sizeof - 1) & ~(int.sizeof - 1));
-            return arg;
-        }
-    }
-}
-else
-{
-    public import core.stdc.stdarg;
-}
+public import core.stdc.stdarg;

--- a/src/ocean/core/Vararg.d
+++ b/src/ocean/core/Vararg.d
@@ -16,7 +16,8 @@
  * Authors: Hauke Duden, Walter Bright
  *
  */
-module ocean.core.Vararg;
+deprecated module ocean.core.Vararg;
 
+pragma(msg, "Import core.stdc.stdarg instead of ocean.core.Vararg");
 
 public import core.stdc.stdarg;

--- a/src/ocean/core/VersionIdentifiers.d
+++ b/src/ocean/core/VersionIdentifiers.d
@@ -13,7 +13,7 @@
 
 *******************************************************************************/
 
-module ocean.core.VersionIdentifiers;
+deprecated module ocean.core.VersionIdentifiers;
 
 
 import ocean.transition;
@@ -29,6 +29,7 @@ import ocean.transition;
 
 *******************************************************************************/
 
+deprecated("Use MakD's Version module to get this information")
 public void versionIdentifiers ( void delegate ( istring version_name ) dg )
 {
     mixin(Version!("DigitalMars", "dg"));
@@ -98,4 +99,3 @@ private template Version ( istring version_name, istring func_name )
     const Version = "version(" ~ version_name ~ ")"
         ~ func_name ~ `("` ~ version_name ~ `");`;
 }
-

--- a/src/ocean/io/Stdout.d
+++ b/src/ocean/io/Stdout.d
@@ -37,42 +37,12 @@ import ocean.io.Console;
 
 import ocean.text.convert.Layout_tango;
 
+import core.stdc.stdarg;
 
+alias void* Arg;
+alias va_list ArgList;
 
-/*******************************************************************************
-
- Platform issues ...
-
-*******************************************************************************/
-
-version (GNU)
-{
-    import ocean.core.Vararg;
-
-    alias void* Arg;
-    alias va_list ArgList;
-}
-else version (LDC)
-{
-    import ocean.core.Vararg;
-
-    alias void* Arg;
-    alias va_list ArgList;
-}
-else version (DigitalMars)
-{
-    import ocean.core.Vararg;
-
-    alias void* Arg;
-    alias va_list ArgList;
-
-    version (X86_64) version = DigitalMarsX64;
-}
-else
-{
-    alias void* Arg;
-    alias void* ArgList;
-}
+version (X86_64) version = DigitalMarsX64;
 
 /*******************************************************************************
 

--- a/src/ocean/io/device/Conduit.d
+++ b/src/ocean/io/device/Conduit.d
@@ -17,12 +17,11 @@
 
 module ocean.io.device.Conduit;
 
-import ocean.transition;
-
-import ocean.core.Thread;
 import ocean.core.ExceptionDefinitions;
+import ocean.transition;
+public import ocean.io.model.IConduit;
 
-public  import ocean.io.model.IConduit;
+import core.thread;
 
 /*******************************************************************************
 

--- a/src/ocean/io/stream/Format.d
+++ b/src/ocean/io/stream/Format.d
@@ -29,7 +29,7 @@ version(DigitalMars)
 {
     version(X86_64) version=DigitalMarsX64;
 
-    import ocean.core.Vararg;
+    import core.stdc.stdarg;
 }
 
 /*******************************************************************************

--- a/src/ocean/text/convert/Layout.d
+++ b/src/ocean/text/convert/Layout.d
@@ -45,38 +45,16 @@ import ocean.util.container.AppendBuffer;
 
 import TangoLayout = ocean.text.convert.Layout_tango;
 
-import core.stdc.stdarg;
+/*
+ * va_list/_start/_arg/_end must be public imported because they are used in
+ * the vaArg template, which is instantiated in other modules as well.
+ */
+public import core.stdc.stdarg;
 
-/*******************************************************************************
-
-    Platform issues ...
-
-*******************************************************************************/
-
-version (DigitalMars) version (X86_64)
-{
-    version = DigitalMarsX86_64;
-}
-
-version (DigitalMarsX86_64)
-{
-
-    /*
-     * va_list/_start/_arg/_end must be public imported because they are used in
-     * the vaArg template, which is instantiated in other modules as well.
-     */
-
-    public import ocean.core.Vararg: va_arg, va_list,
-                               // implicitly referenced by the compiler... YEAH!
-                                     __va_argsave_t;
-}
-else static assert (false, "only Digital Mars x86-64 supported");
-
-/*******************************************************************************
+version = DigitalMarsX86_64;
 
 
-
-*******************************************************************************/
+/******************************************************************************/
 
 abstract class Layout ( T = char )
 {

--- a/src/ocean/text/convert/Layout_tango.d
+++ b/src/ocean/text/convert/Layout_tango.d
@@ -60,7 +60,7 @@ version(UnitTest) import ocean.core.Test;
 
 version(DigitalMars)
 {
-    import ocean.core.Vararg;
+    import core.stdc.stdarg;
     alias void* Arg;
     alias va_list ArgList;
 

--- a/src/ocean/text/json/Json.d
+++ b/src/ocean/text/json/Json.d
@@ -19,7 +19,7 @@ module ocean.text.json.Json;
 
 import ocean.transition;
 
-import ocean.core.Vararg;
+import core.stdc.stdarg;
 
 import ocean.core.Verify;
 

--- a/src/ocean/util/log/Log.d
+++ b/src/ocean/util/log/Log.d
@@ -100,7 +100,7 @@ import ocean.text.convert.Format;
 
 import ocean.util.log.model.ILogger;
 
-import ocean.core.Vararg;
+import core.stdc.stdarg;
 
 import AP = ocean.util.log.Appender;
 import EV = ocean.util.log.Event;

--- a/src/ocean/util/log/StaticTrace.d
+++ b/src/ocean/util/log/StaticTrace.d
@@ -35,40 +35,12 @@ import ocean.io.model.IConduit;
 
 import ocean.io.Console;
 
-/*******************************************************************************
+import core.stdc.stdarg;
 
- Platform issues ...
+alias void* Arg;
+alias va_list ArgList;
 
-*******************************************************************************/
-
-version (GNU)
-{
-    import ocean.core.Vararg;
-
-    alias void* Arg;
-    alias va_list ArgList;
-}
-else version (LDC)
-{
-    import ocean.core.Vararg;
-
-    alias void* Arg;
-    alias va_list ArgList;
-}
-else version (DigitalMars)
-{
-    import ocean.core.Vararg;
-
-    alias void* Arg;
-    alias va_list ArgList;
-
-    version (X86_64) version = DigitalMarsX64;
-}
-else
-{
-    alias void* Arg;
-    alias void* ArgList;
-}
+version (X86_64) version = DigitalMarsX64;
 
 /*******************************************************************************
 
@@ -108,7 +80,7 @@ public class StaticSyncPrint
 
     ***************************************************************************/
 
-    private typeof(find(cstring.init)) finder; 
+    private typeof(find(cstring.init)) finder;
 
     /***************************************************************************
 
@@ -218,4 +190,3 @@ public class StaticSyncPrint
         return this;
     }
 }
-

--- a/test/selectlistener/main.d
+++ b/test/selectlistener/main.d
@@ -23,7 +23,6 @@ import ocean.transition;
 
 import ocean.core.Enforce: enforce;
 import Ocean = ocean.core.Test;
-import ocean.core.Thread;
 import ocean.core.Time: seconds;
 import ocean.io.select.EpollSelectDispatcher;
 import core.stdc.errno: ECONNREFUSED;
@@ -35,6 +34,7 @@ import ocean.sys.socket.UnixSocket;
 import ocean.stdc.posix.sys.un;
 import core.sys.posix.sys.socket;
 import core.stdc.stdlib;
+import core.thread;
 
 import test.selectlistener.UnixServer;
 

--- a/test/unixsocket/main.d
+++ b/test/unixsocket/main.d
@@ -32,10 +32,10 @@ import core.sys.posix.unistd;
 import ocean.stdc.posix.stdlib : mkdtemp;
 import core.stdc.stdio;
 import ocean.math.Math;
-import ocean.core.Thread;
 import ocean.core.Time;
 import ocean.stdc.string;
 import core.stdc.errno;
+import core.thread;
 
 import ocean.text.util.StringC;
 


### PR DESCRIPTION
Just something I noticed as part of the giant cleanup involved with killing `Tango_Layout`.