### PR TITLE
 [V4] Unify Appender.Layout.format delegate type with the rest of Ocean

### DIFF
--- a/relnotes/layout-format.migration.md
+++ b/relnotes/layout-format.migration.md
@@ -1,0 +1,9 @@
+## Appender.Layout's `format` method sink type was updated
+
+* `ocean.util.log.Appender : Appender.Layout.format`
+
+This method was previously accepting a `size_t delegate(Const!(void)[])` as sink type.
+As we moved away from `size_t`-returning delegates, and all those layout were essentially
+casting the data to `cstring` under the hood, those delegates were changed to be the same
+as `FormatterSink` (that is, `void delegate(cstring)`).
+Unless you are defining your own `Appender.Layout` classes, this should not have any effect on you.

--- a/src/ocean/util/log/AppendFile.d
+++ b/src/ocean/util/log/AppendFile.d
@@ -87,7 +87,7 @@ public class AppendFile : Filer
 
     final override void append (LogEvent event)
     {
-        this.layout.format(event, &this.buffer.write);
+        this.layout.format(event, (cstring v) { this.buffer.write(v); });
         this.buffer.append(FileConst.NewlineString).flush;
     }
 }

--- a/src/ocean/util/log/AppendFile.d
+++ b/src/ocean/util/log/AppendFile.d
@@ -1,150 +1,140 @@
 /*******************************************************************************
 
-        Copyright:
-            Copyright (c) 2004 Kris Bell.
-            Some parts copyright (c) 2009-2016 Sociomantic Labs GmbH.
-            All rights reserved.
+   Copyright:
+       Copyright (c) 2004 Kris Bell.
+       Some parts copyright (c) 2009-2016 Sociomantic Labs GmbH.
+       All rights reserved.
 
-        License:
-            Tango Dual License: 3-Clause BSD License / Academic Free License v3.0.
-            See LICENSE_TANGO.txt for details.
+   License:
+       Tango Dual License: 3-Clause BSD License / Academic Free License v3.0.
+       See LICENSE_TANGO.txt for details.
 
-        Version: Initial release: May 2004
+   Version: Initial release: May 2004
 
-        Authors: Kris
+   Authors: Kris
 
 *******************************************************************************/
 
 module ocean.util.log.AppendFile;
 
+import ocean.io.device.File;
+import ocean.io.model.IFile;
+import ocean.io.model.IConduit;
+import ocean.io.stream.Buffered;
 import ocean.transition;
 import ocean.util.log.Appender;
 import ocean.util.log.Event;
 
-import ocean.io.device.File;
-
-import ocean.io.stream.Buffered;
-
-import ocean.io.model.IFile,
-       ocean.io.model.IConduit;
-
 /*******************************************************************************
 
-        Append log messages to a file. This basic version has no rollover
-        support, so it just keeps on adding to the file. There is also an
-        AppendFiles that may suit your needs.
+    Append log messages to a file. This basic version has no rollover support,
+    so it just keeps on adding to the file.
+
+    There is also an AppendFiles that may suit your needs.
 
 *******************************************************************************/
 
-class AppendFile : Filer
+public class AppendFile : Filer
 {
-        private Mask    mask_;
+   private Mask mask_;
 
-        /***********************************************************************
+    /***************************************************************************
 
-                Create a basic FileAppender to a file with the specified
-                path.
+        Create a basic FileAppender to a file with the specified path.
 
-        ***********************************************************************/
+    ***************************************************************************/
 
-        this (istring fp, Appender.Layout how = null)
-        {
-                // Get a unique fingerprint for this instance
-                mask_ = register (fp);
+    public this (istring fp, Appender.Layout how = null)
+    {
+        // Get a unique fingerprint for this instance
+        this.mask_ = register(fp);
 
-                // make it shareable for read
-                File.Style style = File.WriteAppending;
-                style.share = File.Share.Read;
-                configure (new File (fp, style));
-                layout (how);
-        }
+        // make it shareable for read
+        File.Style style = File.WriteAppending;
+        style.share = File.Share.Read;
+        this.configure(new File(fp, style));
+        this.layout(how);
+    }
 
-        /***********************************************************************
+    /***************************************************************************
 
-                Return the fingerprint for this class
+        Returns:
+            the fingerprint for this class
 
-        ***********************************************************************/
+    ***************************************************************************/
 
-        final override Mask mask ()
-        {
-                return mask_;
-        }
+    final override Mask mask ()
+    {
+        return mask_;
+    }
 
-        /***********************************************************************
+    /***************************************************************************
 
-                Return the name of this class
+        Return the name of this class
 
-        ***********************************************************************/
+    ***************************************************************************/
 
-        final override istring name ()
-        {
-                return this.classinfo.name;
-        }
+    final override istring name ()
+    {
+        return this.classinfo.name;
+    }
 
-        /***********************************************************************
+    /***************************************************************************
 
-                Append an event to the output.
+        Append an event to the output.
 
-        ***********************************************************************/
+    ***************************************************************************/
 
-        final override void append (LogEvent event)
-        {
-            layout.format (event, &buffer.write);
-            buffer.append (FileConst.NewlineString)
-                  .flush;
-        }
+    final override void append (LogEvent event)
+    {
+        this.layout.format(event, &this.buffer.write);
+        this.buffer.append(FileConst.NewlineString).flush;
+    }
 }
 
 
