### PR TITLE
Re-enable SmartUnion.handleInvalidCases unittest

### DIFF
--- a/src/ocean/core/SmartUnion.d
+++ b/src/ocean/core/SmartUnion.d
@@ -312,8 +312,6 @@ private const handleInvalidCases = "case none: assert(false);" ~
     // has no default so we add a default here just to avoid the warning.
     "version (D_Version2){} else {default: assert(false);}";
 
-// Disabled until DMD 1.081 becomes widely available
-/*
 ///
 unittest
 {
@@ -336,7 +334,6 @@ unittest
         mixin(TestSmartUnion.handleInvalidCases);
     }
 }
-*/
 
 /******************************************************************************
 


### PR DESCRIPTION
This unittest was using final switch, with the support for it added only
in the DMD v1.081.x, which was not yet widely available at the time of
v3.5.0 release.

Fixes #302.