### PR TITLE
Deprecate ocean.transition : getMsg

### DIFF
--- a/relnotes/getMsg.deprecation.md
+++ b/relnotes/getMsg.deprecation.md
@@ -1,0 +1,6 @@
+### `getMsg` is deprecated in favor of `Exception.message()`
+
+`ocean.transition`
+
+The `getMsg()` utility was introduced to abstract away the differences between runtimes.
+Nowadays (since `v2.077.0`), it always resolves to `Exception.message()` and can be removed.

--- a/src/ocean/transition.d
+++ b/src/ocean/transition.d
@@ -554,6 +554,7 @@ unittest
 
 *******************************************************************************/
 
+deprecated("Use Exception.message() directly")
 cstring getMsg ( Throwable e )
 {
     // if compiled with a runtime which already provides `message()`, use it
@@ -597,7 +598,7 @@ cstring getMsg ( Throwable e )
     }
 }
 
-unittest
+deprecated unittest
 {
     auto e = new Exception("abcde");
     assert (getMsg(e) == "abcde");


### PR DESCRIPTION
```
As mentioned in the release notes, it always resolves to `Exception.message()` nowadays.
```

@mihails-strasuns-sociomantic mentioned that this is now possible.
However, I recommend not to merge before libraries are adapted, otherwise there will be a cascade of useless deprecation messages.