### PR TITLE
Make `IByteQueue.push` accept an `in` buffer argument

### DIFF
--- a/src/ocean/util/container/queue/FixedRingQueue.d
+++ b/src/ocean/util/container/queue/FixedRingQueue.d
@@ -32,6 +32,8 @@ import ocean.util.container.mem.MemManager;
 
 version(UnitTest) import ocean.core.Test;
 
+import ocean.transition;
+
 
 /*******************************************************************************
 
@@ -185,7 +187,7 @@ class FixedByteRingQueue : FixedRingQueueBase!(IByteQueue)
 
     ***************************************************************************/
 
-    bool push ( ubyte[] element )
+    bool push ( in ubyte[] element )
     {
         verify (element.length == super.element_size, "element size mismatch");
 
@@ -193,7 +195,8 @@ class FixedByteRingQueue : FixedRingQueueBase!(IByteQueue)
 
         if (element_in_queue)
         {
-            element_in_queue[] = element[];
+            Const!(void)[] element_ = element;
+            element_in_queue[] = element_[];
             return true;
         }
         else

--- a/src/ocean/util/container/queue/FlexibleFileQueue.d
+++ b/src/ocean/util/container/queue/FlexibleFileQueue.d
@@ -268,7 +268,7 @@ public class FlexibleFileQueue : IByteQueue
 
     ***************************************************************************/
 
-    public bool push ( ubyte[] item )
+    public bool push ( in ubyte[] item )
     {
         verify ( item.length <= this.size,
                  "Read buffer too small to process this item");

--- a/src/ocean/util/container/queue/FlexibleRingQueue.d
+++ b/src/ocean/util/container/queue/FlexibleRingQueue.d
@@ -751,7 +751,7 @@ class FlexibleByteRingQueue : IRingQueue!(IByteQueue)
 
     ***************************************************************************/
 
-    private static void validate ( ExportMetadata meta, void[] data )
+    private static void validate ( in ExportMetadata meta, in void[] data )
     {
         if (meta.items)
         {
@@ -770,7 +770,7 @@ class FlexibleByteRingQueue : IRingQueue!(IByteQueue)
 
             size_t pos = 0;
 
-            for (typeof(meta.items) i = 0; i < meta.items; i++)
+            for (uint i = 0; i < meta.items; i++)
             {
                 verify(pos <= data.length);
 
@@ -789,7 +789,7 @@ class FlexibleByteRingQueue : IRingQueue!(IByteQueue)
                             itoa(start))
                     );
 
-                    auto header = cast(Header*)data[start .. pos].ptr;
+                    auto header = cast(Const!(Header)*)data[start .. pos].ptr;
 
                     enforce!(ValidationError)(
                         (data.length - pos) >= header.length,

--- a/src/ocean/util/container/queue/FlexibleRingQueue.d
+++ b/src/ocean/util/container/queue/FlexibleRingQueue.d
@@ -171,7 +171,7 @@ class FlexibleByteRingQueue : IRingQueue!(IByteQueue)
 
     ***************************************************************************/
 
-    public bool push ( ubyte[] item )
+    public bool push ( in ubyte[] item )
     {
         auto data = this.push(item.length);
 
@@ -310,7 +310,7 @@ class FlexibleByteRingQueue : IRingQueue!(IByteQueue)
 
     ***************************************************************************/
 
-    static public size_t pushSize ( ubyte[] item )
+    static public size_t pushSize ( in ubyte[] item )
     {
         return pushSize(item.length);
     }
@@ -349,7 +349,7 @@ class FlexibleByteRingQueue : IRingQueue!(IByteQueue)
 
     ***************************************************************************/
 
-    bool willFit ( ubyte[] item )
+    bool willFit ( in ubyte[] item )
     {
         return this.willFit(item.length);
     }

--- a/src/ocean/util/container/queue/QueueChain.d
+++ b/src/ocean/util/container/queue/QueueChain.d
@@ -82,7 +82,7 @@ public class QueueChain : IByteQueue
 
     ***************************************************************************/
 
-    public bool push ( ubyte[] item )
+    public bool push ( in ubyte[] item )
     {
         if ( item.length == 0 ) return false;
 

--- a/src/ocean/util/container/queue/model/IByteQueue.d
+++ b/src/ocean/util/container/queue/model/IByteQueue.d
@@ -69,7 +69,7 @@ public interface IByteQueue : IQueueInfo
 
     ***************************************************************************/
 
-    public bool push ( ubyte[] item );
+    public bool push ( in ubyte[] item );
 
 
     /***************************************************************************

--- a/src/ocean/util/container/queue/model/IUntypedQueue.d
+++ b/src/ocean/util/container/queue/model/IUntypedQueue.d
@@ -128,7 +128,7 @@ public interface IUntypedQueue
 
 *******************************************************************************/
 
-public bool push ( IUntypedQueue q, void[] t )
+public bool push ( IUntypedQueue q, in void[] t )
 {
     auto s = q.push(t.length);
     if ( s is null ) return false;


### PR DESCRIPTION
This method does not modify the input so it should accept `const` data.

Trying to apply the same to [`IQueue.push`](https://github.com/sociomantic-tsunami/ocean/blob/v3.4.x/src/ocean/util/container/queue/model/IQueue.d#L75) I found it causes a dilemma in `FixedRingQueue.push`, which comes down to
```d
bool push ( in T element )
{
    // ...
    *element_in_queue = element;
}
```
This is impossible if `T` is a class. If `typeof(element_in_queue)` is `T*` then the `const` from `element` would be lost. But if `typeof(element_in_queue)` is `const(T)*` then one cannot assign to `*element_in_queue`.