### PR TITLE
 Deprecate RTTI-specific functions in stream's Format

### DIFF
--- a/relnotes/arguments-layout.deprecation.md
+++ b/relnotes/arguments-layout.deprecation.md
@@ -1,0 +1,7 @@
+## Arguments.error is now deprecated
+
+`ocean.text.Arguments`
+
+In order to support the upcoming removal of `ocean.text.convert.Layout_tango`,
+the `error` method that takes an argument is deprecated in favor of an `error` method
+which takes no argument and uses `Layout!(char).instance` by default.

--- a/relnotes/stdout-formatter.deprecation.md
+++ b/relnotes/stdout-formatter.deprecation.md
@@ -1,0 +1,8 @@
+## Deprecated RRTI-specific functions in Stdout / stream's Format
+
+`ocean.io.Stdout`, `ocean.io.stream.Format`
+
+In both those module, specific support for RTTI has be removed to prepare for the transition from Layout_tango to Formatter.
+This includes `format` and `formatln` methods accepting the `TypeInfo[]` / `void*[]` duo,
+the `print` function which was redundant with `format` and of little use, the `layout` setter and getter,
+and the `Layout`-accepting constructors.

--- a/src/ocean/core/UnitTestRunner.d
+++ b/src/ocean/core/UnitTestRunner.d
@@ -474,7 +474,7 @@ private scope class UnitTestRunner
                 output.flush();
                 output.close();
             }
