### PR TITLE
Add module to shallow reset a struct

### DIFF
--- a/src/ocean/util/DeepReset.d
+++ b/src/ocean/util/DeepReset.d
@@ -1,12 +1,10 @@
 /*******************************************************************************
 
-    Utility to recursively reset fields of struct to their .init value while
-    preserving array pointers (their length is set to 0 but memory is kept
-    available for further reusage)
+    Utility to recursively reset fields of an aggregate to their .init value
+    while preserving array pointers (their length is set to 0 but memory is kept
+    available for further reuse)
 
-    Copyright:
-        Copyright (c) 2009-2016 Sociomantic Labs GmbH.
-        All rights reserved.
+    Copyright: Copyright (c) 2017 sociomantic labs GmbH. All rights reserved
 
     License:
         Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
@@ -25,7 +23,7 @@ version(UnitTest) import ocean.core.Test;
 
 /*******************************************************************************
 
-    Template to determine the correct DeepReset function to call dependent on
+    Template to determine the correct DeepReset function to call depending on
     the type given.
 
     Params:
@@ -75,7 +73,7 @@ public template DeepReset ( T )
     length to 0.
 
     Params:
-        T = type of array to deep copy
+        T = type of array to deep reset
         dst = destination array
 
 *******************************************************************************/
@@ -96,7 +94,7 @@ public void DynamicArrayDeepReset ( T ) ( ref T[] dst )
     array.
 
     Params:
-        T = type of array to deep copy
+        T = type of array to deep reset
         dst = destination array
 
 *******************************************************************************/
@@ -113,7 +111,7 @@ public void StaticArrayDeepReset ( T ) ( T[] dst )
     Deep reset function for arrays.
 
     Params:
-        T = type of array to deep copy
+        T = type of array to deep reset
         dst = destination array
 
 *******************************************************************************/
