### PR TITLE
[V4] Cleanup and simplify ocean.util.log.Config

### DIFF
--- a/relnotes/Logger-Config.migration.md
+++ b/relnotes/Logger-Config.migration.md
@@ -1,0 +1,8 @@
+# Removed legacy template arguments in Logger's configuration module
+
+* `ocean.util.log.Config : setupLoggerLevel, configureLogger`
+
+Those functions used to take a `LoggerT` template parameter to signify which logger to configure.
+As the old logger implementation is now removed, this parameter is now gone.
+No disturbance is expected in user's code, as it's unlikely that those parameter were provided explicitly,
+since the template parameter was tied to one of the runtime parameter.

--- a/relnotes/Logger-Config.migration.md
+++ b/relnotes/Logger-Config.migration.md
@@ -6,3 +6,14 @@ Those functions used to take a `LoggerT` template parameter to signify which log
 As the old logger implementation is now removed, this parameter is now gone.
 No disturbance is expected in user's code, as it's unlikely that those parameter were provided explicitly,
 since the template parameter was tied to one of the runtime parameter.
+
+# Config-based default for console_layout and file_layout
+
+* `ocean.util.log.Config : Config.{console_layout,file_layout}, configureLoggers`
+
+`configureLoggers` would previously use `LayoutDate` as the default `Layout` for the file appender,
+and `LayoutSimple` for the default `Layout` for the console.
+The default would be used whenever the Logger's `Config.{console_layout,file_layout}` were empty/null.
+Instead of relying on this, those field now have a default value of "date" and "simple", respectively,
+while will be used by "makeLayout" to instantiate the same default layout.
+The only change to users is that setting a null / empty value for those fields is now an error.

--- a/src/ocean/util/log/Config.d
+++ b/src/ocean/util/log/Config.d
@@ -145,7 +145,7 @@ class Config
 
     ***************************************************************************/
 
-    public istring console_layout;
+    public istring console_layout = "simple";
 
     /***************************************************************************
 
@@ -161,7 +161,7 @@ class Config
 
     ***************************************************************************/
 
-    public istring file_layout;
+    public istring file_layout = "date";
 
     /***************************************************************************
 
@@ -406,8 +406,7 @@ public void configureNewLoggers (
     scope Appender delegate(Layout) appender_dg = (Layout l)
                        { return console_appender_fn(use_insert_appender, l); };
 
-    configureLoggers!(LayoutDate, LayoutSimple)
-        (config, m_config, file_appender, appender_dg, makeLayout);
+    configureLoggers(config, m_config, file_appender, appender_dg, makeLayout);
 }
 
 
@@ -418,10 +417,6 @@ public void configureNewLoggers (
     method.
 
     Params:
-        FileLayout = layout to use for logging to file, defaults to LayoutDate
-        ConsoleLayout = layout to use for logging to console, defaults to
-                        LayoutSimple
-
         config   = an instance of an class iterator for Config
         m_config = an instance of the MetaConfig class
         file_appender = delegate which returns appender instances to write to
@@ -435,7 +430,6 @@ public void configureNewLoggers (
 *******************************************************************************/
 
 private void configureLoggers
-    (FileLayout = LayoutDate, ConsoleLayout = LayoutSimple)
     (ClassIterator!(Config, ConfigParser) config, MetaConfig m_config,
      Appender delegate (istring file, Layout layout) file_appender,
      Appender delegate (Layout) console_appender,
@@ -493,8 +487,7 @@ private void configureLoggers
             console_enabled = settings.console();
             syslog_enabled = settings.syslog();
         }