-/*******************************************************************************
-
-        Base class for file appenders
-
-*******************************************************************************/
-
-class Filer : Appender
+/// Base class for file appenders
+public class Filer : Appender
 {
-        package Bout            buffer;
-        private IConduit        conduit_;
+    package Bout            buffer;
+    private IConduit        conduit_;
 
-        /***********************************************************************
+    /***************************************************************************
 
-                Return the conduit
+        Return the conduit
 
-        ***********************************************************************/
+    ***************************************************************************/
 
-        final IConduit conduit ()
+    final IConduit conduit ()
+    {
+        return this.conduit_;
+    }
+
+    /***************************************************************************
+
+        Close the file associated with this Appender
+
+    ***************************************************************************/
+
+    final override void close ()
+    {
+        if (this.conduit_)
         {
-                return conduit_;
+            this.conduit_.detach;
+            this.conduit_ = null;
         }
+    }
 
-        /***********************************************************************
+    /***************************************************************************
 
-                Close the file associated with this Appender
+        Set the conduit
 
-        ***********************************************************************/
+    ***************************************************************************/
 
-        final override void close ()
-        {
-            if (conduit_)
-               {
-               conduit_.detach;
-               conduit_ = null;
-               }
-        }
-
-        /***********************************************************************
-
-                Set the conduit
-
-        ***********************************************************************/
-
-        package final Bout configure (IConduit conduit)
-        {
-                // create a new buffer upon this conduit
-                conduit_ = conduit;
-                return (buffer = new Bout(conduit));
-        }
+    package final Bout configure (IConduit conduit)
+    {
+        // create a new buffer upon this conduit
+        this.conduit_ = conduit;
+        return (this.buffer = new Bout(conduit));
+    }
 }
-
-

--- a/src/ocean/util/log/AppendStderrStdout.d
+++ b/src/ocean/util/log/AppendStderrStdout.d
@@ -71,9 +71,9 @@ public class AppendStderrStdout : Appender
     public this (ILogger.Level first_stderr_level = ILogger.Level.Warn,
                  Appender.Layout how = null)
     {
-        mask_ = register(name);
+        this.mask_ = this.register(name);
         this.first_stderr_level = first_stderr_level;
-        layout(how);
+        this.layout(how);
     }
 
     /***********************************************************************
@@ -85,7 +85,7 @@ public class AppendStderrStdout : Appender
 
     final override public Mask mask ()
     {
-        return mask_;
+        return this.mask_;
     }
 
     /***********************************************************************

--- a/src/ocean/util/log/AppendStderrStdout.d
+++ b/src/ocean/util/log/AppendStderrStdout.d
@@ -119,8 +119,8 @@ public class AppendStderrStdout : Appender
 
         layout.format(
             event,
-            (Const!(void)[] content) {
-                return stream.write(content);
+            (cstring content) {
+                stream.write(content);
             }
         );
         stream.write(Console.Eol);

--- a/src/ocean/util/log/AppendSysLog.d
+++ b/src/ocean/util/log/AppendSysLog.d
@@ -63,8 +63,7 @@ public class AppendSysLog : Appender
 
     private static class SysLogLayout : Layout
     {
-        override public void format ( LogEvent event,
-            size_t delegate(Const!(void)[]) dg )
+        override public void format ( LogEvent event, void delegate(cstring) dg )
         {
             dg("[");
             dg(event.name);
@@ -247,15 +246,14 @@ public class AppendSysLog : Appender
 
     private char* format ( LogEvent event )
     {
-        size_t layoutSink ( Const!(void)[] data )
+        void sink ( cstring data )
         {
-            this.buf ~= castFrom!(Const!(void)[]).to!(cstring)(data);
-            return data.length;
+            this.buf ~= data;
         }
 
         this.buf.length = 0;
         enableStomping(this.buf);
-        this.layout.format(event, &layoutSink);
+        this.layout.format(event, &sink);
         this.buf ~= '\0';
 
         return this.buf.ptr;

--- a/src/ocean/util/log/Appender.d
+++ b/src/ocean/util/log/Appender.d
@@ -48,7 +48,7 @@ public class Appender
 
     public interface Layout
     {
-        void format (LogEvent event, size_t delegate(Const!(void)[]) dg);
+        void format (LogEvent event, void delegate(cstring) dg);
     }
 
     /***************************************************************************
@@ -207,7 +207,7 @@ public class AppendNull : Appender
     /// Append an event to the output
     final override void append (LogEvent event)
     {
-        this.layout.format(event, (Const!(void)[]){return cast(size_t) 0;});
+        this.layout.format(event, (cstring) {});
     }
 }
 
@@ -247,7 +247,7 @@ public class AppendStream : Appender
     {
         const istring Eol = "\n";
 
-        this.layout.format(event, (Const!(void)[] content){return this.stream_.write(content);});
+        this.layout.format(event, (cstring content) { this.stream_.write(content); });
         this.stream_.write(Eol);
         if (this.flush_)
             this.stream_.flush;
@@ -270,7 +270,7 @@ public class LayoutTimer : Appender.Layout
 
     ***************************************************************************/
 
