### PR TITLE
Temporarily disable `final` in only `final switch`

### DIFF
--- a/src/ocean/core/SmartUnion.d
+++ b/src/ocean/core/SmartUnion.d
@@ -312,6 +312,8 @@ private const handleInvalidCases = "case none: assert(false);" ~
     // has no default so we add a default here just to avoid the warning.
     "version (D_Version2){} else {default: assert(false);}";
 
+// Disabled until DMD 1.081 becomes widely available
+/*
 ///
 unittest
 {
@@ -334,6 +336,7 @@ unittest
         mixin(TestSmartUnion.handleInvalidCases);
     }
 }
+*/
 
 /******************************************************************************
 


### PR DESCRIPTION
As development infrastructure was not yet ready for switching to 1.081,
the usage of this feature was premature.