### PR TITLE
Fix flakey `ocean.task` test (major `TimeSet` bug)

### DIFF
--- a/relnotes/expiry.feature.md
+++ b/relnotes/expiry.feature.md
@@ -1,0 +1,6 @@
+* `ocean.time.timeout.model.ExpiryRegistrationBase`
+
+  New method, `drop`, provides same functionality as `unregister`, but also
+  removes the expiry from current list of fired events if it was present there.
+  This makes it possible to disable timer events from the timeout callbacks of
+  other timer events.

--- a/src/ocean/io/select/client/TimerSet.d
+++ b/src/ocean/io/select/client/TimerSet.d
@@ -202,6 +202,7 @@ public class TimerSet ( EventData ) : TimerEventTimeoutManager
         public void unregister ( )
         {
             this.expiry_registration.drop();
+            this.outer.events.recycle(this);
         }
 
 

--- a/src/ocean/io/select/client/TimerSet.d
+++ b/src/ocean/io/select/client/TimerSet.d
@@ -201,7 +201,7 @@ public class TimerSet ( EventData ) : TimerEventTimeoutManager
 
         public void unregister ( )
         {
-            this.expiry_registration.unregister();
+            this.expiry_registration.drop();
         }
 
 

--- a/src/ocean/time/timeout/TimeoutManager.d
+++ b/src/ocean/time/timeout/TimeoutManager.d
@@ -60,7 +60,6 @@ import ocean.transition;
 
 debug
 {
-    import ocean.io.Stdout;
     import core.stdc.time: time_t, ctime;
     import core.stdc.string: strlen;
 }
@@ -217,13 +216,51 @@ abstract class TimeoutManagerBase : ITimeoutManager
                          the IExpiryRegistration instance to unregister
 
             In:
-                Must not be called from within timeout().
+                Must not be called from within timeout(). Doing so would still
+                leave already fired timer events in the TimeoutManager internal
+                list and their respective `timeout` will be called despite
+                unregistration. be called from within timeout().
 
         ***********************************************************************/
 
         void unregister ( ref Expiry expiry )
         {
             this.outer.unregister(expiry);
+        }
+
+        /***********************************************************************
+
+            Unregisters the specified expiry. If the expiry is present in the
+            list of expired registrations being currently iterated over by
+            checkTimeouts, then it will be removed (its timeout method will not
+            be called). (This means that drop can be called from timeout
+            callbacks, unlike unregister.)
+
+            Params:
+                expiry = expiry token returned by register() when registering
+                         the IExpiryRegistration instance to unregister
+
+        ***********************************************************************/
+
+        protected void drop ( ref Expiry expiry )
+        {
+            // If this method is called while checkTimeouts is iterating over
+            // the list of expired registrations, then we need to check whether
+            // the expiry to be dropped is present in the list and remove it, if
+            // it is.
+            // This makes it possible to disable timer events from the
+            // timeout callbacks of other timer events.
+
+            IExpiryRegistration registration =
+                *this.outer.expiry_to_client.get(&expiry);
+            foreach (ref pending; this.outer.expired_registrations[])
+            {
+                if (pending is registration)
+                    pending = null;
+            }
+
+            // do everything else as for regular unregistration
+            this.unregister(expiry);
         }
 
         /***********************************************************************
@@ -296,6 +333,9 @@ abstract class TimeoutManagerBase : ITimeoutManager
     /***************************************************************************
 
         List of expired registrations. Used by the checkTimeouts() method.
+
+        Elements can be set to `null` by `drop` method, in which case they
+        are ignored.
 
     ***************************************************************************/
 
@@ -513,6 +553,11 @@ abstract class TimeoutManagerBase : ITimeoutManager
         // the optional delegate returns false.
         foreach (ref registration; this.expired_registrations[])
         {
+            // registration can be disabled by `drop` method by being set to
+            // `null`
+            if (registration is null)
+                continue;
+
             ITimeoutClient client = registration.timeout();
 
             if (dg !is null) if (!dg(client)) break;

--- a/src/ocean/time/timeout/model/ExpiryRegistrationBase.d
+++ b/src/ocean/time/timeout/model/ExpiryRegistrationBase.d
@@ -88,11 +88,30 @@ abstract class ExpiryRegistrationBase : IExpiryRegistration
                          the IExpiryRegistration instance to unregister
 
             In:
-                Must not be called from within timeout().
+                Must not be called from within timeout(). Doing so would still
+                leave already fired timer events in the TimeoutManager internal
+                list and their respective `timeout` will be called despite
+                unregistration.
 
         ***********************************************************************/
 
         void unregister ( ref Expiry expiry );
+
+        /***********************************************************************
+
+            Unregisters the specified expiry. If the expiry is present in the
+            list of expired registrations being currently iterated over by
+            checkTimeouts, then it will be removed (its timeout method will not
+            be called). (This means that drop can be called from timeout
+            callbacks, unlike unregister.)
+
+            Params:
+                expiry = expiry token returned by register() when registering
+                         the IExpiryRegistration instance to unregister
+
+        ***********************************************************************/
+
+        void drop ( ref Expiry expiry );
 
         /***********************************************************************
 
@@ -190,22 +209,23 @@ abstract class ExpiryRegistrationBase : IExpiryRegistration
 
     public bool unregister ( )
     {
-        if (this.expiry) try
-        {
-            debug ( TimeoutManager ) Stderr("*** unregister ")(this.id)('\n').flush();
+        return this.unregisterWith({ this.mgr.unregister(*this.expiry); });
+    }
 
-            this.mgr.unregister(*this.expiry);
+    /***************************************************************************
 
-            return true;
-        }
-        finally
-        {
-            this.expiry = null;
-        }
-        else
-        {
-            return false;
-        }
+        Same as `unregister` but also removes expirty from list of currently
+        expired registrations. That means it can be called from `timeout`
+        callbacks, contrary to `unregister`.
+
+        Returns:
+            true on success or false if no client was registered.
+
+    ***************************************************************************/
+
+    public bool drop ( )
+    {
+        return this.unregisterWith({ this.mgr.drop(*this.expiry); });
     }
 
     /***************************************************************************
@@ -341,6 +361,46 @@ abstract class ExpiryRegistrationBase : IExpiryRegistration
         {
             debug ( TimeoutManager ) Stderr("no timeout\n").flush();
 
+            return false;
+        }
+    }
+
+    /***************************************************************************
+
+        Extracted common code of `drop` and `unregister`. Uses provided delegate
+        to call relevant TimeoutManager method and augments it with error
+        checking (providing boolean return value) and debug traces.
+
+        Params:
+            dg = delegate that calls relevant TimeoutManager method
+
+        Returns:
+            See `drop`/`unregister`
+
+    ***************************************************************************/
+
+    private bool unregisterWith(void delegate() dg)
+    {
+        if (this.expiry)
+        {
+            try
+            {
+                debug (TimeoutManager)
+                {
+                    Stderr("*** unregister ")(this.id)('\n').flush();
+                }
+
+                dg();
+
+                return true;
+            }
+            finally
+            {
+                this.expiry = null;
+            }
+        }
+        else
+        {
             return false;
         }
     }


### PR DESCRIPTION
We have observed two times that some CI runs fail with totally unrelated test failures coming from task code. Previous case was ~3 weeks ago in one of PRs and it has happened again on v3.x.x HEAD after merging green PR today. It looks like one of task tests has some very low chance of failure that is not foreseen.

Will need further investigation.