-    public override void format (LogEvent event, size_t delegate(Const!(void)[]) dg)
+    public override void format (LogEvent event, void delegate(cstring) dg)
     {
         char[20] tmp = void;
 

--- a/src/ocean/util/log/Appender.d
+++ b/src/ocean/util/log/Appender.d
@@ -40,14 +40,13 @@ public class Appender
 
     /***************************************************************************
 
-                Interface for all logging layout instances
+        Interface for all logging layout instances
 
-                Implement this method to perform the formatting of
-                message content.
+        Implement this method to perform the formatting of message content.
 
     ***************************************************************************/
 
-    interface Layout
+    public interface Layout
     {
         void format (LogEvent event, size_t delegate(Const!(void)[]) dg);
     }
@@ -84,23 +83,23 @@ public class Appender
     abstract void append (LogEvent event);
 
     /// Create an Appender and default its layout to LayoutTimer.
-    this ()
+    public this ()
     {
         if (generic is null)
             generic = new LayoutTimer;
-        layout_ = generic;
+        this.layout_ = generic;
     }
 
     /// Return the current Level setting
     final ILogger.Level level ()
     {
-        return level_;
+        return this.level_;
     }
 
     /// Return the current Level setting
     final Appender level (ILogger.Level l)
     {
-        level_ = l;
+        this.level_ = l;
         return this;
     }
 
@@ -145,25 +144,25 @@ public class Appender
     void layout (Layout how)
     {
         verify(generic !is null);
-        layout_ = how ? how : generic;
+        this.layout_ = how ? how : generic;
     }
 
     /// Return the current Layout
     Layout layout ()
     {
-        return layout_;
+        return this.layout_;
     }
 
     /// Attach another appender to this one
     void next (Appender appender)
     {
-        next_ = appender;
+        this.next_ = appender;
     }
 
     /// Return the next appender in the list
     Appender next ()
     {
-        return next_;
+        return this.next_;
     }
 
     /// Close this appender. This would be used for file, sockets, and the like
@@ -189,14 +188,14 @@ public class AppendNull : Appender
     /// Create with the given Layout
     this (Layout how = null)
     {
-        mask_ = register (name);
-        layout (how);
+        this.mask_ = this.register(name);
+        this.layout(how);
     }
 
     /// Return the fingerprint for this class
     final override Mask mask ()
     {
-        return mask_;
+        return this.mask_;
     }
 
     /// Return the name of this class
@@ -208,7 +207,7 @@ public class AppendNull : Appender
     /// Append an event to the output
     final override void append (LogEvent event)
     {
-        layout.format (event, (Const!(void)[]){return cast(size_t) 0;});
+        this.layout.format(event, (Const!(void)[]){return cast(size_t) 0;});
     }
 }
 
