### PR TITLE
Restore DIO.BufferedDirectWriteTempFile.path() method

### DIFF
--- a/src/ocean/io/device/DirectIO.d
+++ b/src/ocean/io/device/DirectIO.d
@@ -404,6 +404,18 @@ public class BufferedDirectWriteFile: OutputStream
 
     /***************************************************************************
 
+        Returns:
+            what File.toString() returns for the underlying File instance.
+
+    ***************************************************************************/
+
+    public cstring path ( )
+    {
+        return this.file.path();
+    }
+
+    /***************************************************************************
+
         Return the host conduit.
 
     ***************************************************************************/


### PR DESCRIPTION
This method was accidentally removed when adding
ocean.io.device.File.path() method (only the one in the File's subclass
should be removed).

Fixes #398