### PR TITLE
Reduce allocations / clean up code in Process (+ fix name clash with Formatter)

### DIFF
--- a/src/ocean/sys/Process.d
+++ b/src/ocean/sys/Process.d
@@ -23,8 +23,8 @@ import ocean.io.Console;
 import ocean.sys.Common;
 import ocean.sys.Pipe;
 import ocean.core.ExceptionDefinitions;
+import ocean.text.convert.Formatter;
 import ocean.text.Util;
-import Integer = ocean.text.convert.Integer_tango;
 
 version(UnitTest) import ocean.core.Test;
 
@@ -199,37 +199,27 @@ class Process
          */
         public istring toString()
         {
-            cstring str;
-
             switch (reason)
             {
                 case Exit:
-                    str = format("Process exited normally with return code ", status);
-                    break;
+                    return format("Process exited normally with return code {}", status);
 
                 case Signal:
-                    str = format("Process was killed with signal ", status);
-                    break;
+                    return format("Process was killed with signal {}", status);
 
                 case Stop:
-                    str = format("Process was stopped with signal ", status);
-                    break;
+                    return format("Process was stopped with signal {}", status);
 
                 case Continue:
-                    str = format("Process was resumed with signal ", status);
-                    break;
+                    return format("Process was resumed with signal {}", status);
 
                 case Error:
-                    str = format("Process failed with error code ", reason) ~
-                                 " : " ~ SysError.lookup(status);
-                    break;
+                    return format("Process failed with error code {}: {}",
+                                  reason, SysError.lookup(status));
 
                 default:
-                    str = format("Unknown process result ", reason);
-                    break;
+                    return format("Unknown process result {}", reason);
             }
-
-            return assumeUnique(str);
         }
     }
 
@@ -1599,8 +1589,9 @@ class ProcessCreateException: ProcessException
     public this (cstring command, istring message = SysError.lastMsg,
                  istring file = __FILE__, uint line = __LINE__)
     {
-        super("Could not create process for " ~ idup(command) ~ " : " ~ message,
-              file, line);
+        super(
+            format("Could not create process for '{}': {}", command, message),
+            file, line);
     }
 }
 
@@ -1613,8 +1604,9 @@ class ProcessForkException: ProcessException
 {
     public this (int pid, istring file = __FILE__, uint line = __LINE__)
     {
-        auto msg = format("Could not fork process ", pid);
-        super(assumeUnique(msg) ~ " : " ~ SysError.lastMsg, file, line);
+        super(
+            format("Could not fork process {}: {}", pid, SysError.lastMsg),
+            file, line);
     }
 }
 
@@ -1625,8 +1617,9 @@ class ProcessKillException: ProcessException
 {
     public this (int pid, istring file = __FILE__, uint line = __LINE__)
     {
-        auto msg = format("Could not kill process ", pid);
-        super(assumeUnique(msg) ~ " : " ~ SysError.lastMsg, file, line);
+        super(
+            format("Could not kill process {}: {}", pid, SysError.lastMsg),
+            file, line);
     }
 }
 
@@ -1638,22 +1631,10 @@ class ProcessWaitException: ProcessException
 {
     public this (int pid, istring file = __FILE__, uint line = __LINE__)
     {
-        auto msg = format("Could not wait on process ", pid);
-        super(assumeUnique(msg) ~ " : " ~ SysError.lastMsg, file, line);
+        super(
+            format("Could not wait on process {}: {}", pid, SysError.lastMsg),
+            file, line);
     }
-}
-
-
-
-
-/**
- *  append an int argument to a message
-*/
-private mstring format (cstring msg, int value)
-{
-    char[10] tmp;
-
-    return cast(mstring) msg ~ Integer.format (tmp, value);
 }
 
 extern (C) uint sleep (uint s);

--- a/src/ocean/sys/Process.d
+++ b/src/ocean/sys/Process.d
@@ -866,7 +866,7 @@ class Process
 
             // validate the redirection flags
             if((_redirect & (Redirect.OutputToError | Redirect.ErrorToOutput)) == (Redirect.OutputToError | Redirect.ErrorToOutput))
-                throw new ProcessCreateException(_args[0], "Illegal redirection flags", __FILE__, __LINE__);
+                throw new ProcessCreateException(_args[0], "Illegal redirection flags");
 
             // Are we redirecting stdout and stderr?
             bool redirected_output = (_redirect & (Redirect.Output | Redirect.OutputToError)) == Redirect.Output;
@@ -969,7 +969,7 @@ class Process
                         errno = status;
                         _running = false;
 
-                        throw new ProcessCreateException(_args[0], __FILE__, __LINE__);
+                        throw new ProcessCreateException(_args[0]);
                     }
                 }
                 else
