### PR TITLE
Add missing imports in deprecated modules

### DIFF
--- a/src/ocean/math/BigInt.d
+++ b/src/ocean/math/BigInt.d
@@ -15,6 +15,8 @@
 
 deprecated module ocean.math.BigInt;
 
+import ocean.core.Verify;
+version (UnitTest) import ocean.core.Test;
 import ocean.transition;
 
 import ocean.math.internal.BiguintCore;

--- a/src/ocean/stdc/stringz.d
+++ b/src/ocean/stdc/stringz.d
@@ -55,6 +55,7 @@ Const!(char)* toStringz (cstring s, char[] tmp = null)
 
 version (UnitTest)
 {
+    import ocean.core.Test;
     import ocean.stdc.string;
 }
 
@@ -199,8 +200,8 @@ deprecated unittest
     p = toStringz(foo[3..5]);
     test(strlenz(p) == 2);
 
-    auto test = "\0";
-    p = toStringz(test);
+    auto test_str = "\0";
+    p = toStringz(test_str);
     test(*p == 0);
-    test(p == test.ptr);
+    test(p == test_str.ptr);
 }

--- a/src/ocean/text/locale/Data.d
+++ b/src/ocean/text/locale/Data.d
@@ -15,6 +15,7 @@ deprecated module ocean.text.locale.Data;
 import ocean.transition;
 
 import ocean.core.ExceptionDefinitions;
+import ocean.core.Verify;
 
 package void error(mstring msg) {
      throw new LocaleException (idup(msg));

--- a/src/ocean/text/locale/Posix.d
+++ b/src/ocean/text/locale/Posix.d
@@ -24,6 +24,7 @@ version (Posix)
     alias ocean.text.locale.Posix nativeMethods;
 
     import ocean.core.ExceptionDefinitions;
+    version (UnitTest) import ocean.core.Test;
     import ocean.text.locale.Data;
     import ocean.text.util.StringC;
     import core.stdc.ctype;


### PR DESCRIPTION
Those modules were changed to use test and verify without being properly tested.
As ocean doesn't test deprecated module, those modules should probably have been better left alone.
While ocean doesn't detect it, applications using it the modules (directly or through a library) will fail to compile.