### PR TITLE
Rename `ocean.sys.Stats.CpuMemoryStats.log` to collect

### DIFF
--- a/relnotes/logstats.deprecation.md
+++ b/relnotes/logstats.deprecation.md
@@ -1,0 +1,7 @@
+## CpuMemoryStats.log is now deprecated in favour of collect
+
+* `ocean.sys.Stats`
+
+  Method `CpuMemoryStats.log` is now renamed to `CpuMemoryStats.collect` to better
+  represent what it does (it doesn't do any logging, it just collects all the
+  stats and returns them via struct instance that can be used for logging).

--- a/src/ocean/sys/Stats.d
+++ b/src/ocean/sys/Stats.d
@@ -148,7 +148,7 @@ public class CpuMemoryStats
 
     ***************************************************************************/
 
-    public Stats log ()
+    public Stats collect ()
     {
         Stats stats;
 
@@ -202,6 +202,13 @@ public class CpuMemoryStats
         this.previous_stat = current_stat;
 
         return stats;
+    }
+
+    /// ditto
+    deprecated("ocean.sys.Stats.CpuMemoryStats.log is deprecated. Use collect instead.")
+    public Stats log ()
+    {
+        return this.collect();
     }
 
     /***************************************************************************

--- a/src/ocean/util/app/DaemonApp.d
+++ b/src/ocean/util/app/DaemonApp.d
@@ -559,7 +559,7 @@ public abstract class DaemonApp : Application,
 
     protected void reportSystemStats ( )
     {
-        this.stats_ext.stats_log.add(this.system_stats.log());
+        this.stats_ext.stats_log.add(this.system_stats.collect());
     }
 
     /***************************************************************************

--- a/test/sysstats/main.d
+++ b/test/sysstats/main.d
@@ -42,7 +42,7 @@ class MyApp : DaemonApp
 
         this.sys_stats = new CpuMemoryStats;
         // log first time to avoid zeroes in CPU usage in the first log
-        this.sys_stats.log();
+        this.sys_stats.collect();
 
         super(name, desc, VersionInfo.init, settings);
     }
@@ -55,7 +55,7 @@ class MyApp : DaemonApp
 
         auto timer = new TimerEvent(
                 {
-                    stats = this.sys_stats.log();
+                    stats = this.sys_stats.collect();
                     this.epoll.shutdown();
 
                     return false;


### PR DESCRIPTION
Method `CpuMemoryStats.log` is now renamed to `CpuMemoryStats.collect` to better
represent what it does (it doesn't do any logging, it just collects all the
stats and returns them via struct instance that can be used for logging).

Fixes #363