@@ -1075,7 +1075,7 @@ class Process
             }
             else
             {
-                throw new ProcessForkException(_pid, __FILE__, __LINE__);
+                throw new ProcessForkException(_pid);
             }
         }
         else
@@ -1282,14 +1282,14 @@ class Process
                         }
                         else if (rc == -1)
                         {
-                            throw new ProcessWaitException(cast(int) _pid, __FILE__, __LINE__);
+                            throw new ProcessWaitException(cast(int) _pid);
                         }
                         usleep(50000);
                     }
                 }
                 else
                 {
-                    throw new ProcessKillException(_pid, __FILE__, __LINE__);
+                    throw new ProcessKillException(_pid);
                 }
             }
             else
@@ -1596,14 +1596,11 @@ class Process
  */
 class ProcessCreateException: ProcessException
 {
-    public this(cstring command, istring file, uint line)
+    public this (cstring command, istring message = SysError.lastMsg,
+                 istring file = __FILE__, uint line = __LINE__)
     {
-        this(command, SysError.lastMsg, file, line);
-    }
-
-    public this(cstring command, istring message, istring file, uint line)
-    {
-        super("Could not create process for " ~ idup(command) ~ " : " ~ message);
+        super("Could not create process for " ~ idup(command) ~ " : " ~ message,
+              file, line);
     }
 }
 
@@ -1614,10 +1611,10 @@ class ProcessCreateException: ProcessException
  */
 class ProcessForkException: ProcessException
 {
-    public this(int pid, istring file, uint line)
+    public this (int pid, istring file = __FILE__, uint line = __LINE__)
     {
         auto msg = format("Could not fork process ", pid);
-        super(assumeUnique(msg) ~ " : " ~ SysError.lastMsg);
+        super(assumeUnique(msg) ~ " : " ~ SysError.lastMsg, file, line);
     }
 }
 
@@ -1626,10 +1623,10 @@ class ProcessForkException: ProcessException
  */
 class ProcessKillException: ProcessException
 {
-    public this(int pid, istring file, uint line)
+    public this (int pid, istring file = __FILE__, uint line = __LINE__)
     {
         auto msg = format("Could not kill process ", pid);
-        super(assumeUnique(msg) ~ " : " ~ SysError.lastMsg);
+        super(assumeUnique(msg) ~ " : " ~ SysError.lastMsg, file, line);
     }
 }
 
@@ -1639,10 +1636,10 @@ class ProcessKillException: ProcessException
  */
 class ProcessWaitException: ProcessException
 {
-    public this(int pid, istring file, uint line)
+    public this (int pid, istring file = __FILE__, uint line = __LINE__)
     {
         auto msg = format("Could not wait on process ", pid);
-        super(assumeUnique(msg) ~ " : " ~ SysError.lastMsg);
+        super(assumeUnique(msg) ~ " : " ~ SysError.lastMsg, file, line);
     }
 }
 

--- a/src/ocean/sys/Process.d
+++ b/src/ocean/sys/Process.d
@@ -194,32 +194,43 @@ class Process
         public int reason;
         public int status;
 
-        /**
-         * Returns a string with a description of the process execution result.
-         */
-        public istring toString()
+        /// Formatter-compatible string formatting function
+        public void toString (FormatterSink sink)
         {
             switch (reason)
             {
                 case Exit:
-                    return format("Process exited normally with return code {}", status);
+                    sformat(sink,
+                        "Process exited normally with return code {}", status);
+                    break;
 
                 case Signal:
-                    return format("Process was killed with signal {}", status);
+                    sformat(sink, "Process was killed with signal {}", status);
+                    break;
 
                 case Stop:
-                    return format("Process was stopped with signal {}", status);
+                    sformat(sink, "Process was stopped with signal {}", status);
+                    break;
 
                 case Continue:
-                    return format("Process was resumed with signal {}", status);
+                    sformat(sink, "Process was resumed with signal {}", status);
+                    break;
 
                 case Error:
-                    return format("Process failed with error code {}: {}",
-                                  reason, SysError.lookup(status));
+                    sformat(sink, "Process failed with error code {}: {}",
+                        reason, SysError.lookup(status));
+                    break;
 
                 default:
-                    return format("Unknown process result {}", reason);
+                    sformat(sink, "Unknown process result {}", reason);
+                    break;
             }
+        }
+
+        /// Convenience overload that format this as a string
+        public istring toString ()
+        {
+            return format("{}", this);
         }
     }
 


### PR DESCRIPTION
Importing both `Formatter` and `Process` led to a needless clash. This fixes it along with a few other code oddities.