### PR TITLE
Fix collectd test and move it to examples

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -55,10 +55,6 @@ TEST_FILTER_OUT += \
 	$C/src/ocean/core/_util/string.d \
 	$(shell find $C/src/ocean/text/locale -type f)
 
-# integration test which is disabled by default because it depends on Collectd
-TEST_FILTER_OUT += \
-	$C/integrationtest/collectd/main.d
-
 $O/test-%: override LDFLAGS += -lebtree
 
 $O/test-filesystemevent: override LDFLAGS += -lrt

--- a/example/collectd/main.d
+++ b/example/collectd/main.d
@@ -18,43 +18,29 @@
 
 *******************************************************************************/
 
-module integrationtest.collectd.main;
+module example.collectd.main;
 
 import ocean.transition;
 import ocean.core.Test;
-import ocean.net.Collectd;
-import ocean.net.device.LocalSocket; // LocalAddress
-import ocean.stdc.posix.sys.types; // time_t
+import ocean.net.collectd.Collectd;
 
-
-version(UnitTest) {} else
 void main (istring[] args)
 {
     auto address = args.length > 1
         ? args[1]
         : "/var/run/collectd.socket";
-
-    auto list = new Collectd(address);
-    auto get = new Collectd(address);
     auto put = new Collectd(address);
 
     auto baseId = Identifier.create("localhost/ocean_unittest/bytes");
     istring[8] inst = [ "0", "1", "2", "3", "4", "5", "6", "7" ];
-    Collectd.KVP options = [ "interval": "60" ];
-    Bytes c = void;
+    Collectd.PutvalOptions options = { interval : 60 };
+    Bytes c;
+
     for (size_t idx = 0; idx < 8; ++idx)
     {
         c.value = idx;
         baseId.type_instance = inst[idx];
         put.putval(baseId, c, options);
-    }
-
-    foreach (ref val; list.listval())
-    {
-        if (val.identifier.plugin == "ocean_unittest") {
-            auto _ = get.getval!(Bytes)(val.identifier);
-            test!("==")(val.identifier.type_instance[0] - '0', _.value);
-        }
     }
 }
 


### PR DESCRIPTION
It can't be run as part of test target because it requires collectd
daemon. Moving it to examples will at least ensure it compiles.