### PR TITLE
Fix release notes

### DIFF
--- a/relnotes/42.migration.md
+++ b/relnotes/42.migration.md
@@ -3,24 +3,24 @@
 * `ocean.io.Stdout`, `ocean.io.console.AppStatus`, `ocean.io.stream.Format`,
   `ocean.text.Arguments`, `ocean.util.log.Stats`
 
-All remaining users of `ocean.text.convert.Layout[_tango]` have been switched to
-the Formatter.  For those which see their API affected, the most common use case
-of passing arguments will work just as before.  Overriding the formatting
-function will not be possible anymore (as they are template), but redefinition
-is.
+  All remaining users of `ocean.text.convert.Layout[_tango]` have been switched to
+  the Formatter.  For those which see their API affected, the most common use case
+  of passing arguments will work just as before.  Overriding the formatting
+  function will not be possible anymore (as they are template), but redefinition
+  is.
 
-However, forwarding variadic arguments won't work, so functions wishing to
-forward arguments must be defined as templated functions, as shown in
-`PeriodicTrace` release notes.
+  However, forwarding variadic arguments won't work, so functions wishing to
+  forward arguments must be defined as templated functions, as shown in
+  `PeriodicTrace` release notes.
 
-Little difference in output is expected. Pointers will be formatted as
-fixed-length hexadecimal, associative arrays will be formatted as `[ Key:
-value...]` instead of `{ Key: value... }`, qualified (`const` / `immutable`)
-arguments will be correctly formatted, as well as structs, making the output
-consistent accross ocean (as the Logger module already uses the Formatter).
+  Little difference in output is expected. Pointers will be formatted as
+  fixed-length hexadecimal, associative arrays will be formatted as `[ Key:
+  value...]` instead of `{ Key: value... }`, qualified (`const` / `immutable`)
+  arguments will be correctly formatted, as well as structs, making the output
+  consistent accross ocean (as the Logger module already uses the Formatter).
 
 * `ocean.util.log.Stats`
 
-Protected `layout` field was replaced with protected `buffer` field which serves
-the same purpose but is a simple `AppendBuffer` now. Derivative classes have to
-adjust their code to use `this.buffer`.
+  Protected `layout` field was replaced with protected `buffer` field which serves
+  the same purpose but is a simple `AppendBuffer` now. Derivative classes have to
+  adjust their code to use `this.buffer`.

--- a/relnotes/baguette.migration.md
+++ b/relnotes/baguette.migration.md
@@ -2,5 +2,5 @@
 
 * `ocean.text.convert.Layout`, `ocean.text.convert.Layout_tango`, `ocean.core.RuntimeTraits`
 
-Those modules where removed. The Layout one should be completely replaced with the Formatter.
-`RuntimeTraits` was only used by Layout_tango, and provided incomplete support for its functionalities, especially in D2.
+  Those modules where removed. The Layout one should be completely replaced with the Formatter.
+  `RuntimeTraits` was only used by Layout_tango, and provided incomplete support for its functionalities, especially in D2.

--- a/relnotes/bitflip-gone-wrong.migration.md
+++ b/relnotes/bitflip-gone-wrong.migration.md
@@ -1,5 +1,7 @@
-* `ocean.net.http.consts.StatusCodes : StatusPhrase.StatusReasonPhrases`
+## HTTP status reason changed from `Ok` to `OK`
 
-  The status reason was changed from `"Ok"` to `"OK"`.
-  While the previous version wasn't strictly against the RFC defining HTTP 1.1,
-  it consistently uses `"OK"` through the RFC.
+`ocean.net.http.consts.StatusCodes : StatusPhrase.StatusReasonPhrases`
+
+The status reason was changed from `"Ok"` to `"OK"`. While the previous version
+wasn't strictly against the RFC defining HTTP 1.1, it consistently uses `"OK"`
+through the RFC.

--- a/relnotes/decorator.feature.md
+++ b/relnotes/decorator.feature.md
@@ -1,12 +1,9 @@
-* `ocean.util.serialize.contiguous.Serializer`
-  `ocean.util.serialize.contiguous.Deserializer`
+## Several methods now support `Buffer!(void)` as one of possible buffer types
 
-  `serialize` and in-place `deserialize` methods now support `Buffer!(void)` as
-  one of possible buffer types. Old `void[]` and derivatives are still supported
-  too.
+`ocean.util.serialize.contiguous.Serializer`
+`ocean.util.serialize.contiguous.Deserializer`
+: `serialize` and in-place `deserialize`
 
