### PR TITLE
Allow setting mode for the socket in UnixSocketExt

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -64,6 +64,8 @@ $O/test-sysstats: override LDFLAGS += -lebtree
 
 $O/test-httpserver: override LDFLAGS += -lebtree -lglib-2.0
 
+$O/test-unixsockext: override LDFLAGS += -lebtree
+
 # Link unittests to all used libraries
 $O/%unittests: override LDFLAGS += -lglib-2.0 -lpcre -lxml2 -lxslt -lebtree \
 		-lreadline -lhistory -llzo2 -lbz2 -lz -ldl -lgcrypt -lgpg-error -lrt

--- a/relnotes/chmod.feature.md
+++ b/relnotes/chmod.feature.md
@@ -1,0 +1,8 @@
+* `ocean.util.app.ext.UnixSocketExt`
+
+  `UnixSocketExt` now supports setting the mode for the socket after
+  binding. User can set it in the config file in `UNIX_SOCKET.mode`
+  as an octal string and the mode will be applied to the socket after
+  creating it. This allows setting mode which would possibly allow
+  all other users for connecting to the socket, since the socket is created
+  with the umask 002 (which would prevent other users from connecting to it).

--- a/test/unixsockext/main.d
+++ b/test/unixsockext/main.d
@@ -1,0 +1,71 @@
+/*******************************************************************************
+
+    Test for UnixSocketExt
+
+    Copyright:
+        Copyright (c) 2017 sociomantic labs GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+        Alternatively, this file may be distributed under the terms of the Tango
+        3-Clause BSD License (see LICENSE_BSD.txt for details).
+
+*******************************************************************************/
+
+import ocean.transition;
+
+import core.sys.posix.sys.stat;
+import ocean.core.Test;
+import ocean.sys.ErrnoException;
+import ocean.util.app.DaemonApp;
+import ocean.task.Scheduler;
+import ocean.task.Task;
+
+class UnixSockListeningApp : DaemonApp
+{
+    this ( )
+    {
+        initScheduler(SchedulerConfiguration.init);
+        theScheduler.exception_handler = (Task t, Exception e) {
+            throw e;
+        };
+
+        istring name = "Application";
+        istring desc = "Testing unix socket listener mode.";
+
+        DaemonApp.OptionalSettings settings;
+
+        super(name, desc, VersionInfo.init, settings);
+    }
+
+    // Called after arguments and config file parsing.
+    override protected int run ( Arguments args, ConfigParser config )
+    {
+        this.startEventHandling(theScheduler.epoll);
+        auto errnoexception = new ErrnoException;
+
+        // Let's check the mode of the socket!
+        stat_t stats;
+        errnoexception.enforceRetCode!(stat)().call("unix.socket", &stats);
+        test!("==")((stats.st_mode & ~S_IFMT), Octal!("0600"));
+
+        return 0; // return code to OS
+    }
+
+}
+
+import ocean.io.device.File;
+import ocean.util.test.DirectorySandbox;
+
+void main(istring[] args)
+{
+    auto sandbox = DirectorySandbox.create(["etc", "log"]);
+
+    File.set("etc/config.ini", "[LOG.Root]\n" ~
+               "console = false\n\n" ~
+               "[UNIX_SOCKET]\npath=unix.socket\nmode=0600");
+
+    auto app = new UnixSockListeningApp;
+    auto ret = app.main(args);
+}


### PR DESCRIPTION
`UnixSocketExt` now supports setting the mode for the socket after
binding. User can set it in the config file in `UNIX_SOCKET.mode`
as an octal string and the mode will be applied to the socket after
creating it. This allows setting mode which would possibly prevent
all other users for connecting to the socket (most likely choice would
be `0660`).