### PR TITLE
Deprecate `Time.toString` methods

### DIFF
--- a/relnotes/pretty-time.feature.md
+++ b/relnotes/pretty-time.feature.md
@@ -1,0 +1,18 @@
+* `ocean.text.convert.DateTime_tango`
+
+  New `asPrettyStr` function is a thin non-allocating wrapper over `Time` value
+  which enhances it with `toString` method compatible with the `Formatter` and
+  generates formatted string using current locale configured in `DateTime_tango`.
+
+  ```D
+  import ocean.text.convert.Formatter;
+  import ocean.text.convert.DateTime_tango;
+
+  test!("==")(
+    format("{}", asPrettyStr(Time.epoch1970)),
+      "01/01/70 00:00:00"
+  );
+  ```
+
+  This is intended as drop-in replacement for own `Time.toString` method which
+  is going to be deprecated.

--- a/relnotes/time.deprecation.md
+++ b/relnotes/time.deprecation.md
@@ -1,0 +1,16 @@
+* `ocean.time.Time`
+
+  `toString` methods have been deprecated to eventually break circular
+  dependency beween time structs and big chunk of text formatting code. To keep
+  old formatting with next ocean major please adapt code which looks like this:
+
+  ```D
+  format("{}", time);
+  ```
+
+  To be instead written like this:
+
+  ```D
+  import ocean.text.convert.DateTime_tango;
+  format("{}", asPrettyStr(time));
+  ```

--- a/src/ocean/text/convert/DateTime_tango.d
+++ b/src/ocean/text/convert/DateTime_tango.d
@@ -36,6 +36,7 @@ import ocean.core.ExceptionDefinitions;
 import ocean.stdc.posix.langinfo;
 import Integer = ocean.text.convert.Integer_tango;
 import Utf = ocean.text.convert.Utf;
+import ocean.text.convert.Formatter;
 import ocean.text.util.StringC;
 import ocean.time.chrono.Calendar;
 import ocean.time.chrono.Gregorian;
@@ -967,6 +968,41 @@ private struct Result
     private char[] get ()
     {
         return target_[0 .. index];
+    }
+}
+
+/*******************************************************************************
+
+    Params:
+        value = time value to wrap in pretty-printing struct
+
+    Returns:
+        wrapper struct which, when supplied to `Formatter`, prints `value`
+        using current default locale settings.
+
+*******************************************************************************/
+
+public AsPrettyStr asPrettyStr ( Time value )
+{
+    return AsPrettyStr(value);
+}
+
+/*******************************************************************************
+
+    Wrapper struct which, when supplied to `Formatter`, prints `value`
+    using current default locale settings.
+
+*******************************************************************************/
+
+public struct AsPrettyStr
+{
+    private Time value;
+
+    public void toString (FormatterSink sink)
+    {
+        // Layout defaults to 'G'
+        scope dg = (cstring s) { sink(s); return s.length; };
+        DateTimeDefault.format(dg, this.value, "");
     }
 }
 

--- a/src/ocean/time/Time.d
+++ b/src/ocean/time/Time.d
@@ -23,13 +23,6 @@ module ocean.time.Time;
 import ocean.transition;
 import ocean.text.convert.DateTime_tango;
 
-version (UnitTest)
-{
-    import ocean.core.Test;
-    import ocean.text.convert.Formatter;
-}
-
-
 /******************************************************************************
 
     This struct represents a length of time.  The underlying representation is
@@ -884,54 +877,4 @@ struct DateTime
 {
         public Date         date;       /// date representation
         public TimeOfDay    time;       /// time representation
-}
-
-
-
-
-/******************************************************************************
-
-******************************************************************************/
-
-unittest
-{
-    test(TimeSpan.zero > TimeSpan.min);
-    test(TimeSpan.max  > TimeSpan.zero);
-    test(TimeSpan.max  > TimeSpan.min);
-    test(TimeSpan.zero >= TimeSpan.zero);
-    test(TimeSpan.zero <= TimeSpan.zero);
-    test(TimeSpan.max >= TimeSpan.max);
-    test(TimeSpan.max <= TimeSpan.max);
-    test(TimeSpan.min >= TimeSpan.min);
-    test(TimeSpan.min <= TimeSpan.min);
-
-    test (TimeSpan.fromSeconds(50).seconds is 50);
-    test (TimeSpan.fromSeconds(5000).seconds is 5000);
-    test (TimeSpan.fromMinutes(50).minutes is 50);
-    test (TimeSpan.fromMinutes(5000).minutes is 5000);
-    test (TimeSpan.fromHours(23).hours is 23);
-    test (TimeSpan.fromHours(5000).hours is 5000);
-    test (TimeSpan.fromDays(6).days is 6);
-    test (TimeSpan.fromDays(5000).days is 5000);
-
-    test (TimeSpan.fromSeconds(50).time.seconds is 50);
-    test (TimeSpan.fromSeconds(5000).time.seconds is 5000 % 60);
-    test (TimeSpan.fromMinutes(50).time.minutes is 50);
-    test (TimeSpan.fromMinutes(5000).time.minutes is 5000 % 60);
-    test (TimeSpan.fromHours(23).time.hours is 23);
-    test (TimeSpan.fromHours(5000).time.hours is 5000 % 24);
-
-    auto tod = TimeOfDay (25, 2, 3, 4);
-    tod = tod.span.time;
-    test (tod.hours is 1);
-    test (tod.minutes is 2);
-    test (tod.seconds is 3);
-    test (tod.millis is 4);
-}
-
-unittest
-{
-    test!("==")(format("{}", Time.epoch1970), "01/01/70 00:00:00");
-    test!("==")(format("{}", Time.epoch1970 + TimeSpan.fromDays(5)),
-                "01/06/70 00:00:00");
 }