-* `ocean.util.serialize.contiguous.MultiVersionDecorator`
+`ocean.util.serialize.contiguous.MultiVersionDecorator` : `store` and in-place `load`
 
-  `store` and in-place `load` methods now support `Buffer!(void)` as one of
-  possible buffer types. Old `void[]` and derivatives are still supported too.
-
+Old `void[]` and derivatives are still supported too.

--- a/relnotes/delete.deprecation.md
+++ b/relnotes/delete.deprecation.md
@@ -1,4 +1,4 @@
-# Deprecation of `AppenBuffer.deleteContent`
+## Deprecation of `AppenBuffer.deleteContent`
 
 `ocean.util.container.AppenBuffer`
 

--- a/relnotes/inetaddress-einval.migration.md
+++ b/relnotes/inetaddress-einval.migration.md
@@ -1,9 +1,13 @@
-* `ocean.sys.socket.InetAddress`, `ocean.sys.socket.AddressIPSocket`
+## Functions which accept an IP address string now report errors via `errno`
 
-  Functions which accept an IP address string now report an invalid address by
-  setting `errno = EINVAL`. It was `EAFNOSUPPORT` before, which is wrong because
-  `EAFNOSUPPORT` refers to the wrong address family, which is not the case.
-  This affects the following methods:
-  * `ocean.sys.socket.InetAddress.opCall`
-  * `ocean.sys.socket.AddressIPSocket.bind(cstring, ushort)`
-  * `ocean.sys.socket.AddressIPSocket.connect(cstring, ushort)`
+`ocean.sys.socket.InetAddress`, `ocean.sys.socket.AddressIPSocket`
+
+Functions which accept an IP address string now report an invalid address by
+setting `errno = EINVAL`. It was `EAFNOSUPPORT` before, which is wrong because
+`EAFNOSUPPORT` refers to the wrong address family, which is not the case.
+
+This affects the following methods:
+
+* `ocean.sys.socket.InetAddress.opCall`
+* `ocean.sys.socket.AddressIPSocket.bind(cstring, ushort)`
+* `ocean.sys.socket.AddressIPSocket.connect(cstring, ushort)`

--- a/relnotes/map.migration.md
+++ b/relnotes/map.migration.md
@@ -1,5 +1,7 @@
-* `ocean.util.container.map.model.BucketSet`
+## Asbtract `toHash` method now takes `in K key` instead of `K key`
 
-  Asbtract `toHash` method was changed to accept `in K key` instead of just
-  `K key`. Any class that overrides it directly or indirectly will have to be
-  adjusted accordingly.
+`ocean.util.container.map.model.BucketSet`
+
+Asbtract `toHash` method was changed to accept `in K key` instead of just `K
+key`. Any class that overrides it directly or indirectly will have to be
+adjusted accordingly.

--- a/relnotes/message.migration.md
+++ b/relnotes/message.migration.md
@@ -1,4 +1,6 @@
-* `ocean.transition`
+## Now `getMsg(e)` always evaluated to plain `e.message()`
 
-  Now `getMsg(e)` always evaluated to plain `e.message()` call and latter can
-  be used in application code directly.
+`ocean.transition`
+
+Now `getMsg(e)` always evaluated to plain `e.message()` call and latter can be
+used in application code directly.

--- a/relnotes/periodictrace-layout.migration.md
+++ b/relnotes/periodictrace-layout.migration.md
@@ -1,12 +1,13 @@
 ## `PeriodicTrace` and `StaticTrace` were switched to the Formatter
 
-* `ocean.util.log.PeriodicTrace`, `ocean.util.log.StaticTrace`
+`ocean.util.log.PeriodicTrace`, `ocean.util.log.StaticTrace`
 
