### PR TITLE
Wait until uptime part of /proc/uptime progresses

### DIFF
--- a/test/sysstats/main.d
+++ b/test/sysstats/main.d
@@ -58,7 +58,7 @@ class MyApp : DaemonApp
         auto timer = new TimerEvent(
                 {
                     // wait until uptime advances, clock might be slower on VMs
-                    if (ProcVFS.getProcUptime() == uptime)
+                    if (ProcVFS.getProcUptime().uptime == uptime.uptime)
                         return true;
                     stats = this.sys_stats.collect();
                     this.epoll.shutdown();


### PR DESCRIPTION
The test that waits for the progression of the uptime
should confirm that the uptime part of /proc/uptime has progressed,
and not the idle.