--- a/src/ocean/time/Time.d
+++ b/src/ocean/time/Time.d
@@ -699,7 +699,7 @@ struct Time
 
     /// Support for `ocean.text.convert.Formatter`: Print the string in a
     /// user-friendly way
-    deprecated("Use the overload accepting a FormatterSink")
+    deprecated("Use `format(\"{}\", asPrettyStr(time))` instead")
     public void toString (size_t delegate(cstring) sink)
     {
         // Layout defaults to 'G'
@@ -708,6 +708,7 @@ struct Time
 
     /// Support for `ocean.text.convert.Formatter`: Print the string in a
     /// user-friendly way
+    deprecated("Use `format(\"{}\", asPrettyStr(time))` instead")
     public void toString (void delegate(cstring) sink)
     {
         // Layout defaults to 'G'

--- a/src/ocean/time/Time_test.d
+++ b/src/ocean/time/Time_test.d
@@ -66,3 +66,19 @@ unittest
         "01/06/70 00:00:00"
     );
 }
+
+// raw time
+unittest
+{
+    // NB: ocean is compiled with deprecations-as-errors, so deprecated
+    // toString method is not picked even before it is completely removed:
+
+    test!("==")(
+        format("{}", Time.epoch1970),
+        "{ ticks_: 621355968000000000 }"
+    );
+    test!("==")(
+        format("{}", Time.epoch1970 + TimeSpan.fromDays(5)),
+        "{ ticks_: 621360288000000000 }"
+    );
+}

--- a/src/ocean/time/Time_test.d
+++ b/src/ocean/time/Time_test.d
@@ -1,0 +1,53 @@
+/*******************************************************************************
+
+    Copyright:
+        Copyright (c) 2009-2016 Sociomantic Labs GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+        Alternatively, this file may be distributed under the terms of the Tango
+        3-Clause BSD License (see LICENSE_BSD.txt for details).
+
+*******************************************************************************/
+
+module ocean.time.Time_test;
+
+import ocean.time.Time;
+import ocean.core.Test;
+
+unittest
+{
+    test(TimeSpan.zero > TimeSpan.min);
+    test(TimeSpan.max  > TimeSpan.zero);
+    test(TimeSpan.max  > TimeSpan.min);
+    test(TimeSpan.zero >= TimeSpan.zero);
+    test(TimeSpan.zero <= TimeSpan.zero);
+    test(TimeSpan.max >= TimeSpan.max);
+    test(TimeSpan.max <= TimeSpan.max);
+    test(TimeSpan.min >= TimeSpan.min);
+    test(TimeSpan.min <= TimeSpan.min);
+
+    test(TimeSpan.fromSeconds(50).seconds is 50);
+    test(TimeSpan.fromSeconds(5000).seconds is 5000);
+    test(TimeSpan.fromMinutes(50).minutes is 50);
+    test(TimeSpan.fromMinutes(5000).minutes is 5000);
+    test(TimeSpan.fromHours(23).hours is 23);
+    test(TimeSpan.fromHours(5000).hours is 5000);
+    test(TimeSpan.fromDays(6).days is 6);
+    test(TimeSpan.fromDays(5000).days is 5000);
+
+    test(TimeSpan.fromSeconds(50).time.seconds is 50);
+    test(TimeSpan.fromSeconds(5000).time.seconds is 5000 % 60);
+    test(TimeSpan.fromMinutes(50).time.minutes is 50);
+    test(TimeSpan.fromMinutes(5000).time.minutes is 5000 % 60);
+    test(TimeSpan.fromHours(23).time.hours is 23);
+    test(TimeSpan.fromHours(5000).time.hours is 5000 % 24);
+
+    auto tod = TimeOfDay (25, 2, 3, 4);
+    tod = tod.span.time;
+    test(tod.hours is 1);
+    test(tod.minutes is 2);
+    test(tod.seconds is 3);
+    test(tod.millis is 4);
+}

--- a/src/ocean/time/Time_test.d
+++ b/src/ocean/time/Time_test.d
@@ -15,6 +15,8 @@ module ocean.time.Time_test;
 
 import ocean.time.Time;
 import ocean.core.Test;
+import ocean.text.convert.Formatter;
+import ocean.text.convert.DateTime_tango;
 
 unittest
 {
@@ -50,4 +52,17 @@ unittest
     test(tod.minutes is 2);
     test(tod.seconds is 3);
     test(tod.millis is 4);
+}
+
+// pretty time formatting
+unittest
+{
+    test!("==")(
+        format("{}", asPrettyStr(Time.epoch1970)),
+        "01/01/70 00:00:00"
+    );
+    test!("==")(
+        format("{}", asPrettyStr(Time.epoch1970 + TimeSpan.fromDays(5))),
+        "01/06/70 00:00:00"
+    );
 }


### PR DESCRIPTION
First step before removing them in ocean v4.0.0 and breaking one of import cycles vanilla druntime complains about.