### PR TITLE
Use modified TimerSet in task utils with invariant

### DIFF
--- a/src/ocean/io/select/client/TimerSet.d
+++ b/src/ocean/io/select/client/TimerSet.d
@@ -212,8 +212,10 @@ public class TimerSet ( EventData ) : TimerEventTimeoutManager
 
         public void timeout ( )
         {
-            this.fired_dg(this.data);
+            auto fired_dg = this.fired_dg;
+            auto data = this.data;
             this.outer.events.recycle(this);
+            fired_dg(data);
         }
 
 

--- a/src/ocean/io/select/client/TimerSet.d
+++ b/src/ocean/io/select/client/TimerSet.d
@@ -258,14 +258,6 @@ public class TimerSet ( EventData ) : TimerEventTimeoutManager
 
     private ObjectPool!(Event) events;
 
-    version (UnitTest)
-    {
-        public size_t allocated_event_count ( )
-        {
-            return events.length();
-        }
-    }
-
     /***************************************************************************
 
         Constructor.

--- a/src/ocean/io/select/client/TimerSet.d
+++ b/src/ocean/io/select/client/TimerSet.d
@@ -256,7 +256,7 @@ public class TimerSet ( EventData ) : TimerEventTimeoutManager
 
     ***************************************************************************/
 
-    private ObjectPool!(Event) events;
+    protected ObjectPool!(Event) events;
 
     /***************************************************************************
 

--- a/src/ocean/task/util/Timer.d
+++ b/src/ocean/task/util/Timer.d
@@ -112,10 +112,7 @@ unittest
     theScheduler.schedule(task);
     theScheduler.eventLoop();
 
-    // NB: allocated event count is expected to be 1 more than strictly
-    // necessary here because they are recycled only after task finishes
-    // or suspend again, not immediately after it gets resumed on timer
-    test!("==")(.timer.allocated_event_count(), 2);
+    test!("==")(.timer.scheduled_events(), 1);
 }
 
 /*******************************************************************************

--- a/src/ocean/task/util/Timer.d
+++ b/src/ocean/task/util/Timer.d
@@ -245,7 +245,7 @@ unittest
 
 *******************************************************************************/
 
-private TimerSet!(EventData) timer;
+private TaskTimerSet timer;
 
 /*******************************************************************************
 
@@ -258,6 +258,26 @@ private TimerSet!(EventData) timer;
 private struct EventData
 {
     Task to_resume;
+}
+
+/*******************************************************************************
+
+    Derivative from generic ocean TimerSet which augments it with task-specific
+    sanity checks.
+
+*******************************************************************************/
+
+private class TaskTimerSet : TimerSet!(EventData)
+{
+    invariant ( )
+    {
+        auto _this = cast(TaskTimerSet) this;
+        scope iterator = _this.events.new BusyItemsIterator;
+        foreach (event; iterator)
+        {
+            assert (event.data.to_resume.fiber !is null);
+        }
+    }
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Ensures to-be-resumed tasks in currently registered events are in the
valid state.