### PR TITLE
Override IConnectionHandler.unregisterSocket in TaskConnectionHandler

### DIFF
--- a/src/ocean/net/server/connection/TaskConnectionHandler.d
+++ b/src/ocean/net/server/connection/TaskConnectionHandler.d
@@ -112,6 +112,22 @@ abstract class TaskConnectionHandler : IConnectionHandler, Resettable
         this.task = this.new ConnectionHandlerTask;
     }
 
+    /**************************************************************************
+
+        Called by `finalize` to unregister the connection socket from epoll
+        before closing it. This is done because closing a socket does not always
+        mean that it is unregistered from epoll -- in situations where the
+        process has forked, the fork's reference to the underlying kernel file
+        description will prevent it from being unregistered until the fork
+        exits. Therefore, to be certain that the socket will not fire again in
+        epoll, we need to explicitly unregister it.
+
+    ***************************************************************************/
+
+    protected override void unregisterSocket ()
+    {
+        this.transceiver.reset();
+    }
 
     /***************************************************************************
 


### PR DESCRIPTION
TaskConnectionHandler should override
IConnectionHandler.unregisterSocket to unregister the transiver's socket
from epoll prior to closing it, as closing socket doesn't guarantee that
the socket will be unregistered from the epoll.

Fixes #325