### PR TITLE
Fix another log test relying on state

### DIFF
--- a/src/ocean/util/log/Logger.d
+++ b/src/ocean/util/log/Logger.d
@@ -1011,7 +1011,8 @@ unittest
     }
 
     scope appender = new StaticBuffer;
-    auto log = Log.lookup("ocean.util.log.Logger.TestLogAlloc").additive(false)
+    Logger log = (new Logger(Log.hierarchy(), "dummy"))
+        .additive(false)
         .add(appender);
 
     testNoAlloc({


### PR DESCRIPTION
Similar to the same case in previous unittest block which
was fixed earlier. New test case was introduced in 3.5.0