### PR TITLE
Tweaks for `toContextDg` docs

### DIFF
--- a/relnotes/context-dg.feature.md
+++ b/relnotes/context-dg.feature.md
@@ -1,4 +1,4 @@
-# New utility to forge zero-allocation closures with one argument
+## New utility to forge zero-allocation closures with one argument
 
 `ocean.core.TypeConvert`
 

--- a/src/ocean/core/TypeConvert.d
+++ b/src/ocean/core/TypeConvert.d
@@ -271,9 +271,12 @@ void delegate() toContextDg ( alias F ) ( void* context )
 {
     static assert (is(typeof(&F) == void function (void*)));
 
-    // Makes use of the fact that D ABI allows converting aggregate methods
-    // to delegates such that resulting delegate context pointer becomes
-    // aggregate `this`:
+    // This code makes use of two facts:
+    //    1) The D ABI allows aggregate methods to be converted to delegates,
+    //       such that the delegate context pointer becomes the `this` pointer
+    //       of the aggregate
+    //    2) The compiler supports explicit modification of the .ptr member of a
+    //       delegate, without modifying the existing .functptr.
 
     static struct Fake
     {


### PR DESCRIPTION
Based on follow-up comments on https://github.com/sociomantic-tsunami/ocean/pull/349 that came after merging.