### PR TITLE
Fix ocean.io.Path.isWritable

### DIFF
--- a/src/ocean/io/Path.d
+++ b/src/ocean/io/Path.d
@@ -302,9 +302,7 @@ package struct FS
 
                 static bool isWritable (cstring name)
                 {
-                        stat_t stats = void;
-
-                        return (getInfo(name, stats) & O_RDONLY) is 0;
+                        return posix.access(name.ptr, W_OK) == 0;
                 }
 
                 /***************************************************************

--- a/test/pathutils/main.d
+++ b/test/pathutils/main.d
@@ -1,0 +1,45 @@
+/*******************************************************************************
+
+    Unittest for ocean.io.Path
+
+    Copyright:
+        Copyright (c) 2017 sociomantic labs GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+        Alternatively, this file may be distributed under the terms of the Tango
+        3-Clause BSD License (see LICENSE_BSD.txt for details).
+
+*******************************************************************************/
+
+import ocean.transition;
+
+import ocean.core.Enforce;
+
+import ocean.io.device.File;
+
+import ocean.io.device.TempFile;
+
+import ocean.io.Path;
+
+import ocean.core.Test;
+
+import ocean.util.test.DirectorySandbox;
+
+import core.sys.posix.sys.stat;
+
+/// Test method
+void main ( )
+{
+    auto sandbox = DirectorySandbox.create();
+    scope (exit)
+        sandbox.exitSandbox();
+
+    auto temp_file = new TempFile(TempFile.Permanent);
+    auto path = temp_file.toString();
+
+    test!("==")(isWritable(path), true);
+    enforce(chmod((path ~ '\0').ptr, S_IRUSR) == 0);
+    test!("==")(isWritable(path), false);
+}


### PR DESCRIPTION
The previous implementation of isWritable was broken, as it was using
stat function inappropriately, combining it with a O_RDONLY flag from
the open function, which also happens to has value of 0 so it would
always report is writable. On top of this, even if it worked by some
accident, it would still completely ignore the effective/real uid and
the file ownership.
Although now used access doesn't check the real uid/gid, but the
effective one (meaning the succeeding open could still fail/pass), it's
what we actually want most of the time.