@@ -122,7 +120,7 @@ private void ArrayDeepReset ( T ) ( ref T[] dst )
 {
     static if ( isAssocArrayType!(T) )
     {
-        // TODO: copy associative arrays
+        // TODO: reset associative arrays
         pragma(msg, "Warning: deep reset of associative arrays not yet implemented");
     }
     else static if ( is(T S : S[]) )
@@ -170,7 +168,7 @@ private void ArrayDeepReset ( T ) ( ref T[] dst )
     Deep reset function for structs.
 
     Params:
-        T = type of struct to deep copy
+        T = type of struct to deep reset
         dst = destination struct
 
 *******************************************************************************/
@@ -188,7 +186,7 @@ public void StructDeepReset ( T ) ( ref T dst )
     {
         static if ( isAssocArrayType!(typeof(member)) )
         {
-            // TODO: copy associative arrays
+            // TODO: reset associative arrays
             pragma(msg, "Warning: deep reset of associative arrays not yet implemented");
         }
         else static if ( is(typeof(member) S : S[]) )
@@ -224,7 +222,7 @@ public void StructDeepReset ( T ) ( ref T dst )
     Deep reset function for dynamic class instances.
 
     Params:
-        T = type of class to deep copy
+        T = type of class to deep reset
         dst = destination instance
 
 *******************************************************************************/
@@ -240,7 +238,7 @@ public void ClassDeepReset ( T ) ( ref T dst )
     {
         static if ( isAssocArrayType!(typeof(member)) )
         {
-            // TODO: copy associative arrays
+            // TODO: reset associative arrays
             pragma(msg, "Warning: deep reset of associative arrays not yet implemented");
         }
         else static if ( is(typeof(member) S : S[]) )
@@ -268,8 +266,8 @@ public void ClassDeepReset ( T ) ( ref T dst )
         }
     }
 
-    // Recurse into super any classes
-    static if ( is(T S == super ) )
+    // Recurse into any super classes
+    static if ( is(T S == super) )
     {
         foreach ( V; S )
         {
@@ -290,10 +288,10 @@ public void ClassDeepReset ( T ) ( ref T dst )
 
     We first build a basic struct that has both a single sub struct and a
     dynamic array of sub structs. Both of these are then filled along with
-    the fursther sub sub struct.
+    the further sub sub struct.
 
     The DeepReset method is then called. The struct is then confirmed to
-    have had it's members reset to the correct values
+    have had its members reset to the correct values.
 
     TODO Adjust the unit test so it also deals with struct being
     re-initialised to make sure they are not full of old data (~=)

--- a/src/ocean/util/StructShallowReset.d
+++ b/src/ocean/util/StructShallowReset.d
@@ -1,0 +1,127 @@
+/*******************************************************************************
+
+    Utility to reset fields of a struct to their .init value while preserving
+    array pointers (their length is set to 0 but memory is kept available for
+    further reuse).
+
+    Although the functionality provided in this module is similar to that in
+    `ocean.util.DeepReset`, it differs in some fundamental ways (details of
+    which can be found in the function documentation below).
+
+    This utility is intended to be used in very specific cases, with
+    `ocean.util.DeepReset` being the preferred choice for general resetting
+    needs.
+
+    Copyright: Copyright (c) 2017 sociomantic labs GmbH. All rights reserved
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+        Alternatively, this file may be distributed under the terms of the Tango
+        3-Clause BSD License (see LICENSE_BSD.txt for details).
+
+*******************************************************************************/
+
+module ocean.util.StructShallowReset;
+
+
+import ocean.core.Traits: isAssocArrayType;
+
+version ( UnitTest )
+{
+    import ocean.core.Test;
+}
+
+
+/*******************************************************************************
+
+    Resets each field of a struct in a shallow manner. Just like
+    `ocean.util.DeepReset : DeepReset`, this function sets non-aggregate members
+    in the struct to their init value, and resets the lengths of dynamic arrays
+    in the struct to zero. Also, just like DeepReset, associative arrays are not
+    supported.
+
+    The differences between this function and DeepReset are:
+        1. Only structs are supported (not classes)
+        2. Structs containing nested structs/classes are not supported
+        3. Structs containing static arrays are not supported
+
+    The main motivation for introducing this function (and not simply using the
+    existing DeepReset functionality) is that DeepReset recurses into and
+    individually resets every element of each dynamic array present in the
+    struct. However, this additional work is sometimes overkill for certain
+    performance critical applications where just resetting the lengths of the
+    dynamic arrays to zero suffices.
+
+    Params:
+        T = the type of the struct
+        dst = the struct to be reset
+
+*******************************************************************************/
+
+public void structShallowReset ( T ) ( ref T dst )
+{
+    static assert(is(T == struct),
+        "structShallowReset: '" ~ T.stringof ~ "' is not a struct");
+
+    foreach ( i, member; dst.tupleof )
+    {
+        static assert(
+            !isAssocArrayType!(typeof(member)) &&
+            !is(typeof(member) == class) &&
+            !is(typeof(member) == struct),
+            "structShallowReset does not support member '" ~
+            dst.tupleof[i].stringof ~ "' of type '" ~ typeof(member).stringof ~
+            "'");
+
+        static if ( is(typeof(member) S : S[]) ) // some sort of array
+        {
+            static if ( is(typeof(member) U == S[]) ) // dynamic array
+            {
+                dst.tupleof[i].length = 0;
+            }
+            else // static array
+            {
+                static assert(false, "structShallowReset does not support " ~
+                    "member '" ~ dst.tupleof[i].stringof ~ "' of type '" ~
+                    typeof(member).stringof ~ "' (static array)");
+            }
+        }
+        else
+        {
+            dst.tupleof[i] = dst.tupleof[i].init;
+        }
+    }
+}
+
+unittest
+{
+    struct A
+    {
+        int w;
+        int[] x;
+        char y;
+        char[] z;
+    }
+
+    A a;
+
+    a.w = 10;
+    a.x ~= 200;
+    a.x ~= 300;
+    a.y = 'a';
+    a.z ~= 'p';
+    a.z ~= 'q';
+    a.z ~= 'r';
+
+    test!("==")(a.w, 10);
+    test!("==")(a.x.length, 2);
+    test!("==")(a.y, 'a');
+    test!("==")(a.z.length, 3);
+
+    structShallowReset(a);
+
+    test!("==")(a.w, typeof(a.w).init);
+    test!("==")(a.x.length, 0);
+    test!("==")(a.y, typeof(a.y).init);
+    test!("==")(a.z.length, 0);
+}


### PR DESCRIPTION
    The main motivation for introducing this functionality (and not simply
    using the existing DeepReset functionality) is that DeepReset recurses
    into and individually resets every element of each dynamic array present
    in the struct. However, this additional work is sometimes overkill for
    certain performance critical applications where just resetting the
    lengths of the dynamic arrays to zero suffices.