### PR TITLE
Use ISocket's implementation of socket() member in IIPSocket

### DIFF
--- a/src/ocean/sys/socket/IPSocket.d
+++ b/src/ocean/sys/socket/IPSocket.d
@@ -227,14 +227,7 @@ abstract class IIPSocket : ISocket
 
     public int socket ( int type, int protocol = 0 )
     {
-        this.fd = .socket(
-            this.is_ipv6? AF_INET6 : AF_INET,
-            setCloExec(type, SocketFlags.SOCK_CLOEXEC), protocol
-        );
-
-        this.close_in_destructor = (this.fd >= 0);
-
-        return this.fd;
+        return super.socket(this.is_ipv6? AF_INET6 : AF_INET, type, protocol);
     }
 
     /**************************************************************************


### PR DESCRIPTION
IPSocket, inherited from IIPSocket uses all super class's methods,
but IIPSocket also contains `socket` method duplicating all code
already present in `ISocket.socket`. This merely forwards the call to
the superclass, removing duplicate code.

Fixes #323