### PR TITLE
Revert "Change assert(false) to verify(false) in SmartUnion.handleInv…

### DIFF
--- a/src/ocean/core/SmartUnion.d
+++ b/src/ocean/core/SmartUnion.d
@@ -306,7 +306,7 @@ version ( UnitTest )
 
 *******************************************************************************/
 
-private const handleInvalidCases = "case none: verify(false); break;" ~
+private const handleInvalidCases = "case none: assert(false);" ~
     // The D2 build makes sure all enum cases are covered so in fact we don't
     // need a default. However, D1 emits a compiler warning if a switch
     // has no default so we add a default here just to avoid the warning.


### PR DESCRIPTION
…alidCases"

This reverts commit b1f22ac3e89ebd17309897e48d29d4ec49c47d2d as the
change is now a breaking change, since `ocean.core.Verify` needs
to be imported in the modules using this mixin.