### PR TITLE
Monitor for file changes inside MAKD_TMPDIR, not inside /tmp

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -50,7 +50,7 @@ TEST_FILTER_OUT += \
 TEST_FILTER_OUT += \
 	$C/test/collectd/main.d
 
-$O/test-filesystemevent: override LDFLAGS += -lrt
+$O/test-filesystemevent: override LDFLAGS += -lrt -lebtree
 
 $O/test-selectlistener: override LDFLAGS += -lebtree
 

--- a/src/ocean/io/select/client/FileSystemEvent.d
+++ b/src/ocean/io/select/client/FileSystemEvent.d
@@ -382,7 +382,8 @@ class FileSystemEvent : ISelectClient
             verify(ev.mask != typeof(ev.mask).init);
 
             auto path = ev.wd in this.watched_files;
-            verify(path !is null);
+            if (path is null)
+                continue;
 
             if (this.handler)
                 this.handler(*path , ev.mask);

--- a/test/filesystemevent/main.d
+++ b/test/filesystemevent/main.d
@@ -113,6 +113,7 @@ class FileCreationTestTask: Task
         this.suspend();
 
         theScheduler.epoll.unregister(inotifier);
+        inotifier.unwatch(this.watched_path.dup);
 
         test(this.created);
         test!("==")(this.created_name, file_name);

--- a/test/filesystemevent/main.d
+++ b/test/filesystemevent/main.d
@@ -39,6 +39,10 @@ import ocean.task.Task;
 
 import ocean.task.Scheduler;
 
+import ocean.text.convert.Formatter;
+
+import ocean.sys.Environment;
+
 
 class FileCreationTestTask: Task
 {
@@ -128,7 +132,7 @@ class FileCreationTestTask: Task
 
     private void testFileModification ( )
     {
-        auto temp_file = new TempFile(TempFile.Permanent);
+        auto temp_file = new File("./testfile_modification", File.WriteCreate);
         this.temp_path = FilePath(temp_file.toString());
 
         inotifier.watch(cast(char[]) temp_file.toString(),
@@ -158,7 +162,12 @@ class FileCreationTestTask: Task
 
     override public void run ( )
     {
-        auto sandbox = DirectorySandbox.create();
+        auto makd_tmpdir = Environment.get("MAKD_TMPDIR");
+        mstring path_template;
+        sformat(path_template, "{}/Dunittests-XXXXXXXX",
+                makd_tmpdir.length? makd_tmpdir : "/tmp");
+
+        auto sandbox = DirectorySandbox.create(null, path_template);
         scope (exit)
             sandbox.exitSandbox();
 


### PR DESCRIPTION
Travis environment doesn't report file changes/events for files created
inside /tmp directory via inotify, so this creates the files & monitors
them inside MAKD_TMPDIR, if set.