-            output(printer.print(this.xml_doc)).newline;
+            output.formatln("{}", printer.print(this.xml_doc));
         }
         catch (Exception e)
         {
@@ -897,7 +897,7 @@ private scope class UnitTestRunner
     private void printHelp ( FormatOutput!(char) output )
     {
         this.printUsage(output);
-        output.print(`
+        output.format(`
 optional arguments:
   -h, --help        print this message and exit
   -v, --verbose     print more information about unittest progress, can be

--- a/src/ocean/io/Stdout.d
+++ b/src/ocean/io/Stdout.d
@@ -57,8 +57,6 @@ public alias Stderr stderr; /// Alternative.
 
 static this ( )
 {
-    // note that a static-ctor inside Layout fails
-    // to be invoked before this is executed (bug)
     auto layout = Layout!(char).instance;
 
     Stdout = new TerminalOutput!(char)(layout, Cout.stream);

--- a/src/ocean/io/Stdout.d
+++ b/src/ocean/io/Stdout.d
@@ -57,10 +57,8 @@ public alias Stderr stderr; /// Alternative.
 
 static this ( )
 {
-    auto layout = Layout!(char).instance;
-
-    Stdout = new TerminalOutput!(char)(layout, Cout.stream);
-    Stderr = new TerminalOutput!(char)(layout, Cerr.stream);
+    Stdout = new TerminalOutput!(char)(Cout.stream);
+    Stderr = new TerminalOutput!(char)(Cerr.stream);
 
     Stdout.flush = !Cout.redirected;
     Stdout.redirect = Cout.redirected;
@@ -121,7 +119,7 @@ public class TerminalOutput ( T ) : FormatOutput!(T)
 
     public this (OutputStream output, Immut!(T)[] eol = Eol)
     {
-        this (Layout!(T).instance, output, eol);
+        super(output, eol);
     }
 
 
@@ -132,6 +130,7 @@ public class TerminalOutput ( T ) : FormatOutput!(T)
 
     ***************************************************************************/
 
+    deprecated("Using Layout with this class is deprecated - Remove first argument at call site")
     public this (Layout!(T) convert, OutputStream output, Immut!(T)[] eol = Eol)
     {
         super(convert, output, eol);
@@ -146,7 +145,7 @@ public class TerminalOutput ( T ) : FormatOutput!(T)
 
     public typeof(this) format ( Const!(T)[] fmt, ... )
     {
-        super.format(fmt, _arguments, _argptr);
+        super._transitional_format(fmt, _arguments, _argptr);
         return this;
     }
 
@@ -158,6 +157,7 @@ public class TerminalOutput ( T ) : FormatOutput!(T)
 
     ***************************************************************************/
 
+    deprecated("RTTI-specific function is deprecated, use a Formatter-compatible API")
     public typeof(this) format (Const!(T)[] fmt, TypeInfo[] arguments, ArgList args)
     {
         super.format(fmt, arguments, args);
@@ -174,8 +174,8 @@ public class TerminalOutput ( T ) : FormatOutput!(T)
 
     public typeof(this) formatln ( Const!(T)[] fmt, ... )
     {
-        super.formatln(fmt, _arguments, _argptr);
-        return this;
+        super._transitional_format(fmt, _arguments, _argptr);
+        return this.newline;
     }
 
 
@@ -186,6 +186,7 @@ public class TerminalOutput ( T ) : FormatOutput!(T)
 
     ***************************************************************************/
 
+    deprecated("RTTI-specific function is deprecated, use a Formatter-compatible API")
     public typeof(this) formatln (Const!(T)[] fmt, TypeInfo[] arguments, ArgList args)
     {
         super.formatln(fmt, arguments, args);

--- a/src/ocean/io/stream/Buffered.d
+++ b/src/ocean/io/stream/Buffered.d
@@ -1429,18 +1429,3 @@ class BufferedOutput : OutputFilter, OutputBuffer
                 return this;
         }
 }
-
-
-
-/******************************************************************************
-
-******************************************************************************/
-
-debug (Buffered)
-{
-        void main()
-        {
-                auto input = new BufferedInput (null);
-                auto output = new BufferedOutput (null);
-        }
-}

--- a/src/ocean/io/stream/DataFile.d
+++ b/src/ocean/io/stream/DataFile.d
@@ -111,16 +111,3 @@ class DataFileOutput : DataOutput
                 return conduit;
         }
 }
-
-debug (DataFile)
-{
-        import ocean.io.Stdout;
-
-        void main()
-        {
-                auto myFile = new DataFileOutput("Hello.txt");
-                myFile.write("some text");
-                myFile.flush;
-                Stdout.formatln ("{}:{}", myFile.file.position, myFile.seek(myFile.Anchor.Current));
-        }
-}

--- a/src/ocean/io/stream/Format.d
+++ b/src/ocean/io/stream/Format.d
@@ -292,21 +292,3 @@ class FormatOutput(T) : OutputFilter
                 return count;
         }
 }
-
-
-/*******************************************************************************
-
-*******************************************************************************/
-
-debug (Format)
-{
-        import ocean.io.device.Array;
-
-        void main()
-        {
-                auto print = new FormatOutput!(char) (new Array(1024, 1024));
-
-                for (int i=0;i < 1000; i++)
-                     print(i).newline;
-        }
-}

--- a/src/ocean/io/stream/Lines.d
+++ b/src/ocean/io/stream/Lines.d
@@ -130,20 +130,3 @@ unittest
 {
     auto p = new Lines!(char) (new Array("blah".dup));
 }
-
-/*******************************************************************************
-
-*******************************************************************************/
-
-debug (Lines)
-{
-        import ocean.io.Console;
-        import ocean.io.device.Array;
-
-        void main()
-        {
-                auto lines = new Lines!(char)(new Array("one\ntwo\r\nthree"));
-                foreach (i, line, delim; lines)
-                         Cout (line) (delim);
-        }
-}

--- a/src/ocean/io/stream/TextFile.d
+++ b/src/ocean/io/stream/TextFile.d
@@ -84,21 +84,4 @@ class TextFileOutput : TextOutput
         {
                 super (file);
         }
- }
-
-
-/*******************************************************************************
-
-*******************************************************************************/
-
-debug (TextFile)
-{
-        import ocean.io.Console;
-
-        void main()
-        {
-                auto t = new TextFileInput ("TextFile.d");
-                foreach (line; t)
-                         Cout(line).newline;
-        }
 }

--- a/src/ocean/text/Arguments.d
+++ b/src/ocean/text/Arguments.d
@@ -611,6 +611,7 @@ import ocean.io.stream.Format : FormatOutput;
 import ocean.math.Math;
 import ocean.text.Util;
 import ocean.text.convert.Formatter;
+static import ocean.text.convert.Layout_tango; // TODO: deprecated - remove in v4.0.0
 import ocean.text.convert.Integer_tango;
 import ocean.util.container.SortedMap;
 import ocean.util.container.more.Stack;
@@ -1096,6 +1097,7 @@ public class Arguments
 
     ***************************************************************************/
 
+    deprecated("Use the overload that doesn't take a parameter (and use the Formatter)")
     public istring errors ( mstring delegate(mstring buf, cstring fmt, ...) dg )
     {
         char[256] tmp;
@@ -1112,6 +1114,34 @@ public class Arguments
         }
 
         return result;
+    }
+
+    /***************************************************************************
+
+        Constructs a string of error messages.
+
+        Returns:
+            formatted error message string
+
+    ***************************************************************************/
+
+    public istring errors ()
+    {
+        mstring result;
+
+        foreach (arg; args)
+        {
+            if (arg.error)
+            {
+                // TODO: Replace with `sformat` in v4.0.0
+                ocean.text.convert.Layout_tango.Layout!(char).instance.sprint(
+                    result, msgs[arg.error-1], arg.name,
+                    arg.values.length, arg.min, arg.max, arg.bogus,
+                    arg.options);
+            }
+        }
+
+        return assumeUnique(result);
     }
 
 
@@ -1241,7 +1271,7 @@ public class Arguments
 
     public void displayErrors ( FormatOutput!(char) output = Stderr )
     {
-        output(this.errors(&output.layout.sprint));
+        output(this.errors());
     }
 
 

--- a/src/ocean/text/Arguments.d
+++ b/src/ocean/text/Arguments.d
@@ -1271,7 +1271,7 @@ public class Arguments
 
     public void displayErrors ( FormatOutput!(char) output = Stderr )
     {
-        output(this.errors());
+        output.format("{}", this.errors());
     }
 
 

--- a/src/ocean/util/app/ext/ArgumentsExt.d
+++ b/src/ocean/util/app/ext/ArgumentsExt.d
@@ -190,7 +190,7 @@ class ArgumentsExt : IApplicationExtension
             args.displayErrors(this.stderr);
             foreach (error; errors)
             {
-                this.stderr(error).newline;
+                this.stderr.format("{}", error).newline;
             }
             if (ocean_stderr !is null)
                 ocean_stderr.default_colour;


### PR DESCRIPTION
Deprecate a few methods as part of https://github.com/sociomantic-tsunami/ocean/pull/361