### PR TITLE
Make IConnectionHandler.unregisterSocket abstract

### DIFF
--- a/relnotes/unregistersocket.migration.md
+++ b/relnotes/unregistersocket.migration.md
@@ -1,0 +1,19 @@
+## IConnectionHandler.unregisterSocket made abstract
+
+* `ocean.net.server.connection.IConnectionHandler`
+
+  `IConnectionHandler.unregisterSocket` method, previously implemented with an
+  empty body is now made abstract, forcing all ConnectionHandlers to unregister
+  registered socket in a meaningful way before closing them inside the finalizer.
+  In turn, `TaskConnectionHandler` now unregisters its `transceiver` before
+  closing it.
+
+  Example usage:
+
+  ```
+  protected override void unregisterSocket ()
+  {
+      if ( has_registered_client )
+          this.registered_client.unregister();
+  }
+  ```

--- a/src/ocean/net/server/SelectListener.d
+++ b/src/ocean/net/server/SelectListener.d
@@ -681,6 +681,12 @@ unittest
         {
             this.error_occurred = true;
         }
+
+        /// Unregisters the socket from the epoll before closing it. Called by
+        /// finalize.
+        override protected void unregisterSocket ()
+        {
+        }
     }
 
     // Top-level server class which owns the select listener and all global

--- a/src/ocean/net/server/SelectListener_slowtest.d
+++ b/src/ocean/net/server/SelectListener_slowtest.d
@@ -58,6 +58,7 @@ class DummyConHandler : IConnectionHandler
     }
     override protected bool io_error() { return true; }
     override public void handleConnection () {}
+    override public void unregisterSocket() {}
 }
 
 ushort testPort ( ushort port )
@@ -117,6 +118,7 @@ class DummyConHandlerUnix : IConnectionHandler
     }
     override protected bool io_error() { return true; }
     override public void handleConnection () {}
+    override public void unregisterSocket() {}
 }
 
 void test_unix (istring path)

--- a/src/ocean/net/server/connection/IConnectionHandler.d
+++ b/src/ocean/net/server/connection/IConnectionHandler.d
@@ -400,16 +400,9 @@ abstract class IConnectionHandler : IConnectionHandlerInfo,
         exits. Therefore, to be certain that the socket will not fire again in
         epoll, we need to explicitly unregister it.
 
-        This method does nothing by default, but should be overridden by all
-        derived classes.
-
-        TODO: this method should be made abstract in the next major release.
-
     ***************************************************************************/
 
-    protected void unregisterSocket ( )
-    {
-    }
+    abstract protected void unregisterSocket ( );
 
     /***************************************************************************
 

--- a/src/ocean/net/server/connection/TaskConnectionHandler.d
+++ b/src/ocean/net/server/connection/TaskConnectionHandler.d
@@ -112,6 +112,22 @@ abstract class TaskConnectionHandler : IConnectionHandler, Resettable
         this.task = this.new ConnectionHandlerTask;
     }
 
+    /**************************************************************************
+
+        Called by `finalize` to unregister the connection socket from epoll
+        before closing it. This is done because closing a socket does not always
+        mean that it is unregistered from epoll -- in situations where the
+        process has forked, the fork's reference to the underlying kernel file
+        description will prevent it from being unregistered until the fork
+        exits. Therefore, to be certain that the socket will not fire again in
+        epoll, we need to explicitly unregister it.
+
+    ***************************************************************************/
+
+    protected override void unregisterSocket ()
+    {
+        this.transceiver.reset();
+    }
 
     /***************************************************************************
 


### PR DESCRIPTION
`IConnectionHandler.unregisterSocket` method, previously implemented with an
empty body is now made abstract, forcing all ConnectionHandler's to
unregister socket in a meaningful way before closing them from the finalizer.
In turn, `TaskConnectionHandler` now unregister's its `transceiver` before
closing it.