### PR TITLE
Don't error our on deprecation with upstream compiler

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -1,9 +1,12 @@
 # Treat deprecations as errors to ensure ocean doesn't use own deprecated
-# symbols internally
-ifeq ($(DVER),1)
-override DFLAGS := $(filter-out -di,$(DFLAGS)) -v2 -v2=-static-arr-params -v2=-volatile
-else
-override DFLAGS += -de
+# symbols internally. Disable it on explicit flag to make possible regression
+# testing in D upstream.
+ifneq ($(ALLOW_DEPRECATIONS),1)
+	ifeq ($(DVER),2)
+	override DFLAGS += -de
+	else
+	override DFLAGS := $(filter-out -di,$(DFLAGS)) -v2 -v2=-static-arr-params -v2=-volatile
+	endif
 endif
 
 # Makd auto-detects if Ocean's test runner should be used based on submodules,

--- a/Build.mak
+++ b/Build.mak
@@ -5,7 +5,7 @@ ifneq ($(ALLOW_DEPRECATIONS),1)
 	ifeq ($(DVER),2)
 	override DFLAGS += -de
 	else
-	override DFLAGS := $(filter-out -di,$(DFLAGS)) -v2 -v2=-static-arr-params -v2=-volatile
+	override DFLAGS := $(filter-out -di,$(DFLAGS))
 	endif
 endif
 

--- a/Build.mak
+++ b/Build.mak
@@ -1,8 +1,6 @@
 ifeq ($(DVER),1)
 override DFLAGS := $(filter-out -di,$(DFLAGS)) -v2 -v2=-static-arr-params -v2=-volatile
 else
-# Open source Makd uses dmd by default
-DC ?= dmd
 override DFLAGS += -de
 endif
 

--- a/Build.mak
+++ b/Build.mak
@@ -1,3 +1,5 @@
+# Treat deprecations as errors to ensure ocean doesn't use own deprecated
+# symbols internally
 ifeq ($(DVER),1)
 override DFLAGS := $(filter-out -di,$(DFLAGS)) -v2 -v2=-static-arr-params -v2=-volatile
 else

--- a/Build.mak
+++ b/Build.mak
@@ -1,17 +1,3 @@
-# This will make D2 unittests fail if stomping prevention is triggered
-export ASSERT_ON_STOMPING_PREVENTION=1
-
-override DFLAGS += -w -version=GLIBC
-
-# Makd auto-detects if Ocean's test runner should be used based on submodules,
-# but we -or course- don't have Ocean as a submodule, so we set it explicitly.
-TEST_RUNNER_MODULE := ocean.core.UnitTestRunner
-
-# Enable coverage report in CI
-ifdef CI
-COVFLAG:=-cov
-endif
-
 ifeq ($(DVER),1)
 override DFLAGS := $(filter-out -di,$(DFLAGS)) -v2 -v2=-static-arr-params -v2=-volatile
 else
@@ -19,6 +5,10 @@ else
 DC ?= dmd
 override DFLAGS += -de
 endif
+
+# Makd auto-detects if Ocean's test runner should be used based on submodules,
+# but we -or course- don't have Ocean as a submodule, so we set it explicitly.
+TEST_RUNNER_MODULE := ocean.core.UnitTestRunner
 
 # Remove coverage files
 clean += .*.lst

--- a/Config.mak
+++ b/Config.mak
@@ -1,0 +1,9 @@
+# This will make D2 unittests fail if stomping prevention is triggered
+export ASSERT_ON_STOMPING_PREVENTION=1
+
+override DFLAGS += -w -version=GLIBC
+
+# Enable coverage report in CI
+ifdef CI
+COVFLAG:=-cov
+endif

--- a/Config.mak
+++ b/Config.mak
@@ -1,9 +1,11 @@
 # This will make D2 unittests fail if stomping prevention is triggered
+# (only with dmd-transitional, no effect on other compilers)
 export ASSERT_ON_STOMPING_PREVENTION=1
 
+# Common D compiler flags
 override DFLAGS += -w -version=GLIBC
 
 # Enable coverage report in CI
 ifdef CI
-COVFLAG:=-cov
+COVFLAG := -cov
 endif


### PR DESCRIPTION
This is necessary to be able to test ocean as part of upstream
regression test suite.