-Those modules now use `ocean.text.convert.Formatter` for string formatting instead of
-`ocean.text.convert.Layout_tango`.
-As a result, they cannot have runtime variadic arguments forwarded to them
-(only `PeriodicTrace` was offering such an interface).
-As a result, code forwarding runtime vararg should switch to CT vararg:
+Those modules now use `ocean.text.convert.Formatter` for string formatting
+instead of `ocean.text.convert.Layout_tango`.
+
+As a result, they cannot have runtime variadic arguments forwarded to them (only
+`PeriodicTrace` was offering such an interface). As a result, code forwarding
+runtime vararg should switch to CT vararg:
 
 ```D
 public void trace (cstring fmt, ...)

--- a/relnotes/queue-push-const.migration.md
+++ b/relnotes/queue-push-const.migration.md
@@ -1,25 +1,19 @@
 ## Queue I/O buffer arguments now use `void[]` instead of `ubyte[]` and `const`
 
-* `ocean.util.container.queue.model.IByteQueue`,
-  `ocean.util.container.queue.model.IUntypedQueue`,
-  `ocean.util.container.queue.FixedRingQueue`,
-  `ocean.util.container.queue.FlexibleFileQueue`,
-  `ocean.util.container.queue.FlexibleRingQueue`,
-  `ocean.util.container.queue.NotifyingQueue`,
-  `ocean.util.container.queue.QueueChain`
+`ocean.util.container.queue.model.IByteQueue`, `ocean.util.container.queue.model.IUntypedQueue`, `ocean.util.container.queue.FixedRingQueue`, `ocean.util.container.queue.FlexibleFileQueue`, `ocean.util.container.queue.FlexibleRingQueue`, `ocean.util.container.queue.NotifyingQueue`, `ocean.util.container.queue.QueueChain`
 
-  The types of the arguments and return types for queue input or output buffers
-  have been changed to `void[]` and use `const` where applicable. The particular
-  methods are
+The types of the arguments and return types for queue input or output buffers
+have been changed to `void[]` and use `const` where applicable. The particular
+methods are:
 
-  - `bool push ( ubyte[] )` changed to `bool push ( in void[] )`
-  - `ubyte[] push ( size_t )` changed to `void[] push ( size_t )`
-  - `bool push ( IUntypedQueue, void[] )` changed to
-    `bool push ( IUntypedQueue, in void[] )`
-  - `bool pop ( ubyte[] )` changed to `bool pop ( void[] )`
-  - `ubyte[] pop ( )` changed to `void[] pop ( )`
-  - `ubyte[] peek ( )` changed to `void[] peek ( )`
-  - `size_t pushSize ( ubyte[] )` changed to `size_t pushSize ( in void[] )`
-  - `bool willFit ( ubyte[] )` changed to `bool willFit ( in void[] )`
-  - `void save ( void delegate ( void[] , void[], void[] ) )` changed to
-    `void save ( void delegate ( in void[], in void[], in void[] ) )`
+- `bool push ( ubyte[] )` changed to `bool push ( in void[] )`
+- `ubyte[] push ( size_t )` changed to `void[] push ( size_t )`
+- `bool push ( IUntypedQueue, void[] )` changed to
+  `bool push ( IUntypedQueue, in void[] )`
+- `bool pop ( ubyte[] )` changed to `bool pop ( void[] )`
+- `ubyte[] pop ( )` changed to `void[] pop ( )`
+- `ubyte[] peek ( )` changed to `void[] peek ( )`
+- `size_t pushSize ( ubyte[] )` changed to `size_t pushSize ( in void[] )`
+- `bool willFit ( ubyte[] )` changed to `bool willFit ( in void[] )`
+- `void save ( void delegate ( void[] , void[], void[] ) )` changed to
+  `void save ( void delegate ( in void[], in void[], in void[] ) )`

--- a/relnotes/recursive-serializer.migration.md
+++ b/relnotes/recursive-serializer.migration.md
@@ -10,7 +10,7 @@ struct S
 }
 ```
 
-This is unfortunate side effect of making serializer more generic and
-separating type analysis from serialization code. As this feature was not used
-by Sociomantic projects and new implementation will simplify maintenance, it was
+This is unfortunate side effect of making serializer more generic and separating
+type analysis from serialization code. As this feature was not used by
+Sociomantic projects and new implementation will simplify maintenance, it was
 considered a desirable trade-off.

--- a/relnotes/timerext.migration.md
+++ b/relnotes/timerext.migration.md
@@ -1,5 +1,8 @@
-* `ocean.util.app.ext.TimerExt`
+## `TimerExt` is now swallowing all the unhandled exceptions, keeping the timers registered by default
 
-  `TimerExt` is now swallowing all the unhandled exceptions, keeping the timers
-  registered by default. If you need to unregister the timer on the thrown exception,
-  catch the exception yourself and manually return `false` from your handler.
+`ocean.util.app.ext.TimerExt`
+
+`TimerExt` is now swallowing all the unhandled exceptions, keeping the timers
+registered by default. If you need to unregister the timer on the thrown
+exception, catch the exception yourself and manually return `false` from your
+handler.

--- a/relnotes/unixsocket.feature.md
+++ b/relnotes/unixsocket.feature.md
@@ -1,8 +1,6 @@
 ## Interactive session over the unix domain socket.
 
