### PR TITLE
Fix #429: No error message when command line argument has error

### DIFF
--- a/src/ocean/text/Arguments.d
+++ b/src/ocean/text/Arguments.d
@@ -1134,7 +1134,7 @@ public class Arguments
             if (arg.error)
             {
                 // TODO: Replace with `sformat` in v4.0.0
-                ocean.text.convert.Layout_tango.Layout!(char).instance.sprint(
+                ocean.text.convert.Layout_tango.Layout!(char).format(
                     result, msgs[arg.error-1], arg.name,
                     arg.values.length, arg.min, arg.max, arg.bogus,
                     arg.options);
@@ -2607,6 +2607,7 @@ unittest
     x.requires('y');
     test(args.clear.parse("-xy"));
     test(args.clear.parse("-xz") is false);
+    test!("==")(args.errors(), "argument 'x' requires 'y'\n");
 
     // defaults
     z.defaults("foo");


### PR DESCRIPTION
The regression appeared in #362, specifically in commit 480fb9fcd71a89e8e93fe917937fda258b08a5aa.
The change in this commit was wrong, it used `sprint` which is equivalent to `snformat`,
(which write to a buffer up to the buffer's size,
when all we really wanted was something that appended to the buffer.