### PR TITLE
 Deprecate DateTime's formatWide

### DIFF
--- a/relnotes/formatwide.deprecation.md
+++ b/relnotes/formatwide.deprecation.md
@@ -1,0 +1,6 @@
+## DateTime's `formatWide` function is deprecated
+
+`ocean.text.convert.DateTime_tango`
+
+This function, when used with `char` is equivalent to `format`.
+And within ocean, we only support `char`.

--- a/src/ocean/text/convert/DateTime_tango.d
+++ b/src/ocean/text/convert/DateTime_tango.d
@@ -56,12 +56,6 @@ public DateTimeLocale DateTimeDefault;
 static this()
 {
     DateTimeDefault = DateTimeLocale.create;
-    version (WithExtensions)
-    {
-        Extensions8.add  (typeid(Time), &DateTimeDefault.bridge!(char));
-        Extensions16.add (typeid(Time), &DateTimeDefault.bridge!(wchar));
-        Extensions32.add (typeid(Time), &DateTimeDefault.bridge!(dchar));
-    }
 }
 
 /******************************************************************************
@@ -808,15 +802,6 @@ struct DateTimeLocale
         if (rpt is 3)
             return abbreviatedDayName (dayOfWeek);
         return dayName (dayOfWeek);
-    }
-
-    /**********************************************************************
-
-     **********************************************************************/
-
-    private T[] bridge(T) (T[] result, void* arg, T[] format)
-    {
-        return formatWide (result, *cast(Time*) arg, format);
     }
 
     /**********************************************************************

--- a/src/ocean/text/convert/DateTime_tango.d
+++ b/src/ocean/text/convert/DateTime_tango.d
@@ -196,6 +196,7 @@ struct DateTimeLocale
 
      **********************************************************************/
 
+    deprecated("Use format instead")
     T[] formatWide(T) (T[] output, Time dateTime, T[] fmt)
     {
         static if (is (T == char))


### PR DESCRIPTION
It's unused and likely buggy (since it does not support cstring for ex)