### PR TITLE
Formatter: Allow {X} to work as format string, not only {:X}

### DIFF
--- a/relnotes/parser-extended.feature.md
+++ b/relnotes/parser-extended.feature.md
@@ -1,0 +1,6 @@
+## Simplified format specifier
+
+`ocean.text.convert.Formatter`
+
+The Formatter used to refuse format specifiers lacking a colon, so `{:X}` had to be used instead of `{X}`.
+This baseless limitation was removed, and now `{X}` works as `{:X}`.

--- a/src/ocean/text/convert/Formatter.d
+++ b/src/ocean/text/convert/Formatter.d
@@ -725,10 +725,11 @@ private FormatInfo consume (FormatterSink sink, ref cstring fmt)
 
     // Finally get the format string, if any
     // e.g. for `{5:X} that would be 'X'
-    if (*s == ':' && s < end)
+    if (*s == ':')
+        ++s;
+    if (s < end)
     {
-        auto fs = ++s;
-
+        auto fs = s;
         // eat everything up to closing brace
         while (s < end && *s != '}')
             ++s;

--- a/src/ocean/text/convert/Formatter_test.d
+++ b/src/ocean/text/convert/Formatter_test.d
@@ -543,3 +543,9 @@ unittest
     const bool NO  = false;
     test(format("{} -- {}", YES, NO) == "true -- false");
 }
+
+unittest
+{
+    // Used to work only with "{:X}", however this limitation was lifted
+    assert(format("{X}", 42) == "2A");
+}


### PR DESCRIPTION
A change on a rather obscure behavior.