### PR TITLE
Call libgcrypt and libgcrypt-error initialisation functions as shared

### DIFF
--- a/src/ocean/util/cipher/gcrypt/c/gpgerror.d
+++ b/src/ocean/util/cipher/gcrypt/c/gpgerror.d
@@ -608,10 +608,18 @@ const GPG_ERR_SOURCE_SHIFT  = 24;
 /// See original's library documentation for details.
 uint gpg_err_init();
 
-static this ( )
+version (D_Version2)
 {
-    gpg_err_init();
+    mixin("shared static this ( ) { gpg_err_init(); }");
 }
+else
+{
+    static this ( )
+    {
+        gpg_err_init();
+    }
+}
+
 
 /// See original's library documentation for details.
 void gpg_err_deinit (int mode);

--- a/src/ocean/util/cipher/gcrypt/c/libversion.d
+++ b/src/ocean/util/cipher/gcrypt/c/libversion.d
@@ -35,13 +35,26 @@ public istring gcrypt_version = "1.5.0";
 
 *******************************************************************************/
 
-static this ( )
+private void staticCtor ( )
 {
     if ( !gcry_check_version(gcrypt_version.ptr) )
     {
         throw new Exception("Version of libgcrypt is less than "~gcrypt_version);
     }
 }
+
+version (D_Version2)
+{
+    mixin("shared static this () { staticCtor(); }");
+}
+else
+{
+    static this ()
+    {
+        staticCtor();
+    }
+}
+
 
 /// See original's library documentation for details.
 extern (C) Const!(char)* gcry_check_version ( Const!(char)* req_version);


### PR DESCRIPTION
In D2, these initialization functions should be called inside `shared
static` constructor, not inside static constructor, as the
initialization should not be done per thread, but once per application's
lifetime.