### PR TITLE
HttpException: Use catch (Exception) instead of pokemon catch

### DIFF
--- a/src/ocean/net/http/HttpException.d
+++ b/src/ocean/net/http/HttpException.d
@@ -128,7 +128,7 @@ class HttpException : HttpServerException
             auto path = "/path/with/errors";
             e.enforce(false, HttpResponseCode.NotFound, "Unable to locate URI path:", path);
         }
-        catch
+        catch (Exception)
         {
             test!("==")(e.status, HttpResponseCode.NotFound);
             test!("==")(getMsg(e), "Not Found Unable to locate URI path: /path/with/errors");


### PR DESCRIPTION
Pokemon catch is deprecated.