-`ocean.net.server.unix.UnixListener`,
-`ocean.net.server.unix.UnixConnectionHandler`,
-`ocean.util.app.ext.UnixSocketExt`
+`ocean.net.server.unix.UnixListener`, `ocean.net.server.unix.UnixConnectionHandler`, `ocean.util.app.ext.UnixSocketExt`
 
 UnixConnectionHandler now accepts the map of the interactive handlers -
 delegates that accept additional delegate argument: `wait_reply`. These handlers

--- a/relnotes/unregistersocket.migration.md
+++ b/relnotes/unregistersocket.migration.md
@@ -1,19 +1,19 @@
 ## IConnectionHandler.unregisterSocket made abstract
 
-* `ocean.net.server.connection.IConnectionHandler`
+`ocean.net.server.connection.IConnectionHandler`
 
-  `IConnectionHandler.unregisterSocket` method, previously implemented with an
-  empty body is now made abstract, forcing all ConnectionHandlers to unregister
-  registered socket in a meaningful way before closing them inside the finalizer.
-  In turn, `TaskConnectionHandler` now unregisters its `transceiver` before
-  closing it.
+`IConnectionHandler.unregisterSocket` method, previously implemented with an
+empty body is now made abstract, forcing all ConnectionHandlers to unregister
+registered socket in a meaningful way before closing them inside the finalizer.
+In turn, `TaskConnectionHandler` now unregisters its `transceiver` before
+closing it.
 
-  Example usage:
+Example usage:
 
-  ```
-  protected override void unregisterSocket ()
-  {
-      if ( has_registered_client )
-          this.registered_client.unregister();
-  }
-  ```
+```
+protected override void unregisterSocket ()
+{
+    if ( has_registered_client )
+        this.registered_client.unregister();
+}
+```

--- a/relnotes/utrunner.migration.md
+++ b/relnotes/utrunner.migration.md
@@ -1,7 +1,9 @@
-* `core.UnitTestRunner`
+## The `-p` option for the unittest runner can't be used as a wildcard any more
 
-  There is a minor breaking bug fix in the `--package` / `-p` option; now it can't be used as some sort of wildcard.
+`core.UnitTestRunner`
 
-  The `PKG` argument will only match fully qualified names that start with `PKG.` or the exact module `PKG`. Before using `PKG` as argument would have matched `PKG*`, so `PKGfoo` was also a match.
+There is a minor breaking bug fix in the `--package` / `-p` option; now it can't be used as some sort of wildcard.
 
-  As a transitional step, `PKG.` will also be accepted as a package specification, although it will match both `PKG` (exact match) and `PKG.*`.
+The `PKG` argument will only match fully qualified names that start with `PKG.` or the exact module `PKG`. Before using `PKG` as argument would have matched `PKG*`, so `PKGfoo` was also a match.
+
+As a transitional step, `PKG.` will also be accepted as a package specification, although it will match both `PKG` (exact match) and `PKG.*`.

--- a/relnotes/vararg.migration.md
+++ b/relnotes/vararg.migration.md
@@ -1,4 +1,6 @@
-* `ocean.io.console.AppStatus`
+## `formatStaticLine` method now uses template-based variadic argument
 
-  `formatStaticLine` method was changed to use template-based variadic argument
-  list instead of runtime one.
+`ocean.io.console.AppStatus`
+
+`formatStaticLine` method was changed to use template-based variadic argument
+list instead of runtime one.

--- a/relnotes/version.migration.md
+++ b/relnotes/version.migration.md
@@ -1,4 +1,4 @@
-## Changes in --version flag handling and version log
+## Changes in `--version` flag handling and version log + new `--build-info`
 
 `VersionArgsExt` used in both `CliApp` and `DaemonApp` now implements
 `--version` flag to only print basic version information, without any detailed
@@ -12,14 +12,14 @@ also doesn't treat any keys specially, printing all data found in the supplied
 
 Old output:
 
-```
+```console
 $ ./app --version
 app version v1.0 (compiled by 'author' on today with dmd1 using lib1:v10.0 lib2:v0.5)
 ```
 
 New output:
 
-```
+```console
 $ ./app --version
 app version v1.0
 $ ./app --build-info


### PR DESCRIPTION
A mixed combination of old and new formatting is used in release notes,
not only in different files but even also in the same file. There are
also a couple of other formatting issues and some other minor things to
fix.

This commit should make everything more consistent and clean.