### PR TITLE
 Support reopening single files via unix domain socket in DaemonApp

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -77,6 +77,8 @@ $O/test-unixsockext: override LDFLAGS += -lebtree
 
 $O/test-scheduler: override LDFLAGS += -lebtree
 
+$O/test-reopenfiles: override LDFLAGS += -lebtree
+
 # Link unittests to all used libraries
 $O/%unittests: override LDFLAGS += -lglib-2.0 -lpcre -lxml2 -lxslt -lebtree \
 		-lreadline -lhistory -llzo2 -lbz2 -lz -ldl -lgcrypt -lgpg-error -lrt

--- a/relnotes/filepath.feature.md
+++ b/relnotes/filepath.feature.md
@@ -1,0 +1,5 @@
+* `ocean.io.device.File`
+
+  `File.path()` method is added which returns the file path (same as
+  `File.toString()`), but without `idup`ing it (unlike `File.toString()`).
+

--- a/relnotes/reopensocket.feature.md
+++ b/relnotes/reopensocket.feature.md
@@ -1,0 +1,40 @@
+* `ocean.util.app.DaemonApp`
+
+  `DaemonApp`'s `ReopenableFilesExt` now supports reopening commands from the
+  UnixSocketExt. If you have the UnixSocketExt bound to the socket, sending
+  command `reopen_logfile file_path` will reopen the specified file, if
+  registered, and acknowledge the action with `ACK` or `ERROR` strings (followed
+  by the file name which failed to reopen in case of `ERROR`).
+
+  With this in place, reopening only affected files (vs all open registered files)
+  with logrotate can be done as follows:
+
+    1) use `nosharedscripts` directive, so the post-rotate script is called
+       once per file, with the absolute file path passed to it.
+    2) From the absolute file path, get the log directory and deduce socket
+       location from it (application could place the socket in its `run/`
+       directory, so the socket path would be
+       `SOCKETPATH=$(dirname $LOGPATH)/../application.socket`.
+    3) Finally, in post-rotate script, simply executing
+       `test "$(echo reopen_files $LOGPATH | nc -U $SOCKETPATH)" = ACK` will
+       instruct the application to reopen the given logfile and report status
+       to logrotate.
+
+  Example logrotate file:
+
+  ```
+  /srv/dlsnode/log/*.log
+  {
+      rotate 10
+      missingok
+      notifempty
+      delaycompress
+      compress
+      size 1M
+      nosharedscripts
+      postrotate
+        export SOCKETPATH="$(dirname $1)/../dlsnode.socket"
+        test "$(echo reopen_files $1 | nc -U $SOCKETPATH)" = ACK
+      endscript
+    }
+    ```

--- a/src/ocean/io/device/DirectIO.d
+++ b/src/ocean/io/device/DirectIO.d
@@ -305,18 +305,6 @@ public class BufferedDirectWriteFile: OutputStream
             if (!super.open(path, style, O_DIRECT))
                 this.error();
         }
