### PR TITLE
Deprecate a bunch of unused modules

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -35,6 +35,7 @@ TEST_FILTER_OUT += \
 	$C/src/ocean/core/Exception_tango.d \
 	$C/src/ocean/io/device/SerialPort.d \
 	$C/src/ocean/io/device/ProgressFile.d \
+	$C/src/ocean/io/vfs/ZipFolder.d \
 	$C/src/ocean/math/BigInt.d \
 	$C/src/ocean/net/http/ChunkStream.d \
 	$C/src/ocean/util/log/LayoutChainsaw.d \

--- a/Build.mak
+++ b/Build.mak
@@ -38,6 +38,7 @@ TEST_FILTER_OUT += \
 	$C/src/ocean/io/vfs/ZipFolder.d \
 	$C/src/ocean/math/BigInt.d \
 	$C/src/ocean/net/http/ChunkStream.d \
+	$C/src/ocean/util/compress/Zip.d \
 	$C/src/ocean/util/log/LayoutChainsaw.d \
 	$C/src/ocean/util/log/Log.d \
 	$C/src/ocean/text/convert/Memory.d \

--- a/Build.mak
+++ b/Build.mak
@@ -35,6 +35,12 @@ TEST_FILTER_OUT += \
 	$C/src/ocean/core/Exception_tango.d \
 	$C/src/ocean/io/device/SerialPort.d \
 	$C/src/ocean/io/device/ProgressFile.d \
+	$C/src/ocean/io/stream/Digester.d \
+	$C/src/ocean/io/stream/Endian.d \
+	$C/src/ocean/io/stream/Greedy.d \
+	$C/src/ocean/io/stream/Map.d \
+	$C/src/ocean/io/stream/Typed.d \
+	$C/src/ocean/io/stream/Utf.d \
 	$C/src/ocean/io/vfs/ZipFolder.d \
 	$C/src/ocean/math/BigInt.d \
 	$C/src/ocean/net/http/ChunkStream.d \

--- a/Build.mak
+++ b/Build.mak
@@ -36,6 +36,7 @@ TEST_FILTER_OUT += \
 	$C/src/ocean/io/device/SerialPort.d \
 	$C/src/ocean/io/device/ProgressFile.d \
 	$C/src/ocean/math/BigInt.d \
+	$C/src/ocean/net/http/ChunkStream.d \
 	$C/src/ocean/util/log/LayoutChainsaw.d \
 	$C/src/ocean/util/log/Log.d \
 	$C/src/ocean/text/convert/Memory.d \

--- a/relnotes/chunkstream.deprecation.md
+++ b/relnotes/chunkstream.deprecation.md
@@ -1,0 +1,5 @@
+* `ocean.net.http.ChunkStream`
+
+  This module and its two classes, `ChunkOutput` and `ChunkInput` are deprecated.
+  They are heritage from the Tango era and are neither used nor tested nowadays.
+  If you need them, let core team know.

--- a/relnotes/compress-zip.deprecation.md
+++ b/relnotes/compress-zip.deprecation.md
@@ -1,0 +1,3 @@
+* `ocean.util.compress.Zip`
+
+  This now-unused module is an heritage of the Tango times which is not used anymore.

--- a/relnotes/stream-stuff.deprecation.md
+++ b/relnotes/stream-stuff.deprecation.md
@@ -1,0 +1,3 @@
+* `ocean.io.stream.Digester`, `ocean.io.stream.Endian`, `ocean.io.stream.Greedy`, `ocean.io.stream.Map`, `ocean.io.stream.Typed`, `ocean.io.stream.Utf`
+
+  Those module are unused within Sociomantic. They are also  barely tested and antiquated, and thus have been deprecated.

--- a/relnotes/zipfolder.deprecation.md
+++ b/relnotes/zipfolder.deprecation.md
@@ -1,0 +1,4 @@
+* `ocean.io.vfs.ZipFolder`
+
+  This module and all contained classes are deprecated.
+  They are neither used nor tested and it would take a sizeable amount of work to get it in a decent shape.

--- a/src/ocean/io/stream/Digester.d
+++ b/src/ocean/io/stream/Digester.d
@@ -15,7 +15,7 @@
 
 *******************************************************************************/
 
-module ocean.io.stream.Digester;
+deprecated module ocean.io.stream.Digester;
 
 import ocean.transition;
 
@@ -30,7 +30,7 @@ import ocean.util.digest.Digest;
 
 *******************************************************************************/
 