-        configureLogger!(FileLayout, ConsoleLayout)
-            (name.length ? Log.lookup(name) : Log.root,
+        configureLogger(name.length ? Log.lookup(name) : Log.root,
              settings, name,
              file_appender, console_appender,
              console_enabled, syslog_enabled, m_config.buffer_size,
@@ -510,10 +503,6 @@ private void configureLoggers
     method.
 
     Params:
-        FileLayout = layout to use for logging to file, defaults to LayoutDate
-        ConsoleLayout = layout to use for logging to console, defaults to
-                        LayoutSimple
-
         log      = Logger to configure
         settings = an instance of an class iterator for Config
         name     = name of this logger
@@ -532,7 +521,6 @@ private void configureLoggers
 *******************************************************************************/
 
 public void configureLogger
-    (FileLayout = LayoutDate, ConsoleLayout = LayoutSimple)
     (Logger log, Config settings, istring name,
      Appender delegate ( istring file, Layout layout ) file_appender,
      Appender delegate (Layout) console_appender,
@@ -554,10 +542,7 @@ public void configureLogger
 
     if (settings.file.set)
     {
-        Layout file_log_layout = (settings.file_layout.length)
-            ? makeLayout(settings.file_layout)
-            : new FileLayout;
-        log.add(file_appender(settings.file(), file_log_layout));
+        log.add(file_appender(settings.file(), makeLayout(settings.file_layout)));
     }
 
     if (syslog_enabled)
@@ -565,10 +550,7 @@ public void configureLogger
 
     if (console_enabled)
     {
-        Layout console_log_layout = (settings.console_layout.length)
-            ? makeLayout(settings.console_layout)
-            : new ConsoleLayout;
-        log.add(console_appender(console_log_layout));
+        log.add(console_appender(makeLayout(settings.console_layout)));
     }
 
     log.collectStats(settings.collect_stats, settings.propagate);

--- a/src/ocean/util/log/Config.d
+++ b/src/ocean/util/log/Config.d
@@ -414,7 +414,7 @@ public void configureNewLoggers (
     scope Appender delegate(Layout) appender_dg = (Layout l)
                        { return console_appender_fn(use_insert_appender, l); };
 
-    configureLoggers!(Logger, ConfigParser, LayoutDate, LayoutSimple)
+    configureLoggers!(Logger, LayoutDate, LayoutSimple)
         (config, m_config, lookup, file_appender, appender_dg, makeLayout);
 }
 
@@ -427,7 +427,6 @@ public void configureNewLoggers (
 
     Params:
         LoggerT = Type of the logger to configure
-        Source = the type of the config parser
         FileLayout = layout to use for logging to file, defaults to LayoutDate
         ConsoleLayout = layout to use for logging to console, defaults to
                         LayoutSimple
@@ -447,9 +446,9 @@ public void configureNewLoggers (
 *******************************************************************************/
 
 private void configureLoggers
-    (LoggerT : ILogger, Source = ConfigParser,
+    (LoggerT : ILogger,
      FileLayout = LayoutDate, ConsoleLayout = LayoutSimple)
-    (ClassIterator!(Config, Source) config, MetaConfig m_config,
+    (ClassIterator!(Config, ConfigParser) config, MetaConfig m_config,
      LoggerT delegate (cstring name) lookup,
      Appender delegate (istring file, Layout layout) file_appender,
      Appender delegate (Layout) console_appender,

--- a/src/ocean/util/log/Config.d
+++ b/src/ocean/util/log/Config.d
@@ -266,15 +266,15 @@ alias Appender.Layout Layout;
         layout_str = name of the desired layout
 
     Returns:
-        an instance of a suitable layout based on the input string, or an
-        instance of 'LayoutMessageOnly' if no suitable layout was identified.
+        an instance of a suitable layout based on the input string
+
+    Throws:
+        if `layout_str` cannot be matched to any layout
 
 *******************************************************************************/
 
 public Layout newLayout ( cstring layout_str )
 {
-    Layout layout;
-
     mstring tweaked_str = layout_str.dup;
 
     StringSearch!() s;
@@ -288,21 +288,17 @@ public Layout newLayout ( cstring layout_str )
     switch ( tweaked_str )
     {
         case "messageonly":
-            layout = new LayoutMessageOnly;
-            break;
+            return new LayoutMessageOnly;
 
         case "stats":
         case "statslog":
-            layout = new LayoutStatsLog;
-            break;
+            return new LayoutStatsLog;
 
         case "simple":
-            layout = new LayoutSimple;
-            break;
+            return new LayoutSimple;
 
         case "date":
-            layout = new LayoutDate;
-            break;
+            return new LayoutDate;
 
         default:
             // Has to be 2 statements because `istring ~ cstring`
@@ -311,8 +307,6 @@ public Layout newLayout ( cstring layout_str )
             msg ~= layout_str;
             throw new Exception(msg, __FILE__, __LINE__);
     }
-
-    return layout;
 }
 
 ///


### PR DESCRIPTION
The first 3 commits are pretty straightforward and remove some oddities/indirections introduced with the duplication of the loggers.

The last one is something that bugged me when I was working on this code. Having a mix of template arguments and runtime lookup is not very consistent. Using the `makeLayout` allows one to implement whatever default they wish while simplifying the interface for everyone.