### PR TITLE
Reduce EpollProcess memory usage: use a FreelistAllocator

### DIFF
--- a/relnotes/nogc-process.feature.md
+++ b/relnotes/nogc-process.feature.md
@@ -1,0 +1,6 @@
+## `EpollProcess` no longer allocates memory
+
+`ocean.io.select.client.EpollProcess`
+
+`EpollProcess` now uses a `FreeListAllocator` internally, so that starting a
+new process after a previous one has finished no longer allocates memory.

--- a/src/ocean/io/select/client/EpollProcess.d
+++ b/src/ocean/io/select/client/EpollProcess.d
@@ -177,13 +177,27 @@ public abstract class EpollProcess
 
         /***********************************************************************
 
+            Allocate the map from a free list, to reduce memory allocation.
+
+        ***********************************************************************/
+
+        import FreeListAllocator =
+            ocean.util.container.map.model.BucketElementFreeList;
+
+
+        /***********************************************************************
+
             Constructor.
 
         ***********************************************************************/
 
         public this ( )
         {
-            this.processes = new StandardKeyHashingMap!(EpollProcess, int)(20);
+            // Allocate the map using a free list
+
+            this.processes = new StandardKeyHashingMap!(EpollProcess, int)(
+                FreeListAllocator.instantiateAllocator!(
+                    StandardKeyHashingMap!(EpollProcess, int)), 20);
 
             this.sigchild_event = new SelectEvent(&this.selectEventHandler);
 


### PR DESCRIPTION
The existing code assumed that creating new processes is sufficiently rare that memory efficiency is unimportant, but some apps create a large number of processes. (In my apps, several hundred processes are created every second).
To reduce GC usage, use a FreeListAllocator, so that memory is recycled.
