### PR TITLE
Add `Time.fromUnixTime` method

### DIFF
--- a/relnotes/timeunix.feature.md
+++ b/relnotes/timeunix.feature.md
@@ -1,0 +1,6 @@
+## Create Time struct instance from Unix time
+
+* `ocean.time.Time`
+
+  `Time` structure now contains static method `fromUnixTime` which creates
+  `Time` structure instance corresponding to the unix time (relative to 1/1/1970).

--- a/src/ocean/time/Time.d
+++ b/src/ocean/time/Time.d
@@ -23,6 +23,14 @@ module ocean.time.Time;
 import ocean.transition;
 import ocean.text.convert.DateTime_tango;
 
+import core.stdc.time: time_t;
+
+version (UnitTest)
+{
+    import core.stdc.time;
+    import ocean.core.Test;
+}
+
 /******************************************************************************
 
     This struct represents a length of time.  The underlying representation is
@@ -697,6 +705,23 @@ struct Time
                 return TimeSpan(ticks_ - epoch1970.ticks_);
         }
 
+        /**********************************************************************
+
+            Constructs a Time instance from the Unix time (time since 1/1/1970).
+
+            Params:
+                unix_time = number of seconds since 1/1/1970
+
+            Returns:
+                Time instance corresponding the given unix time.
+
+        ***********************************************************************/
+
+        static Time fromUnixTime (time_t unix_time)
+        {
+            return Time(epoch1970.ticks_ + unix_time * TimeSpan.TicksPerSecond);
+        }
+
     /// Support for `ocean.text.convert.Formatter`: Print the string in a
     /// user-friendly way
     deprecated("Use `format(\"{}\", asPrettyStr(time))` instead")
@@ -878,4 +903,11 @@ struct DateTime
 {
         public Date         date;       /// date representation
         public TimeOfDay    time;       /// time representation
+}
+
+unittest
+{
+    auto unix = time(null);
+
+    test!("==")((Time.fromUnixTime(unix) - Time.epoch1970).seconds, unix);
 }


### PR DESCRIPTION
`Time` structure now contains static method `fromUnixTime` which creates
`Time` structure instance corresponding to the unix time (relative to 1/1/1970).

Fixes #188