### PR TITLE
Allow both non-interactive and interactive sessions over the unix socket

### DIFF
--- a/relnotes/unixsocket.feature.md
+++ b/relnotes/unixsocket.feature.md
@@ -1,0 +1,10 @@
+## Interactive session over the unix domain socket.
+
+`ocean.net.server.unix.UnixListener`,
+`ocean.net.server.unix.UnixConnectionHandler`,
+`ocean.util.app.ext.UnixSocketExt`
+
+UnixConnectionHandler now accepts the map of the interactive handlers -
+delegates that accept additional delegate argument: `wait_reply`. These handlers
+can initiate interactive session with the user by sending the data via
+`send_response` and waiting for the user to reply via `wait_reply`.

--- a/relnotes/unixsocket.migration.md
+++ b/relnotes/unixsocket.migration.md
@@ -1,8 +1,0 @@
-* `ocean.net.server.unix.UnixListener`,
-  `ocean.net.server.unix.UnixConnectionHandler`,
-  `ocean.util.app.ext.UnixSocketExt`
-
-Handlers previously used for communicating with the user on UnixSocket now
-accept additional delegate: `waitReply`. Handlers now may initiate interactive
-session with the user by sending the data via `send_response` and waiting for
-user to reply via `wait_reply`.

--- a/src/ocean/net/server/unix/UnixListener.d
+++ b/src/ocean/net/server/unix/UnixListener.d
@@ -54,6 +54,35 @@ public class UnixListener : UnixSocketListener!( BasicCommandHandler )
         this.handler = new BasicCommandHandler(handlers);
         super(address_path, epoll, this.handler);
     }
+
+    /***********************************************************************
+
+        Constructor to create the basic command handler directly from
+        an array of handlers with support for interactive sessions.
+
+        Params:
+            address_path = the file path i.e. addreBasicCommandHandlerss of the Unix domain
+                            server socket
+            epoll        = the `EpollSelectDispatcher` instance to use for
+                            I/O (connection handler parameter)
+            handlers     = Array of command to handler delegate.
+            interactive_handlers  = Array of command to interactive handler delegate.
+
+        Throws:
+        `Exception` if
+            - `path` is too long; `path.length` must be less than
+            `UNIX_PATH_MAX`,
+            - an error occurred creating or binding the server socket.
+
+    ***********************************************************************/
+
+    public this ( istring address_path, EpollSelectDispatcher epoll,
+                  BasicCommandHandler.Handler[istring] handlers,
+                  BasicCommandHandler.InteractiveHandler[istring] interactive_handlers )
+    {
+        this.handler = new BasicCommandHandler(handlers, interactive_handlers);
+        super(address_path, epoll, this.handler);
+    }
 }
 
 /*******************************************************************************

--- a/test/unixlistener/main.d
+++ b/test/unixlistener/main.d
@@ -140,6 +140,9 @@ void client_process (cstring socket_path)
     test!("==")(readData(), "first name? ");
     client.write("John\n");
 
+    client.write("echo Joseph\n");
+    test!("==")(readData(), "Joseph");
+
     client.write("shutdown\n");
     client.close();
 }
@@ -221,8 +224,7 @@ int main ( )
 
         // Command shutting down the epoll
         void handleShutdown ( cstring args,
-                void delegate ( cstring response ) send_response,
-                void delegate ( ref mstring response ) wait_reply )
+                void delegate ( cstring response ) send_response )
         {
             epoll.shutdown();
         }
@@ -263,9 +265,18 @@ int main ( )
             send_response("first name? "); wait_reply(response);
             success_count += first == response ? 1 : 0;
         }
+
+        // Simple echo command, non-interactive
+        void handleEcho ( cstring args,
+                void delegate (cstring response) send_response)
+        {
+            send_response(args);
+        }
+
         auto unix_server   = new UnixListener(idup(local_address), epoll,
-                ["shutdown"[]: &handleShutdown,
-                 "increment": &handleIncrementCommand,
+                ["echo"[]: &handleEcho,
+                 "shutdown": &handleShutdown],
+                ["increment"[]: &handleIncrementCommand,
                  "askMyName": &handleAskMyName,
                  "askMeAgain": &handleAskMyNameReverse]
         );


### PR DESCRIPTION
Most usage scenarios over the unix domain socket doesn't require
interactive session, but they consist only of echoing required data over
the socket. For the API to stay simple, UnixListener and related modules
now allow for the old-fashion echo-only command handlers, which only
have a single delegate argument.