### PR TITLE
Fix memory usage of PullParser in D2 builds

### DIFF
--- a/relnotes/xml.feature.md
+++ b/relnotes/xml.feature.md
@@ -1,0 +1,14 @@
+## Improved memory usage by XML PullParser in D2 builds
+
+`ocean.text.xml.PullParser`
+
+Now doesn't copy input text neither in D1, nor in D2 builds, operating on const
+slices only. Used to have different code path for D2, resulting in new
+allocations each time it was reset.
+
+`ocean.text.xml.Document`
+
+Following changes in `PullParser`, will copy more data from its slices into XML
+node element. Memory usage by `Document` will increase (but will stay fixed for
+a given document), but combined memory usage of `PullParser` + `Document` will
+be the same or even smaller.

--- a/src/ocean/text/xml/Document.d
+++ b/src/ocean/text/xml/Document.d
@@ -333,7 +333,7 @@ version(d)
 version (discrete)
 {
                                   auto node = allocate;
-                                  node.rawValue = super.rawValue;
+                                  Array.copy(node.rawValue, super.rawValue);
                                   node.id = XmlNodeType.Data;
                                   cur.append (node);
 }
@@ -350,9 +350,9 @@ else
                              case XmlTokenType.StartElement:
                                   auto node = allocate;
                                   node.host = cur;
-                                  node.prefixed = super.prefix;
+                                  Array.copy(node.prefixed, super.prefix);
                                   node.id = XmlNodeType.Element;
-                                  node.localName = super.localName;
+                                  Array.copy(node.localName, super.localName);
                                   node.start = p;
 
                                   // inline append
@@ -372,9 +372,9 @@ else
 
                              case XmlTokenType.Attribute:
                                   auto attr = allocate;
-                                  attr.prefixed = super.prefix;
-                                  attr.rawValue = super.rawValue;
-                                  attr.localName = super.localName;
+                                  Array.copy(attr.prefixed, super.prefix);
+                                  Array.copy(attr.rawValue, super.rawValue);
+                                  Array.copy(attr.localName, super.localName);
                                   attr.id = XmlNodeType.Attribute;
                                   cur.attrib (attr);
                                   break;

--- a/src/ocean/text/xml/Document.d
+++ b/src/ocean/text/xml/Document.d
@@ -260,10 +260,6 @@ else
 }
                 newlist;
                 index = 1;
-version(d)
-{
-                freelists = 0;          // needed to align the codegen!
-}
                 return this;
         }
 

--- a/src/ocean/text/xml/PullParser.d
+++ b/src/ocean/text/xml/PullParser.d
@@ -770,4 +770,11 @@ unittest
 {
     auto itr = new PullParser!(char)(testXML);
     testParser (itr);
+
+    // Parsing new text (or even the same one) should not involve any further
+    // memory allocation
+    testNoAlloc({
+        itr.reset(testXML);
+        testParser(itr);
+    }());
 }

--- a/src/ocean/text/xml/PullParser.d
+++ b/src/ocean/text/xml/PullParser.d
@@ -108,8 +108,10 @@ public enum XmlTokenType
 
 *******************************************************************************/
 
