### PR TITLE
 Allow removing the client from the selected set in EpollDispatcher.unregister

### DIFF
--- a/integrationtest/unregisterclient/main.d
+++ b/integrationtest/unregisterclient/main.d
@@ -1,0 +1,88 @@
+/*******************************************************************************
+
+    Test for EpollSelectDispatcher.unregister behaviour
+
+    Copyright:
+        Copyright (c) 2018 sociomantic labs GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+        Alternatively, this file may be distributed under the terms of the Tango
+        3-Clause BSD License (see LICENSE_BSD.txt for details).
+
+*******************************************************************************/
+
+module integrationtest.unregisterclient.main;
+
+import ocean.transition;
+
+import ocean.io.select.EpollSelectDispatcher;
+import ocean.io.select.client.SelectEvent;
+import ocean.core.Test;
+
+private EpollSelectDispatcher epoll;
+
+private SelectEvent event1, event2;
+private int count;
+
+// Corrupts the SelectEvent object. This should make test
+// segfault at access
+private void corruptEventObject (SelectEvent client)
+{
+    version (D_Version2)
+    {
+        auto initializer = client.classinfo.initializer();
+    }
+    else
+    {
+        auto initializer = client.classinfo.init;
+    }
+
+    ubyte* ptr = cast(ubyte*)client;
+    ptr[0..initializer.length] = 0;
+}
+
+version(UnitTest) {} else
+void main(istring[] args)
+{
+    bool handler1()
+    {
+        .count++;
+
+        // unregister and delete the other instance
+        .epoll.unregister(.event2, true);
+        corruptEventObject(.event2);
+
+        return false;
+    }
+
+    bool handler2()
+    {
+        .count++;
+
+        // unregister and delete the other instance
+        .epoll.unregister(.event1, true);
+        corruptEventObject(.event1);
+
+        return false;
+    }
+
+    .epoll = new EpollSelectDispatcher();
+
+    .event1 = new SelectEvent(&handler1);
+    .event2 = new SelectEvent(&handler2);
+
+    .epoll.register(.event1);
+    .epoll.register(.event2);
+
+    // trigger them both
+    .event1.trigger();
+    .event2.trigger();
+
+    // Do a select loop
+    .epoll.eventLoop();
+
+    // Make sure only one was handled.
+    test!("==")(.count, 1);
+}

--- a/relnotes/unregister.feature.md
+++ b/relnotes/unregister.feature.md
@@ -1,0 +1,9 @@
+### Allow removing the client from the selected set in EpollSelectDispatcher.unregister
+
+`ocean.io.select.EpollSelectDispatcher`
+
+`EpollSelectDispatcher.unregister` now accepts an optional flag
+(`remove_from_selected_set`) which will remove the client from the selected set
+if it's in there. This guarantees that the unregistered client's handle method
+will not be subsequently called by the selector. The client may thus be safely
+destroyed after unregistering.

--- a/src/ocean/io/select/EpollSelectDispatcher.d
+++ b/src/ocean/io/select/EpollSelectDispatcher.d
@@ -136,6 +136,15 @@ public class EpollSelectDispatcher : IEpollSelectDispatcherInfo
 
     /***************************************************************************
 
+        List of the clients that we're currently handling. Always slices
+        this.events.
+
+    ***************************************************************************/
+
+    private epoll_event_t[] selected_set;
+
+    /***************************************************************************
+
         Re-usable errno exception
 
      **************************************************************************/
@@ -791,9 +800,11 @@ public class EpollSelectDispatcher : IEpollSelectDispatcherInfo
 
                 version ( EpollCounters ) if ( n == 0 ) this.counters.timeouts++;
 
-                auto selected_set = events[0 .. n];
+                this.selected_set = this.events[0 .. n];
+                scope (exit)
+                    this.selected_set = null;
 
-                this.handle(selected_set, this.unhandled_exception_hook);
+                this.handle(this.selected_set, this.unhandled_exception_hook);
 
                 return n;
             }

--- a/src/ocean/io/select/EpollSelectDispatcher.d
+++ b/src/ocean/io/select/EpollSelectDispatcher.d
@@ -50,6 +50,8 @@ import ocean.io.select.selector.RegisteredClients;
 
 import ocean.core.Array : copy;
 
+import ocean.core.array.Search;
+
 import ocean.util.container.AppendBuffer;
 
 import ocean.time.timeout.model.ITimeoutManager;
@@ -367,6 +369,11 @@ public class EpollSelectDispatcher : IEpollSelectDispatcherInfo
 
        Params:
             client = client to unregister
+            remove_from_selected_set = if true, removes the client from the
+                selected set that may be currently being iterated over. This
+                guarantees that the unregistered client's handle method will not
+                be subsequently called by the selector. The client may thus be
+                safely destroyed after unregistering.
 
        Returns:
             0 if everything worked as expected or the error code (errno) as a
@@ -382,13 +389,36 @@ public class EpollSelectDispatcher : IEpollSelectDispatcherInfo
 
      **************************************************************************/
 
-    public int unregister ( ISelectClient client )
+    public int unregister ( ISelectClient client,
+        bool remove_from_selected_set = false )
     {
         try if (client.is_registered)
         {
             scope (success)
             {
                 this.registered_clients -= client;
+
+                if (remove_from_selected_set)
+                {
+                    /// Predicate for finding the ISelectClient inside
+                    /// array of epoll_event_t entries.
+                    bool entry_to_client (Const!(epoll_event_t) entry)
+                    {
+                        return entry.data.ptr == cast(void*)client;
+                    }
+
+                    auto index = this.selected_set.findIf(&entry_to_client);
+                    // Instead of removing the array entry, we'll just invalidate
+                    // it. This is to avoid problems with both the fact that
+                    // SelectedKeysHandler might be foreach-iterating over
+                    // this array at this time and the fact that shrinking
+                    // the slice owned by EpollSelectDispatcher wouldn't shrink
+                    // the slices owned by SelectedKeysHandler.
+                    if (index < this.selected_set.length)
+                    {
+                        this.selected_set[index] = epoll_event_t.init;
+                    }
+                }
             }
 
             if (!this.epollCtl(epoll.CtlOp.EPOLL_CTL_DEL, client.fileHandle,


### PR DESCRIPTION
`EpollSelectDispatcher.unregister` now accepts an optional flag
(`remove_from_selected_set`) which will remove the client from the
selected set if it's in there. This will allow other ISelectClients to
safely destroy other ISelectClients from their handle method
(previously, this was unsafe because even unregistering the client
would just remove it from the all next epoll cycles, but not from the
other one, if the client's fd reported that it's ready to be handled).

The assumption taken in this PR is that the branch predictor will make most of the branches in the `SelectedKeysHandler.opCall` no-ops, or that they have very little cost compared with the IO that is done, so let's try this before taking alternative more complicated approaches.