### PR TITLE
Fix DaemonApp.onSignal crash on unkown signal

### DIFF
--- a/src/ocean/util/app/DaemonApp.d
+++ b/src/ocean/util/app/DaemonApp.d
@@ -578,7 +578,7 @@ public abstract class DaemonApp : Application,
                     this.epoll.shutdown();
                 break;
             default:
-                assert(false);
+                break;
         }
     }
 


### PR DESCRIPTION
New code added in v3.5.0 was using `assert(false)` instead of a `break`.
Any application which was overriding `onSignal` was not affected.