### PR TITLE
Run PidLock extension before LogExt

### DIFF
--- a/src/ocean/util/app/ext/PidLockExt.d
+++ b/src/ocean/util/app/ext/PidLockExt.d
@@ -77,7 +77,8 @@ class PidLockExt : IConfigExtExtension, IApplicationExtension
 
     /***************************************************************************
 
-        Order doesn't matter, so return default -> 0
+        Order set to -1500, as the extension should run after ConfigExt (-10000)
+        but before LogExt (-1000) (as LogExt can create side effects).
 
         Returns:
             the extension order
@@ -86,7 +87,7 @@ class PidLockExt : IConfigExtExtension, IApplicationExtension
 
     public override int order ( )
     {
-        return 0;
+        return -1500;
     }
 
     /***************************************************************************


### PR DESCRIPTION
PidLock extension require ConfigExt (to read the path to the PidLock
file) but it should be run before LogExt, since the LogExt can try to
perform sideeffects which should not be allowed if another instance of
the application is already running.

Fixes #107