### PR TITLE
Replace C bindings in AppendSysLog with Runtime's

### DIFF
--- a/src/ocean/util/log/AppendSysLog.d
+++ b/src/ocean/util/log/AppendSysLog.d
@@ -22,20 +22,8 @@ import ocean.util.log.Appender;
 import ocean.util.log.Event;
 import ocean.util.log.model.ILogger;
 
+import core.sys.posix.syslog;
 
-/*******************************************************************************
-
-    syslog C functions
-
-    FIXME: use runtime bindings
-
-*******************************************************************************/
-
-extern ( C )
-{
-    void openlog ( in char* ident, int option, int facility );
-    void syslog ( int priority, in char* format, ... );
-}
 
 /*******************************************************************************
 


### PR DESCRIPTION
Since those were mistakenly `public`, I'm targeting v4.x.x