### PR TITLE
Add show_version command to the application's control socket

### DIFF
--- a/relnotes/version.feature.md
+++ b/relnotes/version.feature.md
@@ -1,0 +1,21 @@
+### Print the application's version string to the control socket
+
+`ocean.util.app.DaemonApp`
+
+`DaemonApp`'s will now print the application's `--version` output to the control
+unix socket when `show_version` command is received:
+
+```
+$ echo 'show_version' | nc -U /srv/dlsnode/dlsnode.socket dlsnode
+version v1.9.0-28-gcbc6-dirty (compiled by 'Nemanja Boric' on 2018-03-27
+13:00:30 UTC with DMD64 D Compiler v1.081.2 using beaver:v0.2.2
+dlsproto:v13.2.0 makd:v2.2.0 ocean:v3.7.1-41-gdd24 swarm:v4.6.2 turtle:v8.4.0)
+[dflags='-di -g -debug
+-I/home/nemanjaboric/work/tsunami/dlsnode-1/build/devel/include -I./src
+-I./submodules/swarm/src  -I./submodules/ocean/src  -I./submodules/dlsproto/src
+-I./submodules/makd/src  -I./submodules/turtle/src  -I./submodules/beaver/src
+-w -v2 -v2=-static-arr-params', flavour='devel',
+ver_D_InlineAsm_X86_64='D_InlineAsm_X86_64', ver_D_LP64='D_LP64',
+ver_DigitalMars='DigitalMars', ver_LittleEndian='LittleEndian',
+ver_Posix='Posix', ver_X86_64='X86_64', ver_linux='linux']
+```

--- a/src/ocean/util/app/DaemonApp.d
+++ b/src/ocean/util/app/DaemonApp.d
@@ -311,6 +311,15 @@ public abstract class DaemonApp : Application,
 
         /***********************************************************************
 
+            Unix domain socket command to print the `--version` output of the
+            application to the unix socket.
+
+        ***********************************************************************/
+
+        istring show_version_command = "show_version";
+
+        /***********************************************************************
+
             Set of signals to ignore. Delivery of the signals specified in this
             set will have no effect on the application -- they are not passed
             to the default signal handler.
@@ -404,6 +413,12 @@ public abstract class DaemonApp : Application,
         this.unix_socket_ext = new UnixSocketExt();
         this.config_ext.registerExtension(this.unix_socket_ext);
         this.registerExtension(this.unix_socket_ext);
+
+        if (settings.show_version_command.length)
+        {
+            this.ver_ext.setupUnixSocketHandler(this, this.unix_socket_ext,
+                    settings.show_version_command);
+        }
 
         if (settings.use_task_ext)
         {


### PR DESCRIPTION
It's useful to know which instance of the application is running at the
moment. Sending the command to the unix domain socket will cause the
application to print its version to it.