### PR TITLE
Fix inconsistency for locateDelim() in derived class

### DIFF
--- a/src/ocean/text/util/SplitIterator.d
+++ b/src/ocean/text/util/SplitIterator.d
@@ -514,9 +514,6 @@ abstract class ISplitIterator
             index of the first delimiter occurrence in str or str.length
             either not found or start >= content.length
 
-         In:
-             start must be at most content.length.
-
      **************************************************************************/
 
     public size_t locateDelim ( size_t start = 0 )

--- a/src/ocean/text/util/SplitIterator.d
+++ b/src/ocean/text/util/SplitIterator.d
@@ -253,7 +253,7 @@ class ChrSplitIterator : ISplitIterator
 
         Params:
              str   = string to scan
-             start = search start index
+             start = search start index, must be at most str.length
 
         Returns:
              index of first occurrence of delim in str or str.length if not
@@ -264,7 +264,7 @@ class ChrSplitIterator : ISplitIterator
     public override size_t locateDelim ( cstring str, size_t start = 0 )
     {
         verify(
-            start < str.length,
+            start <= str.length,
             typeof (this).stringof ~ ".locateDelim: start index out of range"
         );
 


### PR DESCRIPTION
The `verify()` applied in the derived class should check for the
same ranges as the one in the base class.

When these methods were using contracts this issue was not noticed due
to the `in` contract inheritance.