### PR TITLE
Update beaver to add D2 auto-conversion for tags and upload codecov reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,25 @@ env:
         - DMD=2.071.2.s1 DIST=xenial F=production
         - DMD=2.071.2.s1 DIST=xenial F=devel
 
+# Don't build tags already converted to D2
+if: NOT tag =~ \+d2$
+
 install: beaver dlang install
 
 script: BEAVER_DOCKER_VARS="F AFTER_SCRIPT" beaver dlang make
 
-after_success:
-    - test "$AFTER_SCRIPT" = "1" && beaver run ci/codecov.sh
-    - test "$AFTER_SCRIPT" = "1" &&
-        BEAVER_DOCKER_VARS="OCEAN_D2_USER OCEAN_D2_PASS"
-        beaver run ci/d2tags.sh
+after_success: test "$AFTER_SCRIPT" = "1" && beaver run ci/codecov.sh
+
+jobs:
+    include:
+        - stage: D2 Release
+          # We need to include the exclusion of D2 tags because this "if"
+          # replaces the global one
+          if: tag IS present AND NOT tag =~ \+d2$
+          # We override it, otherwise is inherited from the first matrix row,
+          # we need DIST and DMD for `beaver dlang install`
+          env: DIST=xenial DMD=2.070.2.s12
+          # before_install and install are inherited
+          script: beaver dlang d2-release
+          # Overridden to NOP, otherwise is inherited
+          after_success: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
         # Make sure beaver is in the PATH
         - PATH="$(git config -f .gitmodules submodule.beaver.path)/bin:$PATH"
     matrix:
-        - DMD=1.081.1 DIST=xenial F=production AFTER_SCRIPT=1
+        - DMD=1.081.1 DIST=xenial F=production
         - DMD=1.081.1 DIST=xenial F=devel
         - DMD=2.070.2.s12 DIST=xenial F=production
         - DMD=2.070.2.s12 DIST=xenial F=devel
@@ -31,9 +31,9 @@ if: NOT tag =~ \+d2$
 
 install: beaver dlang install
 
-script: BEAVER_DOCKER_VARS="F AFTER_SCRIPT" beaver dlang make
+script: beaver dlang make
 
-after_success: test "$AFTER_SCRIPT" = "1" && beaver run ci/codecov.sh
+after_success: beaver dlang codecov
 
 jobs:
     include:
@@ -41,10 +41,12 @@ jobs:
           # We need to include the exclusion of D2 tags because this "if"
           # replaces the global one
           if: tag IS present AND NOT tag =~ \+d2$
-          # We override it, otherwise is inherited from the first matrix row,
-          # we need DIST and DMD for `beaver dlang install`
-          env: DIST=xenial DMD=2.070.2.s12
-          # before_install and install are inherited
+          # env: is inherited from the first matrix row, for converting code to
+          # D2 it doesn't matter what compiler version or F we use, it only
+          # matters that we have a DIST and DMD variables defined, so we just
+          # use whatever the first row have.
+          # before_install: and install: are also inherited and we don't need
+          # to override them.
           script: beaver dlang d2-release
           # Overridden to NOP, otherwise is inherited
           after_success: true


### PR DESCRIPTION
Now when a tag is released, a new stage will also convert the tag to D2, then it will commit the changes, create a new tag with a +d2 suffix, push the changes and create a GitHub release for it.

This is done via the new beaver dlang d2-release command.

* submodules/beaver v0.2.2(480e6f5)...v0.2.2+10(55e9471) (10 commits)
  > dlang: Add a command to release converted D2 tags
  > make-wrapper-dlang: Fix matrix row selection
  > Drop trusty support
  > Change default matrix row for make-wrapper-dlang
  > Add an make wrapper for dlang projects
  (...)