@@ -223,18 +222,18 @@ public class AppendStream : Appender
     ///Create with the given stream and layout
     this (OutputStream stream, bool flush = false, Appender.Layout how = null)
     {
-        verify (stream !is null);
+        verify(stream !is null);
 
-        mask_ = register (name);
-        stream_ = stream;
-        flush_ = flush;
-        layout (how);
+        this.mask_ = register (name);
+        this.stream_ = stream;
+        this.flush_ = flush;
+        this.layout(how);
     }
 
     /// Return the fingerprint for this class
     final override Mask mask ()
     {
-        return mask_;
+        return this.mask_;
     }
 
     /// Return the name of this class
@@ -248,10 +247,10 @@ public class AppendStream : Appender
     {
         const istring Eol = "\n";
 
-        layout.format (event, (Const!(void)[] content){return stream_.write(content);});
-        stream_.write (Eol);
-        if (flush_)
-            stream_.flush;
+        this.layout.format(event, (Const!(void)[] content){return this.stream_.write(content);});
+        this.stream_.write(Eol);
+        if (this.flush_)
+            this.stream_.flush;
     }
 }
 
@@ -271,18 +270,18 @@ public class LayoutTimer : Appender.Layout
 
     ***************************************************************************/
 
-    void format (LogEvent event, size_t delegate(Const!(void)[]) dg)
+    public override void format (LogEvent event, size_t delegate(Const!(void)[]) dg)
     {
         char[20] tmp = void;
 
-        dg (event.toMilli (tmp, event.span));
-        dg (" ");
-        dg (event.levelName);
-        dg (" [");
-        dg (event.name);
-        dg ("] ");
-        dg (event.host.label);
-        dg ("- ");
-        dg (event.toString);
+        dg(event.toMilli (tmp, event.span));
+        dg(" ");
+        dg(event.levelName);
+        dg(" [");
+        dg(event.name);
+        dg("] ");
+        dg(event.host.label);
+        dg("- ");
+        dg(event.toString);
     }
 }

