### PR TITLE
Use names as keys for custom worker fiber pools

### DIFF
--- a/relnotes/fiber-pool.feature.md
+++ b/relnotes/fiber-pool.feature.md
@@ -6,14 +6,19 @@ It is now possible to define dedicated worker fiber pools to process tasks of
 specific type:
 
 ```D
+module mymod;
+
+class MyTask : Task { /* ... */ }
+class MyOtherTask : Task { /* ... */ }
+
 SchedulerConfiguration config;
 
 with (config)
 {
-specialized_pools = [
-  PoolDescription(MyTask.classinfo, 10240),
-  PoolDescription(MyOtherTask.classinfo, 2048),
-];
+    specialized_pools = [
+        PoolDescription("mymod.MyTask", 10240),
+        PoolDescription(MyOtherTask.classinfo.name, 2048),
+    ];
 }
 
 initScheduler(config);
@@ -29,4 +34,4 @@ fibers from the shared pool forever, if processed normally
 
 Note that this functionality can be used side by side with regular scheduling
 queue with no issues - each task will be handled by own sub-system depending
-on its `ClassInfo`.
+on its type.

--- a/src/ocean/task/IScheduler.d
+++ b/src/ocean/task/IScheduler.d
@@ -21,6 +21,7 @@ import core.thread;
 
 import ocean.task.Task;
 import ocean.meta.traits.Indirections : hasIndirections;
+import ocean.meta.types.Qualifiers;
 import ocean.io.select.EpollSelectDispatcher;
 
 /*******************************************************************************
@@ -77,9 +78,9 @@ public interface IScheduler
         /// configuration
         public struct PoolDescription
         {
-            /// result of `Task.classinfo` for task type which is to be handled
-            /// by this pool
-            ClassInfo task_kind;
+            /// fully qualified name (same as `Task.classinfo.name()`) for task
+            /// type which is to be handled by this pool
+            istring task_name;
 
             /// worker fiber allocated stack size
             size_t stack_size;

--- a/src/ocean/task/Scheduler_test.d
+++ b/src/ocean/task/Scheduler_test.d
@@ -151,27 +151,26 @@ unittest
     theScheduler.eventLoop();
 }
 
+class DummyTask : Task
+{
+    int counter;
+
+    override void run ( )
+    {
+        ++this.counter;
+
+        auto stats = theScheduler.getStats();
+        test!("==")(stats.worker_fiber_busy, 0);
+    }
+}
 
 unittest
 {
-    static class DummyTask : Task
-    {
-        int counter;
-
-        override void run ( )
-        {
-            ++this.counter;
-
-            auto stats = theScheduler.getStats();
-            test!("==")(stats.worker_fiber_busy, 0);
-        }
-    }
-
     SchedulerConfiguration config;
     with (config)
     {
         specialized_pools = [
-            PoolDescription(DummyTask.classinfo, 10240)
+            PoolDescription(DummyTask.classinfo.name, 10240)
         ];
     }
 

--- a/test/scheduler/main.d
+++ b/test/scheduler/main.d
@@ -91,7 +91,7 @@ void main ( )
         suspended_task_limit = 1000;
 
         specialized_pools = [
-            PoolDescription(GeneratorTask.classinfo, 204800)
+            PoolDescription(GeneratorTask.classinfo.name, 204800)
         ];
     }
 


### PR DESCRIPTION
Contrary to original `ClassInfo` based approach, this allows to define
such configuration in a regular config file.

This does not count as a breaking change because relevant functionality
was not released yet.