-class DigestInput : InputFilter, InputFilter.Mutator
+deprecated class DigestInput : InputFilter, InputFilter.Mutator
 {
         private Digest filter;
 
@@ -107,7 +107,7 @@ class DigestInput : InputFilter, InputFilter.Mutator
 
 *******************************************************************************/
 
-class DigestOutput : OutputFilter, InputFilter.Mutator
+deprecated class DigestOutput : OutputFilter, InputFilter.Mutator
 {
         private Digest filter;
 

--- a/src/ocean/io/stream/Endian.d
+++ b/src/ocean/io/stream/Endian.d
@@ -18,7 +18,7 @@
 
 *******************************************************************************/
 
-module ocean.io.stream.Endian;
+deprecated module ocean.io.stream.Endian;
 
 import ocean.transition;
 
@@ -36,7 +36,7 @@ version(UnitTest) import ocean.core.Test;
 
 *******************************************************************************/
 
-class EndianInput(T) : InputFilter, InputFilter.Mutator
+deprecated class EndianInput(T) : InputFilter, InputFilter.Mutator
 {
         static if ((T.sizeof != 2) && (T.sizeof != 4) && (T.sizeof != 8))
                     pragma (msg, "EndianInput :: type should be of length 2, 4, or 8 bytes");
@@ -91,7 +91,7 @@ class EndianInput(T) : InputFilter, InputFilter.Mutator
 
 *******************************************************************************/
 
-class EndianOutput (T) : OutputFilter, OutputFilter.Mutator
+deprecated class EndianOutput (T) : OutputFilter, OutputFilter.Mutator
 {
         static if ((T.sizeof != 2) && (T.sizeof != 4) && (T.sizeof != 8))
                     pragma (msg, "EndianOutput :: type should be of length 2, 4, or 8 bytes");

--- a/src/ocean/io/stream/Greedy.d
+++ b/src/ocean/io/stream/Greedy.d
@@ -15,7 +15,7 @@
 
 *******************************************************************************/
 
-module ocean.io.stream.Greedy;
+deprecated module ocean.io.stream.Greedy;
 
 import ocean.transition;
 
@@ -29,7 +29,7 @@ import ocean.io.device.Conduit;
 
 *******************************************************************************/
 
-class GreedyInput : InputFilter
+deprecated class GreedyInput : InputFilter
 {
         /***********************************************************************
 
@@ -96,7 +96,7 @@ class GreedyInput : InputFilter
 
 *******************************************************************************/
 
-class GreedyOutput : OutputFilter
+deprecated class GreedyOutput : OutputFilter
 {
         /***********************************************************************
 

--- a/src/ocean/io/stream/Map.d
+++ b/src/ocean/io/stream/Map.d
@@ -17,7 +17,7 @@
 
 *******************************************************************************/
 
-module ocean.io.stream.Map;
+deprecated module ocean.io.stream.Map;
 
 import ocean.transition;
 
@@ -37,7 +37,7 @@ version(UnitTest) import ocean.core.Test;
 
 *******************************************************************************/
 
-class MapInput(T) : Lines!(T)
+deprecated class MapInput(T) : Lines!(T)
 {
         /***********************************************************************
 
@@ -121,7 +121,7 @@ class MapInput(T) : Lines!(T)
 
 *******************************************************************************/
 
-class MapOutput(T) : OutputFilter
+deprecated class MapOutput(T) : OutputFilter
 {
         private Const!(T)[] eol;
 
@@ -207,7 +207,7 @@ version (UnitTest)
     import ocean.io.device.Array;
 }
 
-unittest
+deprecated unittest
 {
     auto buf = new Array(200);
     auto input = new MapInput!(char)(buf);

--- a/src/ocean/io/stream/Typed.d
+++ b/src/ocean/io/stream/Typed.d
@@ -18,7 +18,7 @@
 
 *******************************************************************************/
 
-module ocean.io.stream.Typed;
+deprecated module ocean.io.stream.Typed;
 
 import ocean.io.device.Conduit;
 
@@ -32,7 +32,7 @@ version(UnitTest) import ocean.core.Test;
 
 *******************************************************************************/
 
-class TypedInput(T) : InputFilter
+deprecated class TypedInput(T) : InputFilter
 {
         /***********************************************************************
 
@@ -93,7 +93,7 @@ class TypedInput(T) : InputFilter
 
 *******************************************************************************/
 
-class TypedOutput(T) : OutputFilter
+deprecated class TypedOutput(T) : OutputFilter
 {
         /***********************************************************************
 
@@ -127,7 +127,7 @@ version (UnitTest)
     import ocean.io.device.Array;
 }
 
-unittest
+deprecated unittest
 {
     Array output;
 

--- a/src/ocean/io/stream/Utf.d
+++ b/src/ocean/io/stream/Utf.d
@@ -19,7 +19,7 @@
 
 *******************************************************************************/
 
-module ocean.io.stream.Utf;
+deprecated module ocean.io.stream.Utf;
 
 import ocean.transition;
 
@@ -36,7 +36,7 @@ import Utf = ocean.text.convert.Utf;
 
 *******************************************************************************/
 
-class UtfInput(T, S) : InputFilter, InputFilter.Mutator
+deprecated class UtfInput(T, S) : InputFilter, InputFilter.Mutator
 {
         static if (!is (S == char) && !is (S == wchar) && !is (S == dchar))
                     pragma (msg, "Source type must be char, wchar, or dchar");
@@ -131,7 +131,7 @@ class UtfInput(T, S) : InputFilter, InputFilter.Mutator
 
 *******************************************************************************/
 
-class UtfOutput (S, T) : OutputFilter, OutputFilter.Mutator
+deprecated class UtfOutput (S, T) : OutputFilter, OutputFilter.Mutator
 {
         static if (!is (S == char) && !is (S == wchar) && !is (S == dchar))
                     pragma (msg, "Source type must be char, wchar, or dchar");

--- a/src/ocean/io/vfs/ZipFolder.d
+++ b/src/ocean/io/vfs/ZipFolder.d
@@ -17,7 +17,7 @@
 
 *******************************************************************************/
 
-module ocean.io.vfs.ZipFolder;
+deprecated module ocean.io.vfs.ZipFolder;
 
 import ocean.transition;
 
@@ -279,7 +279,7 @@ private
  * the sync operation, you can also use the archive member to get a reference
  * to the underlying ZipFolder instance.
  */
-class ZipSubFolder : VfsFolder, VfsSync
+deprecated class ZipSubFolder : VfsFolder, VfsSync
 {
     ///
     final istring name()
@@ -595,7 +595,7 @@ private:
  * ZipFolder serves as the root object for all Zip archives in the VFS.
  * Presently, it can only open archives on the local filesystem.
  */
-class ZipFolder : ZipSubFolder
+deprecated class ZipFolder : ZipSubFolder
 {
     /**
      * Opens an archive from the local filesystem.  If the readonly argument
@@ -943,7 +943,7 @@ private:
 /**
  * This class represents a file within an archive.
  */
-class ZipFile : VfsFile
+deprecated class ZipFile : VfsFile
 {
     ///
     final istring name()
@@ -1276,7 +1276,7 @@ else
 // ************************************************************************ //
 // ************************************************************************ //
 
-class ZipSubFolderEntry : VfsFolderEntry
+deprecated class ZipSubFolderEntry : VfsFolderEntry
 {
     final VfsFolder open()
     {
@@ -1382,7 +1382,7 @@ private:
 // ************************************************************************ //
 // ************************************************************************ //
 
-class ZipSubFolderGroup : VfsFolders
+deprecated class ZipSubFolderGroup : VfsFolders
 {
     final int opApply(int delegate(ref VfsFolder) dg)
     {
@@ -1503,7 +1503,7 @@ private:
 // ************************************************************************ //
 // ************************************************************************ //
 
-class ZipFileGroup : VfsFiles
+deprecated class ZipFileGroup : VfsFiles
 {
     final int opApply(int delegate(ref VfsFile) dg)
     {

--- a/src/ocean/net/http/ChunkStream.d
+++ b/src/ocean/net/http/ChunkStream.d
@@ -19,7 +19,7 @@
 
 *******************************************************************************/
 
-module ocean.net.http.ChunkStream;
+deprecated module ocean.net.http.ChunkStream;
 
 import ocean.transition;
 
@@ -39,7 +39,7 @@ import Integer = ocean.text.convert.Integer_tango;
 
 *******************************************************************************/
 
-class ChunkOutput : OutputFilter
+deprecated class ChunkOutput : OutputFilter
 {
         private OutputBuffer output;
 
@@ -98,7 +98,7 @@ class ChunkOutput : OutputFilter
 
 *******************************************************************************/
 
-class ChunkInput : Lines!(char)
+deprecated class ChunkInput : Lines!(char)
 {
         private alias void delegate(cstring line) Headers;
 

--- a/src/ocean/util/compress/Zip.d
+++ b/src/ocean/util/compress/Zip.d
@@ -15,7 +15,7 @@
  *
  ******************************************************************************/
 
-module ocean.util.compress.Zip;
+deprecated module ocean.util.compress.Zip;
 
 import ocean.transition;
 import ocean.core.Verify;
@@ -2945,5 +2945,3 @@ private:
         assert( _position >= 0 );
     }
 }
-
-


### PR DESCRIPTION
[I was trying to adapt `Stdout` in v4.x.x to use the Formatter...](https://i.imgur.com/rQIb4Vw.mp4)
Since it uses `FormatOutput`, I started to look at the class, its functionalities and how to adapt that to the Formatter. Reducing the amount of modules using those classes should offer a much better overview of the wanted functionalities.