--- a/src/ocean/util/log/InsertConsole.d
+++ b/src/ocean/util/log/InsertConsole.d
@@ -136,12 +136,12 @@ public class InsertConsole: Appender
         {
             layout.format(
               event,
-              ( Const!(void)[] content )
+              ( cstring content )
               {
                   size_t written;
                   while (pos + content.length > buffer.length)
                   {
-                      buffer[pos .. $] = cast(char[]) content[0 .. buffer.length - pos];
+                      buffer[pos .. $] = content[0 .. buffer.length - pos];
 
                       written += stream_.write(CSI);
                       written += stream_.write(LINE_UP);
@@ -164,11 +164,9 @@ public class InsertConsole: Appender
 
                   if (content.length > 0)
                   {
-                      buffer[pos .. pos + content.length] = cast(char[]) content[];
+                      buffer[pos .. pos + content.length] = content[];
                       pos += content.length;
                   }
-
-                  return written;
               } );
 
             stream_.write(CSI);

--- a/src/ocean/util/log/LayoutDate.d
+++ b/src/ocean/util/log/LayoutDate.d
@@ -58,7 +58,7 @@ public class LayoutDate : Appender.Layout
 
         ***********************************************************************/
 
-    public override void format (LogEvent event, size_t delegate(Const!(void)[]) dg)
+    public override void format (LogEvent event, void delegate(cstring) dg)
     {
         auto level = event.levelName;
 

--- a/src/ocean/util/log/LayoutDate.d
+++ b/src/ocean/util/log/LayoutDate.d
@@ -58,30 +58,30 @@ public class LayoutDate : Appender.Layout
 
         ***********************************************************************/
 
-        void format (LogEvent event, size_t delegate(Const!(void)[]) dg)
-        {
-                auto level = event.levelName;
+    public override void format (LogEvent event, size_t delegate(Const!(void)[]) dg)
+    {
+        auto level = event.levelName;
 
-                // convert time to field values
-                auto tm = event.time;
-                auto dt = (localTime) ? WallClock.toDate(tm) : Clock.toDate(tm);
+        // convert time to field values
+        auto tm = event.time;
+        auto dt = (localTime) ? WallClock.toDate(tm) : Clock.toDate(tm);
 
-                // format date according to ISO-8601 (lightweight formatter)
-                char[20] tmp = void;
-                char[256] tmp2 = void;
-                dg (layout (tmp2, "%0-%1-%2 %3:%4:%5,%6 %7 [%8] - ",
-                            convert (tmp[0..4],   dt.date.year),
-                            convert (tmp[4..6],   dt.date.month),
-                            convert (tmp[6..8],   dt.date.day),
-                            convert (tmp[8..10],  dt.time.hours),
-                            convert (tmp[10..12], dt.time.minutes),
-                            convert (tmp[12..14], dt.time.seconds),
-                            convert (tmp[14..17], dt.time.millis),
-                            level,
-                            event.name
-                            ));
-                dg (event.toString);
-        }
+        // format date according to ISO-8601 (lightweight formatter)
+        char[20] tmp = void;
+        char[256] tmp2 = void;
+        dg(layout(tmp2, "%0-%1-%2 %3:%4:%5,%6 %7 [%8] - ",
+                  convert(tmp[0..4],   dt.date.year),
+                  convert(tmp[4..6],   dt.date.month),
+                  convert(tmp[6..8],   dt.date.day),
+                  convert(tmp[8..10],  dt.time.hours),
+                  convert(tmp[10..12], dt.time.minutes),
+                  convert(tmp[12..14], dt.time.seconds),
+                  convert(tmp[14..17], dt.time.millis),
+                  level,
+                  event.name
+               ));
+        dg(event.toString);
+    }
 
         /**********************************************************************
 

--- a/src/ocean/util/log/layout/LayoutMessageOnly.d
+++ b/src/ocean/util/log/layout/LayoutMessageOnly.d
@@ -31,7 +31,7 @@ public class LayoutMessageOnly : Appender.Layout
 
     ***************************************************************************/
 
-    public override void format (LogEvent event, size_t delegate(Const!(void)[]) dg)
+    public override void format (LogEvent event, void delegate(cstring) dg)
     {
         dg(event.toString);
     }

--- a/src/ocean/util/log/layout/LayoutMessageOnly.d
+++ b/src/ocean/util/log/layout/LayoutMessageOnly.d
@@ -16,33 +16,14 @@
 
 module ocean.util.log.layout.LayoutMessageOnly;
 
-
-
-
 import ocean.transition;
 import ocean.util.log.Appender;
 import ocean.util.log.Event;
 
 
-
-/*******************************************************************************
-
-    A layout with only the message
-
-*******************************************************************************/
-
+/// Ditto
 public class LayoutMessageOnly : Appender.Layout
 {
-    /***************************************************************************
-
-        Constructor
-
-    ***************************************************************************/
-
-    this ( )
-    {
-    }
-
     /***************************************************************************
 
         Subclasses should implement this method to perform the
@@ -50,10 +31,8 @@ public class LayoutMessageOnly : Appender.Layout
 
     ***************************************************************************/
 
-    void format (LogEvent event, size_t delegate(Const!(void)[]) dg)
+    public override void format (LogEvent event, size_t delegate(Const!(void)[]) dg)
     {
-        dg (event.toString);
+        dg(event.toString);
     }
-
 }
-

--- a/src/ocean/util/log/layout/LayoutSimple.d
+++ b/src/ocean/util/log/layout/LayoutSimple.d
@@ -64,7 +64,7 @@ public class LayoutSimple : Appender.Layout
 
     ***************************************************************************/
 
-    public override void format (LogEvent event, size_t delegate(Const!(void)[]) dg)
+    public override void format (LogEvent event, void delegate(cstring) dg)
     {
         auto level = event.levelName;
 

--- a/src/ocean/util/log/layout/LayoutSimple.d
+++ b/src/ocean/util/log/layout/LayoutSimple.d
@@ -16,80 +16,76 @@
 module ocean.util.log.layout.LayoutSimple;
 
 import ocean.transition;
-
+import Integer = ocean.text.convert.Integer_tango;
 import ocean.text.Util;
-
-import ocean.time.Clock,
-        ocean.time.WallClock;
-
+import ocean.time.Clock;
+import ocean.time.WallClock;
 import ocean.util.log.Appender;
 import ocean.util.log.Event;
-
-import  Integer = ocean.text.convert.Integer_tango;
 
 
 /*******************************************************************************
 
-        A simple layout, prefixing each message with the log level and
-        the name of the logger.
+   A simple layout, prefixing each message with the log level and
+   the name of the logger.
 
-        Example:
-        ------
-        import ocean.util.log.layout.LayoutSimple;
-        import ocean.util.log.Logger;
-        import ocean.util.log.AppendConsole;
+   Example:
+   ------
+   import ocean.util.log.layout.LayoutSimple;
+   import ocean.util.log.Logger;
+   import ocean.util.log.AppendConsole;
 
 
-        Log.root.clear;
-        Log.root.add(new AppendConsole(new LayoutSimple));
+   Log.root.clear;
+   Log.root.add(new AppendConsole(new LayoutSimple));
 
-        auto logger = Log.lookup("Example");
+   auto logger = Log.lookup("Example");
 
-        logger.trace("Trace example");
-        logger.error("Error example");
-        logger.fatal("Fatal example");
-        -----
+   logger.trace("Trace example");
+   logger.error("Error example");
+   logger.fatal("Fatal example");
+   -----
 
-        Produced output:
-        -----
-        Trace [Example] - Trace example
-        Error [Example] - Error example
-        Fatal [Example] - Fatal example
-        ----
+   Produced output:
+   -----
+   Trace [Example] - Trace example
+   Error [Example] - Error example
+   Fatal [Example] - Fatal example
+   ----
 
 *******************************************************************************/
 
 public class LayoutSimple : Appender.Layout
 {
-        /***********************************************************************
+    /***************************************************************************
 
-                Subclasses should implement this method to perform the
-                formatting of the actual message content.
+        Subclasses should implement this method to perform the formatting
+        of the actual message content.
 
-        ***********************************************************************/
+    ***************************************************************************/
 
-        void format (LogEvent event, size_t delegate(Const!(void)[]) dg)
-        {
-                auto level = event.levelName;
+    public override void format (LogEvent event, size_t delegate(Const!(void)[]) dg)
+    {
+        auto level = event.levelName;
 
-                // format date according to ISO-8601 (lightweight formatter)
-                char[20] tmp = void;
-                char[256] tmp2 = void;
-                dg (layout (tmp2, "%0 [%1] - ",
-                            level,
-                            event.name
-                            ));
-                dg (event.toString);
-        }
+        // format date according to ISO-8601 (lightweight formatter)
+        char[20] tmp = void;
+        char[256] tmp2 = void;
+        dg(layout(tmp2, "%0 [%1] - ",
+                  level,
+                  event.name
+               ));
+        dg(event.toString);
+    }
 
-        /**********************************************************************
+    /**********************************************************************
 
-                Convert an integer to a zero prefixed text representation
+        Convert an integer to a zero prefixed text representation
 
-        **********************************************************************/
+    **********************************************************************/
 
-        private cstring convert (mstring tmp, long i)
-        {
-                return Integer.formatter (tmp, i, 'u', '?', 8);
-        }
+    private cstring convert (mstring tmp, long i)
+    {
+        return Integer.formatter(tmp, i, 'u', '?', 8);
+    }
 }

--- a/src/ocean/util/log/layout/LayoutStatsLog.d
+++ b/src/ocean/util/log/layout/LayoutStatsLog.d
@@ -1,96 +1,92 @@
 /*******************************************************************************
 
-        Slightly modified LayoutDate class. Does NOT output the level.
-        Intended for StatsLog.
+   Slightly modified LayoutDate class. Does NOT output the level.
+   Intended for StatsLog.
 
-        Copyright:
-            Copyright (c) 2004 Kris Bell.
-            Some parts copyright (c) 2009-2016 Sociomantic Labs GmbH.
-            All rights reserved.
+   Copyright:
+       Copyright (c) 2004 Kris Bell.
+       Some parts copyright (c) 2009-2016 Sociomantic Labs GmbH.
+       All rights reserved.
 
-        License:
-            Tango Dual License: 3-Clause BSD License / Academic Free License v3.0.
-            See LICENSE_TANGO.txt for details.
+   License:
+       Tango Dual License: 3-Clause BSD License / Academic Free License v3.0.
+       See LICENSE_TANGO.txt for details.
 
-        Version: Initial release: May 2004
+   Version: Initial release: May 2004
 
-        Authors: Kris & Mathias Baumann
+   Authors: Kris & Mathias Baumann
 
 *******************************************************************************/
 
 module ocean.util.log.layout.LayoutStatsLog;
 
 import ocean.transition;
-
+import Integer = ocean.text.convert.Integer_tango;
 import ocean.text.Util;
-
-import ocean.time.Clock,
-        ocean.time.WallClock;
-
+import ocean.time.Clock;
+import ocean.time.WallClock;
 import ocean.util.log.Appender;
 import ocean.util.log.Event;
 
-import  Integer = ocean.text.convert.Integer_tango;
 
 /*******************************************************************************
 
-        A layout with ISO-8601 date information prefixed to each message
+   A layout with ISO-8601 date information prefixed to each message
 
 *******************************************************************************/
 
 public class LayoutStatsLog : Appender.Layout
 {
-        private bool localTime;
+   private bool localTime;
 
-        /***********************************************************************
+    /***************************************************************************
 
-                Ctor with indicator for local vs UTC time. Default is
-                local time.
+        Ctor with indicator for local vs UTC time. Default is local time.
 
-        ***********************************************************************/
+    ***********************************************************************/
 
-        this (bool localTime = true)
-        {
-                this.localTime = localTime;
-        }
+    public this (bool localTime = true)
+    {
+        this.localTime = localTime;
+    }
 
-        /***********************************************************************
+    /***************************************************************************
 
-                Subclasses should implement this method to perform the
-                formatting of the actual message content.
+        Subclasses should implement this method to perform the formatting
+        of the actual message content.
 
-        ***********************************************************************/
+    ***************************************************************************/
 
-        void format (LogEvent event, size_t delegate(Const!(void)[]) dg)
-        {
-                auto level = event.levelName;
+    public override void format (LogEvent event, size_t delegate(Const!(void)[]) dg)
+    {
+        auto level = event.levelName;
 
-                // convert time to field values
-                auto tm = event.time;
-                auto dt = (localTime) ? WallClock.toDate(tm) : Clock.toDate(tm);
+        // convert time to field values
+        auto tm = event.time;
+        auto dt = (localTime) ? WallClock.toDate(tm) : Clock.toDate(tm);
 
-                // format date according to ISO-8601 (lightweight formatter)
-                char[20] tmp = void;
-                char[256] tmp2 = void;
-                dg (layout (tmp2, "%0-%1-%2 %3:%4:%5,%6 ",
-                            convert (tmp[0..4],   dt.date.year),
-                            convert (tmp[4..6],   dt.date.month),
-                            convert (tmp[6..8],   dt.date.day),
-                            convert (tmp[8..10],  dt.time.hours),
-                            convert (tmp[10..12], dt.time.minutes),
-                            convert (tmp[12..14], dt.time.seconds),
-                            convert (tmp[14..17], dt.time.millis)));
-                dg (event.toString);
-        }
+        // format date according to ISO-8601 (lightweight formatter)
+        char[20] tmp = void;
+        char[256] tmp2 = void;
+        dg(layout(tmp2, "%0-%1-%2 %3:%4:%5,%6 ",
+                  convert(tmp[0..4],   dt.date.year),
+                  convert(tmp[4..6],   dt.date.month),
+                  convert(tmp[6..8],   dt.date.day),
+                  convert(tmp[8..10],  dt.time.hours),
+                  convert(tmp[10..12], dt.time.minutes),
+                  convert(tmp[12..14], dt.time.seconds),
+                  convert(tmp[14..17], dt.time.millis)));
+        dg(event.toString);
+    }
 
-        /**********************************************************************
+    /***************************************************************************
 
-                Convert an integer to a zero prefixed text representation
+        Convert an integer to a zero prefixed text representation
 
-        **********************************************************************/
+    ***************************************************************************/
 
-        private cstring convert (mstring tmp, long i)
-        {
-                return Integer.formatter (tmp, i, 'u', '?', 8);
-        }
+    private cstring convert (mstring tmp, long i)
+    {
+        return Integer.formatter(tmp, i, 'u', '?', 8);
+    }
 }

--- a/src/ocean/util/log/layout/LayoutStatsLog.d
+++ b/src/ocean/util/log/layout/LayoutStatsLog.d
@@ -57,7 +57,7 @@ public class LayoutStatsLog : Appender.Layout
 
     ***************************************************************************/
 
-    public override void format (LogEvent event, size_t delegate(Const!(void)[]) dg)
+    public override void format (LogEvent event, void delegate(cstring) dg)
     {
         auto level = event.levelName;
 


### PR DESCRIPTION
The first commit cleans up the indent / code style in the modules being touched. Since I was changing some part of the code, it felt counter-productive to spend time keeping the original, out of sync style. As those modules are seldom touched, so it's pretty safe conflict-wise.

The second commit is just a clean-up I spotted when doing the original logger separation / refactoring.