### PR TITLE
Exit the client process after write/read, don't run the next tests in it

### DIFF
--- a/test/selectlistener/main.d
+++ b/test/selectlistener/main.d
@@ -123,7 +123,7 @@ void run_test ( istring socket_path )
     if (pid == 0)  // child
     {
         run_client(socket_path);
-        return;
+        _Exit(0);
     }
 
     epoll.eventLoop();


### PR DESCRIPTION
Intended return was to stop the client process after it would send/read
data from the socket. However, this would just exit the frame,
continuing running the test next test, as the main would not exit
immediately.