### PR TITLE
DaemonApp: Align the stats timer call with the interval

### DIFF
--- a/relnotes/aligned-stats.feature.md
+++ b/relnotes/aligned-stats.feature.md
@@ -1,0 +1,9 @@
+### Stats timer is now triggered at a predictable moment
+
+`ocean.util.app.DaemonApp`
+
+In order to help with multiple instance apps, or similar apps needing to compare their stats,
+the initial call to `onStatsTimer` will not be dependent on when the application was started anymore,
+but will be aligned on the interval provided.
+For example, if an application starts at 12:00:04 with an interval of 30 (the default),
+the first call to `onStatsTimer` will happen at 12:00:30 instead of 12:00:34 (currently).

--- a/src/ocean/util/app/DaemonApp.d
+++ b/src/ocean/util/app/DaemonApp.d
@@ -45,8 +45,11 @@ import ocean.util.app.ext.model.ILogExtExtension;
 import ocean.util.app.ext.model.ISignalExtExtension;
 
 import ocean.transition;
+version (UnitTest) import ocean.core.Test;
 import ocean.core.Verify;
 import ocean.task.IScheduler;
+
+import core.stdc.time;
 
 /// ditto
 public abstract class DaemonApp : Application,
@@ -460,13 +463,42 @@ public abstract class DaemonApp : Application,
         this.registerExtension(this.timer_ext);
 
         // Register stats timer with epoll
-        this.timer_ext.register(&this.statsTimer, this.stats_ext.config.interval);
+        ulong initial_offset = timeToNextInterval(this.stats_ext.config.interval);
+        this.timer_ext.register(
+            &this.statsTimer, initial_offset, this.stats_ext.config.interval);
 
         // Register signal event handler with epoll
         this.epoll.register(this.signal_ext.selectClient());
 
         /// Initialize the unix socket with epoll.
         this.unix_socket_ext.initializeSocket(this.epoll);
+    }
+
+    /***************************************************************************
+
+        Params:
+            interval = interval used for calling the stats timer
+            current  = current time, default to now (`time(null)`)
+
+        Returns:
+            function to calculate the amount of time to wait until the next
+            interval is reached.
+
+    ***************************************************************************/
+
+    private static ulong timeToNextInterval (ulong interval, time_t current = time(null))
+    {
+        return (current % interval) ? (interval - (current % interval)) : 0;
+    }
+
+    unittest
+    {
+        time_t orig = 704124854; // 14 seconds past the minute
+        test!("==")(timeToNextInterval(15, orig), 1);
+        test!("==")(timeToNextInterval(20, orig), 6);
+        test!("==")(timeToNextInterval(30, orig), 16);
+        test!("==")(timeToNextInterval(60, orig), 46);
+        test!("==")(timeToNextInterval(15, orig + 1), 0);
     }
 
     /***************************************************************************

--- a/src/ocean/util/log/Stats.d
+++ b/src/ocean/util/log/Stats.d
@@ -216,7 +216,7 @@ public class StatsLog
 
             Frequency at which Collectd should expect to receive metrics
 
-            This metric is expressed in metric, and should rarely needs to be
+            This metric is expressed in seconds, and should rarely needs to be
             modified. Defaults to 30s.
 
         ***********************************************************************/

--- a/src/ocean/util/log/Stats.d
+++ b/src/ocean/util/log/Stats.d
@@ -214,7 +214,7 @@ public class StatsLog
 
         /***********************************************************************
 
-            Frequency at which Collectd should expect to receive metrics
+            Frequency at which stats are collected
 
             This metric is expressed in seconds, and should rarely needs to be
             modified. Defaults to 30s.


### PR DESCRIPTION
> This will make stats easier to compare between two apps / multiple instances, provided the clocks are in sync.

CC @scott-gibson-sociomantic who had the idea following a discussion with @andrej-mitrovic-sociomantic 