### PR TITLE
Deprecate opCall alias to deprecated print

### DIFF
--- a/relnotes/stdout-formatter.deprecation.md
+++ b/relnotes/stdout-formatter.deprecation.md
@@ -6,4 +6,5 @@ In both those module, specific support for RTTI has be removed to prepare for
 the transition from Layout_tango to Formatter.  This includes `format` and
 `formatln` methods accepting the `TypeInfo[]` / `void*[]` duo, the `print`
 function which was redundant with `format` and of little use, the `layout`
-setter and getter, and the `Layout`-accepting constructors.
+setter and getter, and the `Layout`-accepting constructors. Same applies to
+`opCall` as it was aliasing the `print` method.

--- a/relnotes/stdout-formatter.deprecation.md
+++ b/relnotes/stdout-formatter.deprecation.md
@@ -2,7 +2,8 @@
 
 `ocean.io.Stdout`, `ocean.io.stream.Format`
 
-In both those module, specific support for RTTI has be removed to prepare for the transition from Layout_tango to Formatter.
-This includes `format` and `formatln` methods accepting the `TypeInfo[]` / `void*[]` duo,
-the `print` function which was redundant with `format` and of little use, the `layout` setter and getter,
-and the `Layout`-accepting constructors.
+In both those module, specific support for RTTI has be removed to prepare for
+the transition from Layout_tango to Formatter.  This includes `format` and
+`formatln` methods accepting the `TypeInfo[]` / `void*[]` duo, the `print`
+function which was redundant with `format` and of little use, the `layout`
+setter and getter, and the `Layout`-accepting constructors.

--- a/src/ocean/io/stream/Format.d
+++ b/src/ocean/io/stream/Format.d
@@ -81,6 +81,7 @@ class FormatOutput(T) : OutputFilter
         private Layout!(T)      convert;
         private bool            flushLines;
 
+        deprecated("Use the 'format' method instead, or 'flush'")
         public alias print      opCall;         /// opCall -> print
         public alias newline    nl;             /// nl -> newline
 


### PR DESCRIPTION
Found when rebasing v4.x.x and trying to clean deprecated things.