### PR TITLE
Remove version GLIBC

### DIFF
--- a/src/ocean/stdc/gnu/string.d
+++ b/src/ocean/stdc/gnu/string.d
@@ -15,8 +15,6 @@
 
 module ocean.stdc.gnu.string;
 
-version (GLIBC):
-
 import ocean.transition;
 import core.stdc.stddef: wchar_t;
 

--- a/src/ocean/stdc/posix/gnu/socket.d
+++ b/src/ocean/stdc/posix/gnu/socket.d
@@ -17,8 +17,6 @@ module ocean.stdc.posix.gnu.socket;
 
 import ocean.stdc.posix.sys.socket;
 
-version (GLIBC):
-
 extern (C):
 
 int accept4(int, sockaddr*, socklen_t*, int);

--- a/src/ocean/stdc/posix/gnu/stdlib.d
+++ b/src/ocean/stdc/posix/gnu/stdlib.d
@@ -15,11 +15,8 @@
 
 module ocean.stdc.posix.gnu.stdlib;
 
-version (GLIBC):
-
 extern (C):
 
 int mkstemps(char*, int); // BSD and other systems too
 int mkostemp(char*, int);
 int mkostemps(char*, int, int);
-

--- a/src/ocean/stdc/posix/stdlib.d
+++ b/src/ocean/stdc/posix/stdlib.d
@@ -16,6 +16,6 @@ module ocean.stdc.posix.stdlib;
 
 public import core.sys.posix.stdlib;
 
-version (GLIBC) public import ocean.stdc.posix.gnu.stdlib;
+public import ocean.stdc.posix.gnu.stdlib;
 
 extern (C) char* mkdtemp(char*);

--- a/src/ocean/stdc/posix/sys/socket.d
+++ b/src/ocean/stdc/posix/sys/socket.d
@@ -19,7 +19,7 @@ public import core.sys.posix.netinet.tcp;
 public import core.sys.posix.netinet.in_;
 public import core.sys.posix.netdb;
 
-version (GLIBC) public import ocean.stdc.posix.gnu.socket;
+public import ocean.stdc.posix.gnu.socket;
 
 enum
 {

--- a/src/ocean/stdc/string.d
+++ b/src/ocean/stdc/string.d
@@ -21,7 +21,7 @@ version (D_Version2)
     public import core.stdc.wchar_;
 }
 
-version (GLIBC) public import ocean.stdc.gnu.string;
+public import ocean.stdc.gnu.string;
 
 version (Posix)
 {


### PR DESCRIPTION
It is always defined in D1, and Ocean is not meant to run in another environment.
This will make it slightly easier to use the upstream compiler in the future.