-class PullParser(Ch = char)
+class PullParser(ChMut = char)
 {
+    alias Const!(ChMut)  Ch;
+
     public int           depth;
     public Ch[]          prefix;
     public Ch[]          rawValue;
@@ -126,7 +128,7 @@ class PullParser(Ch = char)
 
      ***********************************************************************/
 
-    this(Immut!(Ch)[] content = null)
+    this(Ch[] content = null)
     {
         reset (content);
     }
@@ -610,18 +612,6 @@ class PullParser(Ch = char)
     {
         text.reset (newText);
         reset_;
-    }
-
-    version (D_Version2)
-    {
-        // adding this as versioned overload to avoid extra allocation
-        // for mutable argument
-
-        final void reset(Const!(Ch)[] newText)
-        {
-            text.reset (newText.dup);
-            reset_;
-        }
     }
 
     /***********************************************************************

--- a/src/ocean/text/xml/PullParser.d
+++ b/src/ocean/text/xml/PullParser.d
@@ -39,12 +39,12 @@ version (UnitTest)
 *******************************************************************************/
 
 version (whitespace)
-         version = retainwhite;
+    version = retainwhite;
 else
-   {
+{
    version = stripwhite;
    version = partialwhite;
-   }
+}
 
 /*******************************************************************************
 
@@ -52,8 +52,17 @@ else
 
 *******************************************************************************/
 
-public enum XmlNodeType {Element, Data, Attribute, CData,
-                         Comment, PI, Doctype, Document};
+public enum XmlNodeType
+{
+    Element,
+    Data,
+    Attribute,
+    CData,
+    Comment,
+    PI,
+    Doctype,
+    Document
+}
 
 /*******************************************************************************
 
@@ -61,10 +70,20 @@ public enum XmlNodeType {Element, Data, Attribute, CData,
 
 *******************************************************************************/
 
-public enum XmlTokenType {Done, StartElement, Attribute, EndElement,
-                          EndEmptyElement, Data, Comment, CData,
-                          Doctype, PI, None};
-
+public enum XmlTokenType
+{
+    Done,
+    StartElement,
+    Attribute,
+    EndElement,
+    EndEmptyElement,
+    Data,
+    Comment,
+    CData,
+    Doctype,
+    PI,
+    None
+}
 
 /*******************************************************************************
 
@@ -91,677 +110,677 @@ public enum XmlTokenType {Done, StartElement, Attribute, EndElement,
 
 class PullParser(Ch = char)
 {
-        public int                      depth;
-        public Ch[]                     prefix;
-        public Ch[]                     rawValue;
-        public Ch[]                     localName;
-        public XmlTokenType             type = XmlTokenType.None;
+    public int           depth;
+    public Ch[]          prefix;
+    public Ch[]          rawValue;
+    public Ch[]          localName;
+    public XmlTokenType  type = XmlTokenType.None;
 
-        package XmlText!(Ch)            text;
-        private bool                    stream;
-        private istring                 errMsg;
+    package XmlText!(Ch) text;
+    private bool         stream;
+    private istring      errMsg;
 
-        /***********************************************************************
+    /***********************************************************************
 
-                Construct a parser on the given content (may be null)
+      Construct a parser on the given content (may be null)
 
-        ***********************************************************************/
+     ***********************************************************************/
 
-        this(Immut!(Ch)[] content = null)
+    this(Immut!(Ch)[] content = null)
+    {
+        reset (content);
+    }
+
+    /***********************************************************************
+
+      Consume the next token and return its type
+
+     ***********************************************************************/
+
+    final XmlTokenType next()
+    {
+        auto e = text.end;
+        auto p = text.point;
+
+        // at end of document?
+        if (p >= e)
+            return endOfInput;
+        version (stripwhite)
         {
-                reset (content);
-        }
-
-        /***********************************************************************
-
-                Consume the next token and return its type
-
-        ***********************************************************************/
-
-        final XmlTokenType next()
-        {
-                auto e = text.end;
-                auto p = text.point;
-
-                // at end of document?
-                if (p >= e)
+            // strip leading whitespace
+            while (*p <= 32)
+                if (++p >= e)
                     return endOfInput;
-version (stripwhite)
-{
-                // strip leading whitespace
-                while (*p <= 32)
-                       if (++p >= e)
-                           return endOfInput;
-}
-                // StartElement or Attribute?
-                if (type < XmlTokenType.EndElement)
-                   {
-version (retainwhite)
-{
-                   // strip leading whitespace (thanks to DRK)
-                   while (*p <= 32)
-                          if (++p >= e)
-                              return endOfInput;
-}
-                   switch (*p)
-                          {
-                          case '>':
-                               // termination of StartElement
-                               ++depth;
-                               ++p;
-                               break;
-
-                          case '/':
-                               // empty element closure
-                               text.point = p;
-                               return doEndEmptyElement;
-
-                          default:
-                               // must be attribute instead
-                               text.point = p;
-                               return doAttributeName;
-                          }
-                   }
-
-                // consume data between elements?
-                if (*p != '<')
-                   {
-                   auto q = p;
-                   while (++p < e && *p != '<') {}
-
-                   if (p < e)
-                      {
-version (partialwhite)
-{
-                      // include leading whitespace
-                      while (*(q-1) <= 32)
-                             --q;
-}
-                      text.point = p;
-                      rawValue = q [0 .. p - q];
-                      return type = XmlTokenType.Data;
-                      }
-                   return endOfInput;
-                   }
-
-                // must be a '<' character, so peek ahead
-                switch (p[1])
-                       {
-                       case '!':
-                            // one of the following ...
-                            if (p[2..4] == "--")
-                               {
-                               text.point = p + 4;
-                               return doComment;
-                               }
-                            else
-                               if (p[2..9] == "[CDATA[")
-                                  {
-                                  text.point = p + 9;
-                                  return doCData;
-                                  }
-                               else
-                                  if (p[2..9] == "DOCTYPE")
-                                     {
-                                     text.point = p + 9;
-                                     return doDoctype;
-                                     }
-                            return doUnexpected("!", p);
-
-                       case '\?':
-                            // must be PI data
-                            text.point = p + 2;
-                            return doPI;
-
-                       case '/':
-                            // should be a closing element name
-                            p += 2;
-                            auto q = p;
-                            while (*q > 63 || text.name[*q])
-                                   ++q;
-
-                            if (*q is ':')
-                               {
-                               prefix = p[0 .. q - p];
-                               p = ++q;
-                               while (*q > 63 || text.attributeName[*q])
-                                      ++q;
-
-                               localName = p[0 .. q - p];
-                               }
-                            else
-                               {
-                               prefix = null;
-                               localName = p[0 .. q - p];
-                               }
-
-                            while (*q <= 32)
-                                   if (++q >= e)
-                                       return endOfInput;
-
-                            if (*q is '>')
-                               {
-                               --depth;
-                               text.point = q + 1;
-                               return type = XmlTokenType.EndElement;
-                               }
-                            return doExpected(">", q);
-
-                       default:
-                            // scan new element name
-                            auto q = ++p;
-                            while (*q > 63 || text.name[*q])
-                                   ++q;
-
-                            // check if we ran past the end
-                            if (q >= e)
-                                return endOfInput;
-
-                            if (*q != ':')
-                               {
-                               prefix = null;
-                               localName = p [0 .. q - p];
-                               }
-                            else
-                               {
-                               prefix = p[0 .. q - p];
-                               p = ++q;
-                               while (*q > 63 || text.attributeName[*q])
-                                      ++q;
-                               localName = p[0 .. q - p];
-                               }
-
-                            text.point = q;
-                            return type = XmlTokenType.StartElement;
-                       }
         }
-
-        /***********************************************************************
-
-        ***********************************************************************/
-
-        private XmlTokenType doAttributeName()
+        // StartElement or Attribute?
+        if (type < XmlTokenType.EndElement)
         {
-                auto p = text.point;
-                auto q = p;
-                auto e = text.end;
-
-                while (*q > 63 || text.attributeName[*q])
-                       ++q;
-                if (q >= e)
-                    return endOfInput;
-
-                if (*q is ':')
-                   {
-                   prefix = p[0 .. q - p];
-                   p = ++q;
-
-                   while (*q > 63 || text.attributeName[*q])
-                          ++q;
-
-                   localName = p[0 .. q - p];
-                   }
-                else
-                   {
-                   prefix = null;
-                   localName = p[0 .. q - p];
-                   }
-
-                if (*q <= 32)
-                   {
-                   while (*++q <= 32) {}
-                   if (q >= e)
-                       return endOfInput;
-                   }
-
-                if (*q is '=')
-                   {
-                   while (*++q <= 32) {}
-                   if (q >= e)
-                       return endOfInput;
-
-                   auto quote = *q;
-                   switch (quote)
-                          {
-                          case '"':
-                          case '\'':
-                               p = q + 1;
-                               while (*++q != quote) {}
-                               if (q < e)
-                                  {
-                                  rawValue = p[0 .. q - p];
-                                  text.point = q + 1;   // skip end quote
-                                  return type = XmlTokenType.Attribute;
-                                  }
-                               return endOfInput;
-
-                          default:
-                               return doExpected("\' or \"", q);
-                          }
-                   }
-
-                return doExpected ("=", q);
-        }
-
-        /***********************************************************************
-
-        ***********************************************************************/
-
-        private XmlTokenType doEndEmptyElement()
-        {
-                if (text.point[0] is '/' && text.point[1] is '>')
-                   {
-                   localName = prefix = null;
-                   text.point += 2;
-                   return type = XmlTokenType.EndEmptyElement;
-                   }
-                return doExpected("/>", text.point);
-       }
-
-        /***********************************************************************
-
-        ***********************************************************************/
-
-        private XmlTokenType doComment()
-        {
-                auto e = text.end;
-                auto p = text.point;
-                auto q = p;
-
-                while (p < e)
-                      {
-                      while (*p != '-')
-                             if (++p >= e)
-                                 return endOfInput;
-
-                      if (p[0..3] == "-->")
-                         {
-                         text.point = p + 3;
-                         rawValue = q [0 .. p - q];
-                         return type = XmlTokenType.Comment;
-                         }
-                      ++p;
-                      }
-
-                return endOfInput;
-        }
-
-        /***********************************************************************
-
-        ***********************************************************************/
-
-        private XmlTokenType doCData()
-        {
-                auto e = text.end;
-                auto p = text.point;
-
-                while (p < e)
-                      {
-                      auto q = p;
-                      while (*p != ']')
-                             if (++p >= e)
-                                 return endOfInput;
-
-                      if (p[0..3] == "]]>")
-                         {
-                         text.point = p + 3;
-                         rawValue = q [0 .. p - q];
-                         return type = XmlTokenType.CData;
-                         }
-                      ++p;
-                      }
-
-                return endOfInput;
-        }
-
-        /***********************************************************************
-
-        ***********************************************************************/
-
-        private XmlTokenType doPI()
-        {
-                auto e = text.end;
-                auto p = text.point;
-                auto q = p;
-
-                while (p < e)
-                      {
-                      while (*p != '\?')
-                             if (++p >= e)
-                                 return endOfInput;
-
-                      if (p[1] == '>')
-                         {
-                         rawValue = q [0 .. p - q];
-                         text.point = p + 2;
-                         return type = XmlTokenType.PI;
-                         }
-                      ++p;
-                      }
-                return endOfInput;
-        }
-
-        /***********************************************************************
-
-        ***********************************************************************/
-
-        private XmlTokenType doDoctype()
-        {
-                auto e = text.end;
-                auto p = text.point;
-
-                // strip leading whitespace
-                while (*p <= 32)
-                       if (++p >= e)
-                           return endOfInput;
-
-                auto q = p;
-                while (p < e)
-                      {
-                      if (*p is '>')
-                         {
-                         rawValue = q [0 .. p - q];
-                         prefix = null;
-                         text.point = p + 1;
-                         return type = XmlTokenType.Doctype;
-                         }
-                      else
-                         {
-                         if (*p == '[')
-                             do {
-                                if (++p >= e)
-                                    return endOfInput;
-                                } while (*p != ']');
-                         ++p;
-                         }
-                      }
-
-                if (p >= e)
-                    return endOfInput;
-                return XmlTokenType.Doctype;
-        }
-
-        /***********************************************************************
-
-        ***********************************************************************/
-
-        private XmlTokenType endOfInput ()
-        {
-                if (depth && (stream is false))
-                    error ("Unexpected EOF");
-
-                return XmlTokenType.Done;
-        }
-
-        /***********************************************************************
-
-        ***********************************************************************/
-
-        private XmlTokenType doUnexpected (istring msg, Ch* p)
-        {
-                return position ("parse error :: unexpected  " ~ msg, p);
-        }
-
-        /***********************************************************************
-
-        ***********************************************************************/
-
-        private XmlTokenType doExpected (istring msg, Ch* p)
-        {
-                char[6] tmp = void;
-                return position ("parse error :: expected  " ~ msg ~ " instead of "
-                    ~ idup(Utf.toString(p[0..1], tmp)), p);
-        }
-
-        /***********************************************************************
-
-        ***********************************************************************/
-
-        private XmlTokenType position (istring msg, Ch* p)
-        {
-                return error (msg ~ " at position "
-                    ~ idup(Integer.toString(p-text.text.ptr)));
-        }
-
-        /***********************************************************************
-
-        ***********************************************************************/
-
-        protected final XmlTokenType error (istring msg)
-        {
-                errMsg = msg;
-                throw new XmlException (msg);
-        }
-
-        /***********************************************************************
-
-                Return the raw value of the current token
-
-        ***********************************************************************/
-
-        final Ch[] value()
-        {
-                return rawValue;
-        }
-
-        /***********************************************************************
-
-                Return the name of the current token
-
-        ***********************************************************************/
-
-        final Ch[] name()
-        {
-                if (prefix.length)
-                    return prefix ~ ":" ~ localName;
-                return localName;
-        }
-
-        /***********************************************************************
-
-                Returns the text of the last error
-
-        ***********************************************************************/
-
-        final istring error()
-        {
-                return errMsg;
-        }
-
-        /***********************************************************************
-
-                Reset the parser
-
-        ***********************************************************************/
-
-        final bool reset()
-        {
-                text.reset (text.text);
-                reset_;
-                return true;
-        }
-
-        /***********************************************************************
-
-                Reset parser with new content
-
-        ***********************************************************************/
-
-        final void reset(Ch[] newText)
-        {
-                text.reset (newText);
-                reset_;
-        }
-
-        version (D_Version2)
-        {
-            // adding this as versioned overload to avoid extra allocation
-            // for mutable argument
-
-            final void reset(Const!(Ch)[] newText)
+            version (retainwhite)
             {
-                    text.reset (newText.dup);
-                    reset_;
+                // strip leading whitespace (thanks to DRK)
+                while (*p <= 32)
+                    if (++p >= e)
+                        return endOfInput;
+            }
+            switch (*p)
+            {
+                case '>':
+                    // termination of StartElement
+                    ++depth;
+                    ++p;
+                    break;
+
+                case '/':
+                    // empty element closure
+                    text.point = p;
+                    return doEndEmptyElement;
+
+                default:
+                    // must be attribute instead
+                    text.point = p;
+                    return doAttributeName;
             }
         }
 
-        /***********************************************************************
-
-                experimental: set streaming mode
-
-                Use at your own risk, may be removed.
-
-        ***********************************************************************/
-
-        final void incremental (bool yes = true)
+        // consume data between elements?
+        if (*p != '<')
         {
-                stream = yes;
+            auto q = p;
+            while (++p < e && *p != '<') {}
+
+            if (p < e)
+            {
+                version (partialwhite)
+                {
+                    // include leading whitespace
+                    while (*(q-1) <= 32)
+                        --q;
+                }
+                text.point = p;
+                rawValue = q [0 .. p - q];
+                return type = XmlTokenType.Data;
+            }
+            return endOfInput;
         }
 
-        /***********************************************************************
-
-        ***********************************************************************/
-
-        private void reset_()
+        // must be a '<' character, so peek ahead
+        switch (p[1])
         {
-                depth = 0;
-                errMsg = null;
-                type = XmlTokenType.None;
+            case '!':
+                // one of the following ...
+                if (p[2..4] == "--")
+                {
+                    text.point = p + 4;
+                    return doComment;
+                }
+                else
+                    if (p[2..9] == "[CDATA[")
+                    {
+                        text.point = p + 9;
+                        return doCData;
+                    }
+                    else
+                        if (p[2..9] == "DOCTYPE")
+                        {
+                            text.point = p + 9;
+                            return doDoctype;
+                        }
+                return doUnexpected("!", p);
 
-                auto p = text.point;
-                if (p)
-                   {
-                   static if (Ch.sizeof == 1)
-                          {
-                          // consume UTF8 BOM
-                          if (p[0] is 0xef && p[1] is 0xbb && p[2] is 0xbf)
-                              p += 3;
-                          }
+            case '\?':
+                // must be PI data
+                text.point = p + 2;
+                return doPI;
 
-                   //TODO enable optional declaration parsing
-                   auto e = text.end;
-                   while (p < e && *p <= 32)
-                          ++p;
+            case '/':
+                // should be a closing element name
+                p += 2;
+                auto q = p;
+                while (*q > 63 || text.name[*q])
+                    ++q;
 
-                   if (p < e)
-                       if (p[0] is '<' && p[1] is '\?' && p[2..5] == "xml")
-                          {
-                          p += 5;
-                          while (p < e && *p != '\?')
-                                 ++p;
-                          p += 2;
-                          }
-                   text.point = p;
-                   }
+                if (*q is ':')
+                {
+                    prefix = p[0 .. q - p];
+                    p = ++q;
+                    while (*q > 63 || text.attributeName[*q])
+                        ++q;
+
+                    localName = p[0 .. q - p];
+                }
+                else
+                {
+                    prefix = null;
+                    localName = p[0 .. q - p];
+                }
+
+                while (*q <= 32)
+                    if (++q >= e)
+                        return endOfInput;
+
+                if (*q is '>')
+                {
+                    --depth;
+                    text.point = q + 1;
+                    return type = XmlTokenType.EndElement;
+                }
+                return doExpected(">", q);
+
+            default:
+                // scan new element name
+                auto q = ++p;
+                while (*q > 63 || text.name[*q])
+                    ++q;
+
+                // check if we ran past the end
+                if (q >= e)
+                    return endOfInput;
+
+                if (*q != ':')
+                {
+                    prefix = null;
+                    localName = p [0 .. q - p];
+                }
+                else
+                {
+                    prefix = p[0 .. q - p];
+                    p = ++q;
+                    while (*q > 63 || text.attributeName[*q])
+                        ++q;
+                    localName = p[0 .. q - p];
+                }
+
+                text.point = q;
+                return type = XmlTokenType.StartElement;
         }
+    }
+
+    /***********************************************************************
+
+     ***********************************************************************/
+
+    private XmlTokenType doAttributeName()
+    {
+        auto p = text.point;
+        auto q = p;
+        auto e = text.end;
+
+        while (*q > 63 || text.attributeName[*q])
+            ++q;
+        if (q >= e)
+            return endOfInput;
+
+        if (*q is ':')
+        {
+            prefix = p[0 .. q - p];
+            p = ++q;
+
+            while (*q > 63 || text.attributeName[*q])
+                ++q;
+
+            localName = p[0 .. q - p];
+        }
+        else
+        {
+            prefix = null;
+            localName = p[0 .. q - p];
+        }
+
+        if (*q <= 32)
+        {
+            while (*++q <= 32) {}
+            if (q >= e)
+                return endOfInput;
+        }
+
+        if (*q is '=')
+        {
+            while (*++q <= 32) {}
+            if (q >= e)
+                return endOfInput;
+
+            auto quote = *q;
+            switch (quote)
+            {
+                case '"':
+                case '\'':
+                    p = q + 1;
+                    while (*++q != quote) {}
+                    if (q < e)
+                    {
+                        rawValue = p[0 .. q - p];
+                        text.point = q + 1;   // skip end quote
+                        return type = XmlTokenType.Attribute;
+                    }
+                    return endOfInput;
+
+                default:
+                    return doExpected("\' or \"", q);
+            }
+        }
+
+        return doExpected ("=", q);
+    }
+
+    /***********************************************************************
+
+     ***********************************************************************/
+
+    private XmlTokenType doEndEmptyElement()
+    {
+        if (text.point[0] is '/' && text.point[1] is '>')
+        {
+            localName = prefix = null;
+            text.point += 2;
+            return type = XmlTokenType.EndEmptyElement;
+        }
+        return doExpected("/>", text.point);
+    }
+
+    /***********************************************************************
+
+     ***********************************************************************/
+
+    private XmlTokenType doComment()
+    {
+        auto e = text.end;
+        auto p = text.point;
+        auto q = p;
+
+        while (p < e)
+        {
+            while (*p != '-')
+                if (++p >= e)
+                    return endOfInput;
+
+            if (p[0..3] == "-->")
+            {
+                text.point = p + 3;
+                rawValue = q [0 .. p - q];
+                return type = XmlTokenType.Comment;
+            }
+            ++p;
+        }
+
+        return endOfInput;
+    }
+
+    /***********************************************************************
+
+     ***********************************************************************/
+
+    private XmlTokenType doCData()
+    {
+        auto e = text.end;
+        auto p = text.point;
+
+        while (p < e)
+        {
+            auto q = p;
+            while (*p != ']')
+                if (++p >= e)
+                    return endOfInput;
+
+            if (p[0..3] == "]]>")
+            {
+                text.point = p + 3;
+                rawValue = q [0 .. p - q];
+                return type = XmlTokenType.CData;
+            }
+            ++p;
+        }
+
+        return endOfInput;
+    }
+
+    /***********************************************************************
+
+     ***********************************************************************/
+
+    private XmlTokenType doPI()
+    {
+        auto e = text.end;
+        auto p = text.point;
+        auto q = p;
+
+        while (p < e)
+        {
+            while (*p != '\?')
+                if (++p >= e)
+                    return endOfInput;
+
+            if (p[1] == '>')
+            {
+                rawValue = q [0 .. p - q];
+                text.point = p + 2;
+                return type = XmlTokenType.PI;
+            }
+            ++p;
+        }
+        return endOfInput;
+    }
+
+    /***********************************************************************
+
+     ***********************************************************************/
+
+    private XmlTokenType doDoctype()
+    {
+        auto e = text.end;
+        auto p = text.point;
+
+        // strip leading whitespace
+        while (*p <= 32)
+            if (++p >= e)
+                return endOfInput;
+
+        auto q = p;
+        while (p < e)
+        {
+            if (*p is '>')
+            {
+                rawValue = q [0 .. p - q];
+                prefix = null;
+                text.point = p + 1;
+                return type = XmlTokenType.Doctype;
+            }
+            else
+            {
+                if (*p == '[')
+                    do {
+                        if (++p >= e)
+                            return endOfInput;
+                    } while (*p != ']');
+                ++p;
+            }
+        }
+
+        if (p >= e)
+            return endOfInput;
+        return XmlTokenType.Doctype;
+    }
+
+    /***********************************************************************
+
+     ***********************************************************************/
+
+    private XmlTokenType endOfInput ()
+    {
+        if (depth && (stream is false))
+            error ("Unexpected EOF");
+
+        return XmlTokenType.Done;
+    }
+
+    /***********************************************************************
+
+     ***********************************************************************/
+
+    private XmlTokenType doUnexpected (istring msg, Ch* p)
+    {
+        return position ("parse error :: unexpected  " ~ msg, p);
+    }
+
+    /***********************************************************************
+
+     ***********************************************************************/
+
+    private XmlTokenType doExpected (istring msg, Ch* p)
+    {
+        char[6] tmp = void;
+        return position ("parse error :: expected  " ~ msg ~ " instead of "
+                ~ idup(Utf.toString(p[0..1], tmp)), p);
+    }
+
+    /***********************************************************************
+
+     ***********************************************************************/
+
+    private XmlTokenType position (istring msg, Ch* p)
+    {
+        return error (msg ~ " at position "
+                ~ idup(Integer.toString(p-text.text.ptr)));
+    }
+
+    /***********************************************************************
+
+     ***********************************************************************/
+
+    protected final XmlTokenType error (istring msg)
+    {
+        errMsg = msg;
+        throw new XmlException (msg);
+    }
+
+    /***********************************************************************
+
+      Return the raw value of the current token
+
+     ***********************************************************************/
+
+    final Ch[] value()
+    {
+        return rawValue;
+    }
+
+    /***********************************************************************
+
+      Return the name of the current token
+
+     ***********************************************************************/
+
+    final Ch[] name()
+    {
+        if (prefix.length)
+            return prefix ~ ":" ~ localName;
+        return localName;
+    }
+
+    /***********************************************************************
+
+      Returns the text of the last error
+
+     ***********************************************************************/
+
+    final istring error()
+    {
+        return errMsg;
+    }
+
+    /***********************************************************************
+
+      Reset the parser
+
+     ***********************************************************************/
+
+    final bool reset()
+    {
+        text.reset (text.text);
+        reset_;
+        return true;
+    }
+
+    /***********************************************************************
+
+      Reset parser with new content
+
+     ***********************************************************************/
+
+    final void reset(Ch[] newText)
+    {
+        text.reset (newText);
+        reset_;
+    }
+
+    version (D_Version2)
+    {
+        // adding this as versioned overload to avoid extra allocation
+        // for mutable argument
+
+        final void reset(Const!(Ch)[] newText)
+        {
+            text.reset (newText.dup);
+            reset_;
+        }
+    }
+
+    /***********************************************************************
+
+        experimental: set streaming mode
+
+        Use at your own risk, may be removed.
+
+     ***********************************************************************/
+
+    final void incremental (bool yes = true)
+    {
+        stream = yes;
+    }
+
+    /***********************************************************************
+
+     ***********************************************************************/
+
+    private void reset_()
+    {
+        depth = 0;
+        errMsg = null;
+        type = XmlTokenType.None;
+
+        auto p = text.point;
+        if (p)
+        {
+            static if (Ch.sizeof == 1)
+            {
+                // consume UTF8 BOM
+                if (p[0] is 0xef && p[1] is 0xbb && p[2] is 0xbf)
+                    p += 3;
+            }
+
+            //TODO enable optional declaration parsing
+            auto e = text.end;
+            while (p < e && *p <= 32)
+                ++p;
+
+            if (p < e)
+                if (p[0] is '<' && p[1] is '\?' && p[2..5] == "xml")
+                {
+                    p += 5;
+                    while (p < e && *p != '\?')
+                        ++p;
+                    p += 2;
+                }
+            text.point = p;
+        }
+    }
 }
 
 
 /*******************************************************************************
 
-*******************************************************************************/
+ *******************************************************************************/
 
 package struct XmlText(Ch)
 {
-        package Ch*     end;
-        package size_t  len;
-        package Ch[]    text;
-        package Ch*     point;
+    package Ch*     end;
+    package size_t  len;
+    package Ch[]    text;
+    package Ch*     point;
 
-        final void reset(Ch[] newText)
-        {
-                this.text = newText;
-                this.len = newText.length;
-                this.point = text.ptr;
-                this.end = point + len;
-        }
+    final void reset(Ch[] newText)
+    {
+        this.text = newText;
+        this.len = newText.length;
+        this.point = text.ptr;
+        this.end = point + len;
+    }
 
-        static Const!(ubyte[64]) name =
-        [
-             // 0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
-                0,  1,  1,  1,  1,  1,  1,  1,  1,  0,  0,  1,  1,  0,  1,  1,  // 0
-                1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  // 1
-                0,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  0,  // 2
-                1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  0,  1,  1,  1,  0,  0   // 3
-        ];
+    static Const!(ubyte[64]) name =
+    [
+        // 0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+        0,  1,  1,  1,  1,  1,  1,  1,  1,  0,  0,  1,  1,  0,  1,  1,  // 0
+        1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  // 1
+        0,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  0,  // 2
+        1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  0,  1,  1,  1,  0,  0   // 3
+    ];
 
-        static Const!(ubyte[64]) attributeName =
-        [
-             // 0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
-                0,  1,  1,  1,  1,  1,  1,  1,  1,  0,  0,  1,  1,  0,  1,  1,  // 0
-                1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  // 1
-                0,  0,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  0,  // 2
-                1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  0,  1,  0,  0,  0,  0   // 3
-        ];
+    static Const!(ubyte[64]) attributeName =
+    [
+        // 0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+        0,  1,  1,  1,  1,  1,  1,  1,  1,  0,  0,  1,  1,  0,  1,  1,  // 0
+        1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  // 1
+        0,  0,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  0,  // 2
+        1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  0,  1,  0,  0,  0,  0   // 3
+    ];
 }
 
 /*******************************************************************************
 
-*******************************************************************************/
+ *******************************************************************************/
 
 version (UnitTest)
 {
-	/***********************************************************************
+    /***********************************************************************
 
-	***********************************************************************/
+     ***********************************************************************/
 
-	void testParser(Ch)(PullParser!(Ch) itr)
-	{
-	        test(itr.next);
-	        test(itr.value == "element [ <!ELEMENT element (#PCDATA)>]");
-	        test(itr.type == XmlTokenType.Doctype);
-	        test(itr.next);
-	        test(itr.localName == "element");
-	        test(itr.type == XmlTokenType.StartElement);
-	        test(itr.depth == 0);
-	        test(itr.next);
-	        test(itr.localName == "attr");
-	        test(itr.value == "1");
-	        test(itr.next);
-	        test(itr.type == XmlTokenType.Attribute);
-	        test(itr.localName == "attr2");
-	        test(itr.value == "two");
-	        test(itr.next);
-	        test(itr.value == "comment");
-	        test(itr.next);
-	        test(itr.rawValue == "test&amp;&#x5a;");
-	        test(itr.next);
-	        test(itr.prefix == "qual");
-	        test(itr.localName == "elem");
-	        test(itr.next);
-	        test(itr.type == XmlTokenType.EndEmptyElement);
-	        test(itr.next);
-	        test(itr.localName == "el2");
-	        test(itr.depth == 1);
-	        test(itr.next);
-	        test(itr.localName == "attr3");
-	        test(itr.value == "3three", itr.value);
-	        test(itr.next);
-	        test(itr.rawValue == "sdlgjsh");
-	        test(itr.next);
-	        test(itr.localName == "el3");
-	        test(itr.depth == 2);
-	        test(itr.next);
-	        test(itr.type == XmlTokenType.EndEmptyElement);
-	        test(itr.next);
-	        test(itr.value == "data");
-	        test(itr.next);
-	        test(itr.rawValue == "pi test", itr.rawValue);
-	        test(itr.next);
-	        test(itr.localName == "el2");
-	        test(itr.next);
-	        test(itr.localName == "element");
-	        test(!itr.next);
-	}
+    void testParser(Ch)(PullParser!(Ch) itr)
+    {
+        test(itr.next);
+        test(itr.value == "element [ <!ELEMENT element (#PCDATA)>]");
+        test(itr.type == XmlTokenType.Doctype);
+        test(itr.next);
+        test(itr.localName == "element");
+        test(itr.type == XmlTokenType.StartElement);
+        test(itr.depth == 0);
+        test(itr.next);
+        test(itr.localName == "attr");
+        test(itr.value == "1");
+        test(itr.next);
+        test(itr.type == XmlTokenType.Attribute);
+        test(itr.localName == "attr2");
+        test(itr.value == "two");
+        test(itr.next);
+        test(itr.value == "comment");
+        test(itr.next);
+        test(itr.rawValue == "test&amp;&#x5a;");
+        test(itr.next);
+        test(itr.prefix == "qual");
+        test(itr.localName == "elem");
+        test(itr.next);
+        test(itr.type == XmlTokenType.EndEmptyElement);
+        test(itr.next);
+        test(itr.localName == "el2");
+        test(itr.depth == 1);
+        test(itr.next);
+        test(itr.localName == "attr3");
+        test(itr.value == "3three", itr.value);
+        test(itr.next);
+        test(itr.rawValue == "sdlgjsh");
+        test(itr.next);
+        test(itr.localName == "el3");
+        test(itr.depth == 2);
+        test(itr.next);
+        test(itr.type == XmlTokenType.EndEmptyElement);
+        test(itr.next);
+        test(itr.value == "data");
+        test(itr.next);
+        test(itr.rawValue == "pi test", itr.rawValue);
+        test(itr.next);
+        test(itr.localName == "el2");
+        test(itr.next);
+        test(itr.localName == "element");
+        test(!itr.next);
+    }
 
 
-	/***********************************************************************
+    /***********************************************************************
 
-	***********************************************************************/
+     ***********************************************************************/
 
-	const istring testXML = "<?xml version=\"1.0\" ?><!DOCTYPE element [ <!ELEMENT element (#PCDATA)>]><element "
-	    ~ "attr=\"1\" attr2=\"two\"><!--comment-->test&amp;&#x5a;<qual:elem /><el2 attr3 = "
-	    ~ "'3three'><![CDATA[sdlgjsh]]><el3 />data<?pi test?></el2></element>";
+    const istring testXML = "<?xml version=\"1.0\" ?><!DOCTYPE element [ <!ELEMENT element (#PCDATA)>]><element "
+        ~ "attr=\"1\" attr2=\"two\"><!--comment-->test&amp;&#x5a;<qual:elem /><el2 attr3 = "
+        ~ "'3three'><![CDATA[sdlgjsh]]><el3 />data<?pi test?></el2></element>";
 }
 
 unittest

--- a/src/ocean/text/xml/PullParser.d
+++ b/src/ocean/text/xml/PullParser.d
@@ -1,17 +1,15 @@
 /*******************************************************************************
 
-        Copyright:
-            Copyright (C) 2007 Aaron Craelius and Kris Bell
-            Some parts copyright (c) 2009-2016 Sociomantic Labs GmbH.
-            All rights reserved.
+    Copyright:
+        Copyright (C) 2007 Aaron Craelius and Kris Bell
+        Some parts copyright (c) 2009-2016 Sociomantic Labs GmbH.
+        All rights reserved.
 
-        License:
-            Tango Dual License: 3-Clause BSD License / Academic Free License v3.0.
-            See LICENSE_TANGO.txt for details.
+    License:
+        Tango Dual License: 3-Clause BSD License / Academic Free License v3.0.
+        See LICENSE_TANGO.txt for details.
 
-        Version: Initial release: February 2008
-
-        Authors: Aaron, Kris
+    Authors: Aaron, Kris
 
 *******************************************************************************/
 


### PR DESCRIPTION
Alternative approach to https://github.com/sociomantic-tsunami/ocean/pull/347

Now `PullParser` operates strictly on slices and does no allocations and
`Document` copies those slices into nodes when necessary.