### PR TITLE
Minimal fixes for exception_handler

### DIFF
--- a/src/ocean/io/select/EpollSelectDispatcher.d
+++ b/src/ocean/io/select/EpollSelectDispatcher.d
@@ -151,7 +151,7 @@ public class EpollSelectDispatcher : IEpollSelectDispatcherInfo
 
     ***************************************************************************/
 
-    private void delegate (Exception) unhandled_exception_hook;
+    private bool delegate (Exception) unhandled_exception_hook;
 
     /***************************************************************************
 
@@ -690,7 +690,7 @@ public class EpollSelectDispatcher : IEpollSelectDispatcherInfo
      **************************************************************************/
 
     public void eventLoop ( bool delegate ( ) select_cycle_hook = null,
-        void delegate (Exception) unhandled_exception_hook  = null )
+        bool delegate (Exception) unhandled_exception_hook  = null )
     {
         verify(!this.in_event_loop, "Event loop has already been started.");
 
@@ -712,10 +712,11 @@ public class EpollSelectDispatcher : IEpollSelectDispatcherInfo
             }
             catch (Exception e)
             {
-                if (unhandled_exception_hook !is null)
-                    unhandled_exception_hook(e);
-                else
+                if (  (unhandled_exception_hook is null)
+                    || !unhandled_exception_hook(e))
+                {
                     throw e;
+                }
             }
 
             if (select_cycle_hook !is null)

--- a/src/ocean/io/select/selector/SelectedKeysHandler.d
+++ b/src/ocean/io/select/selector/SelectedKeysHandler.d
@@ -118,7 +118,7 @@ class SelectedKeysHandler: ISelectedKeysHandler
     ***************************************************************************/
 
     override public void opCall ( epoll_event_t[] selected_set,
-        void delegate (Exception) unhandled_exception_hook )
+        bool delegate (Exception) unhandled_exception_hook )
     {
         foreach (key; selected_set)
         {
@@ -143,7 +143,7 @@ class SelectedKeysHandler: ISelectedKeysHandler
      **************************************************************************/
 
     final protected void handleSelectedKey ( epoll_event_t key,
-        void delegate (Exception) unhandled_exception_hook )
+        bool delegate (Exception) unhandled_exception_hook )
     {
         debug (EpollFdSanity)
         {

--- a/src/ocean/io/select/selector/TimeoutSelectedKeysHandler.d
+++ b/src/ocean/io/select/selector/TimeoutSelectedKeysHandler.d
@@ -106,7 +106,7 @@ class TimeoutSelectedKeysHandler: SelectedKeysHandler
     ***************************************************************************/
 
     public override void opCall ( epoll_event_t[] selected_set,
-        void delegate (Exception) unhandled_exception_hook )
+        bool delegate (Exception) unhandled_exception_hook )
     {
         if (this.timeout_manager.us_left < timeout_manager.us_left.max)
         {

--- a/src/ocean/io/select/selector/model/ISelectedKeysHandler.d
+++ b/src/ocean/io/select/selector/model/ISelectedKeysHandler.d
@@ -33,5 +33,5 @@ interface ISelectedKeysHandler
     ***************************************************************************/
 
     void opCall ( epoll_event_t[] selected_set,
-        void delegate (Exception) unhandled_exception_hook );
+        bool delegate (Exception) unhandled_exception_hook );
 }


### PR DESCRIPTION
Does not try to address fundamental flaws discussed in https://github.com/sociomantic-tsunami/ocean/issues/451 but
makes it at least possible to reset handler back to null after event loop was
already started.