### PR TITLE
Revert constification of pop/peek return value

### DIFF
--- a/relnotes/queue-push-const.migration.md
+++ b/relnotes/queue-push-const.migration.md
@@ -16,9 +16,9 @@
   - `ubyte[] push ( size_t )` changed to `void[] push ( size_t )`
   - `bool push ( IUntypedQueue, void[] )` changed to
     `bool push ( IUntypedQueue, in void[] )`
-  - `ubyte[] pop ( )` changed to `Const!(void)[] pop ( )`
   - `bool pop ( ubyte[] )` changed to `bool pop ( void[] )`
-  - `ubyte[] peek ( )` changed to `Const!(void)[] peek ( )`
+  - `ubyte[] pop ( )` changed to `void[] pop ( )`
+  - `ubyte[] peek ( )` changed to `void[] peek ( )`
   - `size_t pushSize ( ubyte[] )` changed to `size_t pushSize ( in void[] )`
   - `bool willFit ( ubyte[] )` changed to `bool willFit ( in void[] )`
   - `void save ( void delegate ( void[] , void[], void[] ) )` changed to

--- a/src/ocean/util/container/queue/FixedRingQueue.d
+++ b/src/ocean/util/container/queue/FixedRingQueue.d
@@ -234,12 +234,12 @@ class FixedByteRingQueue : FixedRingQueueBase!(IByteQueue)
 
      ***************************************************************************/
 
-    Const!(void)[] pop ( )
+    void[] pop ( )
     {
         return super.pop_();
     }
 
-    Const!(void)[] peek ( )
+    void[] peek ( )
     {
         return super.peek_();
     }
@@ -451,7 +451,7 @@ abstract class FixedRingQueueBase ( IBaseQueue ) : IRingQueue!(IBaseQueue)
 
     ***************************************************************************/
 
-    protected Const!(void)[] pop_ ( )
+    protected void[] pop_ ( )
     out (element)
     {
         assert (!element || element.length == this.element_size);
@@ -471,7 +471,7 @@ abstract class FixedRingQueueBase ( IBaseQueue ) : IRingQueue!(IBaseQueue)
     }
 
 
-    protected Const!(void)[] peek_ ( )
+    protected void[] peek_ ( )
     out (element)
     {
         assert (!element || element.length == this.element_size);

--- a/src/ocean/util/container/queue/FlexibleFileQueue.d
+++ b/src/ocean/util/container/queue/FlexibleFileQueue.d
@@ -384,7 +384,7 @@ public class FlexibleFileQueue : IByteQueue
 
     ***************************************************************************/
 
-    public Const!(void)[] pop ( )
+    public void[] pop ( )
     {
         return this.getItem();
     }
@@ -396,7 +396,7 @@ public class FlexibleFileQueue : IByteQueue
 
     ***************************************************************************/
 
-    public Const!(void)[] peek ( )
+    public void[] peek ( )
     {
         return this.getItem(false);
     }

--- a/src/ocean/util/container/queue/FlexibleRingQueue.d
+++ b/src/ocean/util/container/queue/FlexibleRingQueue.d
@@ -228,7 +228,7 @@ class FlexibleByteRingQueue : IRingQueue!(IByteQueue)
 
     ***************************************************************************/
 
-    public Const!(void)[] pop ( )
+    public void[] pop ( )
     {
         return this.items ? this.pop_() : null;
     }
@@ -244,7 +244,7 @@ class FlexibleByteRingQueue : IRingQueue!(IByteQueue)
 
     ***************************************************************************/
 
-    public Const!(void)[] peek ( )
+    public void[] peek ( )
     {
         if (this.items)
         {
@@ -828,21 +828,6 @@ class FlexibleByteRingQueue : IRingQueue!(IByteQueue)
         }
     }
 
-    /***************************************************************************
-
-        Pops an item from the queue. The item can be modified in-place.
-        This method is for the unit test.
-
-        Returns:
-            item popped from queue, may be null if queue is empty
-
-    ***************************************************************************/
-
-    private void[] pop_test ( )
-    {
-        return this.items ? this.pop_() : null;
-    }
-
     /**************************************************************************/
 
     static class ValidationError: Exception
@@ -1100,7 +1085,7 @@ unittest
         {
             for (uint i = 0; i < n; i++)
             {
-                if (auto popped = q.pop_test())
+                if (auto popped = q.pop())
                 {
                     test (popped.length == 1);
                     static ubyte[] unexpected = [cast(ubyte)Q_SIZE+1];

--- a/src/ocean/util/container/queue/NotifyingQueue.d
+++ b/src/ocean/util/container/queue/NotifyingQueue.d
@@ -471,7 +471,7 @@ class NotifyingByteQueue : ISuspendable, IQueueInfo
 
     ***************************************************************************/
 
-    public Const!(void)[] pop ( )
+    public void[] pop ( )
     {
         if ( !this.enabled )
         {

--- a/src/ocean/util/container/queue/QueueChain.d
+++ b/src/ocean/util/container/queue/QueueChain.d
@@ -135,7 +135,7 @@ public class QueueChain : IByteQueue
 
     ***************************************************************************/
 
-    public Const!(void)[] pop ( )
+    public void[] pop ( )
     {
         if ( this.queue.is_empty() == false )
         {
@@ -169,7 +169,7 @@ public class QueueChain : IByteQueue
 
     ***************************************************************************/
 
-    public Const!(void)[] peek ( )
+    public void[] peek ( )
     {
         if ( this.queue.is_empty() == false )
         {

--- a/src/ocean/util/container/queue/model/IByteQueue.d
+++ b/src/ocean/util/container/queue/model/IByteQueue.d
@@ -82,7 +82,7 @@ public interface IByteQueue : IQueueInfo
 
     ***************************************************************************/
 
-    public Const!(void)[] pop ( );
+    public void[] pop ( );
 
 
     /***************************************************************************
@@ -94,6 +94,6 @@ public interface IByteQueue : IQueueInfo
 
     ***************************************************************************/
 
-    public Const!(void)[] peek ( );
+    public void[] peek ( );
 }
 


### PR DESCRIPTION
It was not needed as returned slice always comes from a mutable buffer
and resulting impact on downstream code was too intrusive.