-
-        /***********************************************************************
-
-            Returns:
-                the file's path
-
-        ***********************************************************************/
-
-        public cstring path ( )
-        {
-            return this.toString();
-        }
     }
 
     /***************************************************************************
@@ -412,18 +400,6 @@ public class BufferedDirectWriteFile: OutputStream
         verify(this.file.fileHandle == -1);
         this.file.open(path);
         this.free_index = 0;
-    }
-
-    /***************************************************************************
-
-        Returns:
-            what File.toString() returns for the underlying File instance
-
-    ***************************************************************************/
-
-    public cstring path ( )
-    {
-        return this.file.path();
     }
 
     /***************************************************************************

--- a/src/ocean/io/device/File.d
+++ b/src/ocean/io/device/File.d
@@ -412,6 +412,18 @@ class File : Device, Device.Seek, Device.Truncate
                 return idup(path_);
         }
 
+        /**********************************************************************
+
+            Returns:
+                path used by this file.
+
+        **********************************************************************/
+
+        public cstring path ()
+        {
+            return this.path_;
+        }
+
         /***********************************************************************
 
                 Convenience function to return the content of a file.

--- a/src/ocean/util/app/ext/ReopenableFilesExt.d
+++ b/src/ocean/util/app/ext/ReopenableFilesExt.d
@@ -181,7 +181,7 @@ public class ReopenableFilesExt : IApplicationExtension, ISignalExtExtension
         foreach ( file; this.open_files )
         {
             file.close();
-            file.open(file.toString(), file.style);
+            file.open(file.path(), file.style);
         }
     }
 
@@ -214,7 +214,7 @@ public class ReopenableFilesExt : IApplicationExtension, ISignalExtExtension
             if (file.path() == file_path || path_buffer[] == file_path)
             {
                 file.close();
-                file.open(file.toString(), file.style);
+                file.open(file.path(), file.style);
                 reopened = true;
             }
         }

--- a/test/reopenfiles/main.d
+++ b/test/reopenfiles/main.d
@@ -1,0 +1,176 @@
+/*******************************************************************************
+
+    Test for ReopenableFilesExt in combination with UnixSocketExt
+
+    Copyright:
+        Copyright (c) 2017 sociomantic labs GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+        Alternatively, this file may be distributed under the terms of the Tango
+        3-Clause BSD License (see LICENSE_BSD.txt for details).
+
+*******************************************************************************/
+
+import ocean.transition;
+
+import core.sys.posix.sys.stat;
+import core.sys.linux.fcntl;
+
+import ocean.core.Enforce;
+import ocean.core.Test;
+import ocean.io.FilePath;
+import ocean.io.device.File;
+import ocean.io.select.protocol.task.TaskSelectTransceiver;
+import ocean.io.select.protocol.generic.ErrnoIOException: IOWarning, IOError;
+
+import ocean.sys.socket.UnixSocket;
+import ocean.stdc.posix.sys.un;
+
+import ocean.task.Scheduler;
+import ocean.task.Task;
+
+import ocean.util.app.DaemonApp;
+import ocean.util.test.DirectorySandbox;
+
+/// Socket class to bind/connect
+private istring socket_path = "reopensocket.socket";
+
+/// Main application class
+class ReopenableFilesApp : DaemonApp
+{
+    /// Count of the remaining tasks. Shut downs
+    /// the scheduler when 0.
+    private int task_remaining;
+
+    /// Task used to send command and confirm the response
+    class SendingTask: Task
+    {
+        /// Command to send
+        cstring command_to_send;
+        /// Response to expect
+        cstring expected_response;
+
+        /// Constructor
+        this (cstring command_to_send,
+            cstring expected_response)
+        {
+            this.command_to_send = command_to_send;
+            this.expected_response = expected_response;
+        }
+
+        /// Main task method
+        override void run()
+        {
+            auto socket_address = sockaddr_un.create(socket_path);
+
+            auto client = new UnixSocket();
+
+            auto socket_fd = client.socket();
+            enforce(socket_fd >= 0, "socket() call failed!");
+
+            auto connect_result = client.connect(&socket_address);
+            enforce(connect_result == 0,
+                    "connect() call failed");
+
+            // set non-blocking mode on the client socket
+            auto existing_flags = fcntl(client.fileHandle(),
+                F_GETFL, 0);
+            enforce(existing_flags != -1);
+            enforce(fcntl(client.fileHandle(),
+                F_SETFL, existing_flags | O_NONBLOCK) != -1);
+
+            // Use the task-blocking tranceiver, so
+            // the scheduler can handle other epoll clients
+            auto transceiver = new TaskSelectTransceiver(client,
+                new IOWarning(client), new IOError(client));
+            transceiver.write(command_to_send);
+
+            // Confirm the response!
+            auto buff = new char[this.expected_response.length];
+            transceiver.read(buff);
+            test!("==")(buff, this.expected_response);
+
+            if (--this.outer.task_remaining == 0)
+            {
+                theScheduler.shutdown();
+            }
+        }
+    }
+
+    /// Constructor.
+    this ( )
+    {
+        initScheduler(SchedulerConfiguration.init);
+        theScheduler.exception_handler = (Task, Exception e) {
+            throw e;
+        };
+
+        istring name = "Application";
+        istring desc = "Testing reopenable files ext";
+
+        DaemonApp.OptionalSettings settings;
+
+        super(name, desc, VersionInfo.init, settings);
+    }
+
+    /// Called after arguments and config file parsing.
+    override protected int run ( Arguments args, ConfigParser config )
+    {
+        this.startEventHandling(theScheduler.epoll);
+
+        auto original_file = new File;
+        original_file.open("filelocation.txt", File.ReadWriteOpen);
+        this.reopenable_files_ext.register(original_file);
+
+        // move this file now
+        auto path = new FilePath(original_file.path());
+        path.rename("newfilelocation.txt");
+
+        auto new_file = new File;
+        new_file.open("filelocation.txt", File.ReadWriteOpen);
+        new_file.write("Pre-reload");
+
+        // we haven't done reloading
+        test!("==")(original_file.length, 0);
+
+        auto good_task = new SendingTask("reopen_files filelocation.txt\n",
+            "ACK\n");
+        theScheduler.schedule(good_task);
+
+        auto bad_task = new SendingTask("reopen_files nonregistered.txt\n",
+            "ERROR: Could not rotate the file 'nonregistered.txt'\n");
+        theScheduler.schedule(bad_task);
+
+        // Counter used to figure out when to exit the scheduler
+        this.task_remaining = 2;
+
+        // Spin the task and start working
+        theScheduler.eventLoop();
+
+        // Test if the file has been reloaded
+        test!("!=")(original_file.length, 0);
+        auto buff = new char["Pre-reload".length];
+        original_file.read(buff);
+        test!("==")(buff, "Pre-reload");
+
+        return 0;
+    }
+
+}
+
+
+void main(istring[] args)
+{
+    auto sandbox = DirectorySandbox.create(["etc", "log"]);
+    scope (success)
+        sandbox.remove();
+
+    File.set("etc/config.ini", "[LOG.Root]\n" ~
+               "console = false\n\n" ~
+               "[UNIX_SOCKET]\npath=" ~ socket_path ~ "\nmode=0600");
+
+    auto app = new ReopenableFilesApp;
+    app.main(args);
+}


### PR DESCRIPTION
`DaemonApp`'s `ReopenableFilesExt` now supports reopening commands from the
UnixSocketExt. If you have the UnixSocketExt bound to the socket, sending command
`reopen_logfile file_path` will reopen this file, if registered, and acknowledge
the action with `ACK` or `ERROR` strings.

This is different than reopening files with the reopen signal, which
is not capable passing the file path to it, so it forces reopening all
files.
