### PR TITLE
Always import meta.traits.Indirections in Contiguous

### DIFF
--- a/src/ocean/util/serialize/contiguous/Contiguous.d
+++ b/src/ocean/util/serialize/contiguous/Contiguous.d
@@ -19,7 +19,7 @@ module ocean.util.serialize.contiguous.Contiguous;
 
 import ocean.transition;
 import ocean.core.Verify;
-
+import ocean.meta.traits.Indirections;
 import ocean.core.Enforce;
 
 version(UnitTest)
@@ -28,10 +28,6 @@ version(UnitTest)
     debug = ContiguousIntegrity;
 }
 
-debug(ContiguousIntegrity)
-{
-    import ocean.meta.traits.Indirections;
-}
 
 /*******************************************************************************
 

--- a/src/ocean/util/serialize/contiguous/Contiguous.d
+++ b/src/ocean/util/serialize/contiguous/Contiguous.d
@@ -285,7 +285,7 @@ package template ensureValueTypeMember ( S, size_t i, T )
 
     static if (is (T == union))
     {
-        static assert (!ContainsDynamicArray!(T),
+        static assert (!containsDynamicArray!(T),
                        M.stringof ~ " " ~ S.tupleof[i].stringof ~
                        " - unions containing dynamic arrays are not " ~
                        "allowed, sorry");
@@ -313,6 +313,13 @@ unittest
     static struct S2
     {
         int a, b, c;
+
+        union
+        {
+            char x;
+            int y;
+        }
+
         S1 subs;
     }
 


### PR DESCRIPTION
The template `hasIndirections` is required in all builds (not just unittests).

(Fix for regression introduced in the unreleased commit "Switch ocean internally to use ocean.meta".)