### PR TITLE
Always use `Exception.message()` instead of `getMsg()`

### DIFF
--- a/integrationtest/httpserver/main.d
+++ b/integrationtest/httpserver/main.d
@@ -79,7 +79,7 @@ class TestHttpHandler: TaskHttpConnectionHandler
 
     static void printEx ( Exception e )
     {
-        Stderr.formatln("{} @{}:{}", getMsg(e), e.file, e.line);
+        Stderr.formatln("{} @{}:{}", e.message(), e.file, e.line);
     }
 }
 

--- a/integrationtest/scheduler/main.d
+++ b/integrationtest/scheduler/main.d
@@ -103,7 +103,7 @@ void main ( )
     theScheduler.exception_handler = ( Task t, Exception e )
     {
         Stderr.formatln("{} [{}:{}] {}", e.classinfo.name,
-            e.file, e.line, getMsg(e));
+            e.file, e.line, e.message());
         abort();
     };
 

--- a/src/ocean/core/Enforce.d
+++ b/src/ocean/core/Enforce.d
@@ -99,7 +99,7 @@ unittest
     }
     catch (Exception e)
     {
-        assert(getMsg(e) == "enforcement has failed");
+        assert(e.message() == "enforcement has failed");
         assert(e.line == __LINE__ - 6);
     }
 
@@ -110,7 +110,7 @@ unittest
     }
     catch (Exception e)
     {
-        assert(getMsg(e) == "custom message");
+        assert(e.message() == "custom message");
         assert(e.line == __LINE__ - 6);
     }
 }
@@ -120,7 +120,7 @@ unittest
     Enforces that given expression evaluates to boolean `true` after
     implicit conversion.
 
-    NB! When present 'msg' is used instead of existing 'getMsg(e)'
+    NB! When present 'msg' is used instead of existing 'e.message()'
 
     In D2 we will be able to call this via UFCS:
         exception.enforce(1 == 1);
@@ -154,7 +154,7 @@ public void enforceImpl ( T ) ( lazy Exception e, T ok, lazy istring msg,
         }
         else
         {
-            if (!getMsg(exception).length)
+            if (!exception.message().length)
             {
                 exception.msg = "enforcement has failed";
             }
@@ -201,7 +201,7 @@ unittest
     }
     catch (MyException e)
     {
-        assert(getMsg(e) == "enforcement has failed");
+        assert(e.message() == "enforcement has failed");
         assert(e.line == __LINE__ - 6);
     }
 
@@ -212,7 +212,7 @@ unittest
     }
     catch (MyException e)
     {
-        assert(getMsg(e) == "custom message");
+        assert(e.message() == "custom message");
         assert(e.line == __LINE__ - 6);
     }
 
@@ -224,7 +224,7 @@ unittest
     catch (MyException e)
     {
         // preserved from previous enforcement
-        assert(getMsg(e) == "custom message");
+        assert(e.message() == "custom message");
         assert(e.line == __LINE__ - 7);
     }
 
@@ -350,7 +350,7 @@ unittest
     }
     catch (Exception e)
     {
-        assert(getMsg(e) == "expression '2 == 3' evaluates to false");
+        assert(e.message() == "expression '2 == 3' evaluates to false");
         assert(e.line == __LINE__ - 6);
     }
 
@@ -361,7 +361,7 @@ unittest
     }
     catch (Exception e)
     {
-        assert(getMsg(e) == "expression '3 > 4' evaluates to false");
+        assert(e.message() == "expression '3 > 4' evaluates to false");
         assert(e.line == __LINE__ - 6);
     }
 
@@ -373,7 +373,7 @@ unittest
     catch (Exception e)
     {
         assert(e.line == __LINE__ - 5);
-        assert(getMsg(e) == "expression 'null !is null' evaluates to false");
+        assert(e.message() == "expression 'null !is null' evaluates to false");
     }
 
     // Check that enforce won't try to modify the exception reference
@@ -453,7 +453,7 @@ unittest
     }
     catch (MyException e)
     {
-        assert(getMsg(e) == "expression '2 == 3' evaluates to false");
+        assert(e.message() == "expression '2 == 3' evaluates to false");
         assert(e.line == __LINE__ - 6);
     }
 
@@ -465,7 +465,7 @@ unittest
     catch (MyException e)
     {
         assert(e.line == __LINE__ - 5);
-        assert(getMsg(e) == "expression '0X000000000000002B is 0X000000000000002A' evaluates to false");
+        assert(e.message() == "expression '0X000000000000002B is 0X000000000000002A' evaluates to false");
     }
 
     // call enforce() with condition "2 == 2" and verify it doesn't evaluate its
@@ -541,7 +541,7 @@ unittest
     catch (Exception e)
     {
         assert (e.next is next_e);
-        assert (getMsg(e) == "2");
+        assert (e.message() == "2");
         assert (e.next.msg == "1");
     }
 }

--- a/src/ocean/core/Exception.d
+++ b/src/ocean/core/Exception.d
@@ -270,7 +270,7 @@ unittest
     auto e = new SomeReusableException(100);
 
     e.set("message");
-    test (getMsg(e) == "message");
+    test (e.message() == "message");
     auto old_ptr = e.reused_msg[].ptr;
 
     try
@@ -279,14 +279,14 @@ unittest
         assert (false);
     }
     catch (SomeReusableException) { }
-    test (getMsg(e) == "immutable");
+    test (e.message() == "immutable");
 
     try
     {
         e.enforce(false, "longer message");
     }
     catch (SomeReusableException) { }
-    test (getMsg(e) == "longer message");
+    test (e.message() == "longer message");
     test (old_ptr is e.reused_msg[].ptr);
 
     try
@@ -294,7 +294,7 @@ unittest
         e.badName("NAME", 42);
     }
     catch (SomeReusableException) { }
-    test (getMsg(e) == "Wrong name (NAME) 0x2A 42");
+    test (e.message() == "Wrong name (NAME) 0x2A 42");
     test (old_ptr is e.reused_msg[].ptr);
 }
 
@@ -302,7 +302,7 @@ unittest
 {
     auto e = new SomeReusableException;
     e.set("aaa").fmtAppend("{0}{0}", 42);
-    test!("==")(getMsg(e), "aaa4242");
+    test!("==")(e.message(), "aaa4242");
 }
 
 version (UnitTest)
@@ -362,7 +362,7 @@ unittest
     }
     catch (CardBoardException e)
     {
-        test!("==")(getMsg(e), "Transmogrification failed"[]);
+        test!("==")(e.message(), "Transmogrification failed"[]);
         test!("==")(e.file, __FILE__[]);
         test!("==")(e.line, __LINE__ - 9);
     }

--- a/src/ocean/core/Test.d
+++ b/src/ocean/core/Test.d
@@ -94,7 +94,7 @@ unittest
     }
     catch (TestException e)
     {
-        assert(getMsg(e) == "unit test has failed");
+        assert(e.message() == "unit test has failed");
         assert(e.line == __LINE__ - 6);
     }
 
@@ -105,7 +105,7 @@ unittest
     }
     catch (TestException e)
     {
-        assert(getMsg(e) == "expression '2 == 3' evaluates to false");
+        assert(e.message() == "expression '2 == 3' evaluates to false");
         assert(e.line == __LINE__ - 6);
     }
 }
@@ -288,7 +288,7 @@ unittest
     }
     catch (TestException e)
     {
-        assert(getMsg(e) == "[name] unit test has failed");
+        assert(e.message() == "[name] unit test has failed");
     }
 
     try
@@ -298,7 +298,7 @@ unittest
     }
     catch (TestException e)
     {
-        assert(getMsg(e) == "[name] expression '2 > 3' evaluates to false");
+        assert(e.message() == "[name] expression '2 > 3' evaluates to false");
     }
 }
 
@@ -362,7 +362,7 @@ unittest
     }
     catch (TestException e)
     {
-        assert(getMsg(e) == `[struct] expression '{ a: 1, arr: "ab" } == { a: 2, arr: "cd" }' evaluates to false`);
+        assert(e.message() == `[struct] expression '{ a: 1, arr: "ab" } == { a: 2, arr: "cd" }' evaluates to false`);
     }
 }
 
@@ -379,6 +379,6 @@ unittest
     }
     catch (TestException e)
     {
-        assert(getMsg(e) == `[typedef] expression '10 == 20' evaluates to false`);
+        assert(e.message() == `[typedef] expression '10 == 20' evaluates to false`);
     }
 }

--- a/src/ocean/core/UnitTestRunner.d
+++ b/src/ocean/core/UnitTestRunner.d
@@ -479,7 +479,7 @@ private scope class UnitTestRunner
         catch (Exception e)
         {
             Stderr.formatln("{}: error: writing XML file '{}': {} [{}:{}]",
-                    this.prog, this.xml_file, getMsg(e), e.file, e.line);
+                    this.prog, this.xml_file, e.message(), e.file, e.line);
             return false;
         }
 
@@ -648,7 +648,7 @@ private scope class UnitTestRunner
             version (D_Version2)
                 e.toString((d) { err ~= d; });
             else
-                err = sformat(err, "{}:{}: test failure: {}", e.file, e.line, getMsg(e));
+                err = sformat(err, "{}:{}: test failure: {}", e.file, e.line, e.message());
             return Result.Fail;
         }
         catch (AssertException e)
@@ -656,14 +656,14 @@ private scope class UnitTestRunner
             version (D_Version2)
                 e.toString((d) { err ~= d; });
             else
-                err = sformat(err, "{}:{}: assert error: {}", e.file, e.line, getMsg(e));
+                err = sformat(err, "{}:{}: assert error: {}", e.file, e.line, e.message());
         }
         catch (SanityException e)
         {
             version (D_Version2)
                 e.toString((d) { err ~= d; });
             else
-                err = sformat(err, "{}:{}: sanity exception: {}", e.file, e.line, getMsg(e));
+                err = sformat(err, "{}:{}: sanity exception: {}", e.file, e.line, e.message());
         }
         catch (Exception e)
         {
@@ -671,7 +671,7 @@ private scope class UnitTestRunner
                 e.toString((d) { err ~= d; });
             else
                 err = sformat(err, "{}:{}: unexpected exception {}: {}",
-                              e.file, e.line, e.classinfo.name, getMsg(e));
+                              e.file, e.line, e.classinfo.name, e.message());
         }
 
         return Result.Error;

--- a/src/ocean/io/FileException.d
+++ b/src/ocean/io/FileException.d
@@ -127,7 +127,7 @@ unittest
     catch (FileException e)
     {
         test!("==")(
-            getMsg(e),
+            e.message(),
             "Bad file descriptor (failed operation on '<42>')"[]
         );
         test!("==")(e.line, check_line);

--- a/src/ocean/io/select/EpollSelectDispatcher.d
+++ b/src/ocean/io/select/EpollSelectDispatcher.d
@@ -356,7 +356,7 @@ public class EpollSelectDispatcher : IEpollSelectDispatcherInfo
             debug ( ISelectClient )
             {
                 Stderr.formatln("{} :: Error during register: '{}' @{}:{}",
-                    client, getMsg(e), e.file, e.line).flush();
+                    client, e.message(), e.file, e.line).flush();
             }
             throw e;
         }
@@ -450,7 +450,7 @@ public class EpollSelectDispatcher : IEpollSelectDispatcherInfo
             debug ( ISelectClient )
             {
                 Stderr.formatln("{} :: Error during unregister: '{}' @{}:{}",
-                    client, getMsg(e), e.file, e.line).flush();
+                    client, e.message(), e.file, e.line).flush();
             }
             throw e;
         }
@@ -543,7 +543,7 @@ public class EpollSelectDispatcher : IEpollSelectDispatcherInfo
             debug ( ISelectClient )
             {
                 Stderr.formatln("Error during changeClient: '{}' @{}:{}",
-                    getMsg(e), e.file, e.line).flush();
+                    e.message(), e.file, e.line).flush();
             }
             throw e;
         }
@@ -922,4 +922,3 @@ public class EpollSelectDispatcher : IEpollSelectDispatcherInfo
         return ms + ((us - ms * 1000) != 0);
     }
 }
-

--- a/src/ocean/io/select/client/model/ISelectClient.d
+++ b/src/ocean/io/select/client/model/ISelectClient.d
@@ -241,7 +241,7 @@ public abstract class ISelectClient : ITimeoutClient, ISelectable, ISelectClient
             // a helpful printout to notify the application programmer.
             debug Stderr.formatln(
                 "Very bad: Exception thrown from inside ISelectClient.error() delegate! -- {} ({}:{})",
-                getMsg(e), e.file, e.line
+                e.message(), e.file, e.line
             );
         }
     }

--- a/src/ocean/io/select/protocol/fiber/model/IFiberSelectProtocol.d
+++ b/src/ocean/io/select/protocol/fiber/model/IFiberSelectProtocol.d
@@ -287,7 +287,7 @@ abstract class IFiberSelectProtocol : IFiberSelectClient
             if (super.fiber.isRegistered(this))
             {
                 debug ( SelectFiber) Stderr.formatln("{}.transmitLoop: suspending fd {} fiber ({} @ {}:{})",
-                    typeof(this).stringof, this.conduit.fileHandle, getMsg(e), e.file, e.line);
+                    typeof(this).stringof, this.conduit.fileHandle, e.message(), e.file, e.line);
 
                 // Exceptions thrown by transmit() or in the case of the Error
                 // event are passed to the fiber resume() to be rethrown in
@@ -295,7 +295,7 @@ abstract class IFiberSelectProtocol : IFiberSelectClient
                 super.fiber.suspend(IOReady, e);
 
                 debug ( SelectFiber) Stderr.formatln("{}.transmitLoop: resumed fd {} fiber, rethrowing ({} @ {}:{})",
-                    typeof(this).stringof, this.conduit.fileHandle, getMsg(e), e.file, e.line);
+                    typeof(this).stringof, this.conduit.fileHandle, e.message(), e.file, e.line);
             }
 
             throw e;

--- a/src/ocean/io/select/selector/SelectedKeysHandler.d
+++ b/src/ocean/io/select/selector/SelectedKeysHandler.d
@@ -285,7 +285,7 @@ class SelectedKeysHandler: ISelectedKeysHandler
             debug (ISelectClient)
             {
                 Stderr.format("{} :: Error while finalizing client: '{}'",
-                    client, getMsg(e)).flush();
+                    client, e.message()).flush();
                 if ( e.line )
                 {
                     Stderr.format("@ {}:{}", e.file, e.line);
@@ -317,7 +317,7 @@ class SelectedKeysHandler: ISelectedKeysHandler
             // FIXME: printing on separate lines for now as a workaround for a
             // dmd bug with varargs
             Stderr.formatln("{} :: Error during handle:", client);
-            Stderr.formatln("    '{}'", getMsg(e)).flush();
+            Stderr.formatln("    '{}'", e.message()).flush();
             if ( e.line )
             {
                 Stderr.formatln("    @ {}:{}", e.file, e.line).flush();
@@ -401,12 +401,12 @@ class SelectedKeysHandler: ISelectedKeysHandler
         version (none)
         {
              Stderr.formatln("{} :: ISelectClient handle exception: '{}' @{}:{}",
-                 client, getMsg(e), e.file, e.line);
+                 client, e.message(), e.file, e.line);
         }
         else
         {
             Stderr.formatln("{} :: ISelectClient handle exception:", client);
-            Stderr.formatln("    '{}'", getMsg(e));
+            Stderr.formatln("    '{}'", e.message());
             Stderr.formatln("    @{}:{}", e.file, e.line);
         }
         Stderr.flush();

--- a/src/ocean/net/http/HttpException.d
+++ b/src/ocean/net/http/HttpException.d
@@ -118,7 +118,7 @@ class HttpException : HttpServerException
         catch (Exception)
         {
             test!("==")(e.status, HttpResponseCode.OK);
-            test!("==")(getMsg(e), "Ok Invalid resource");
+            test!("==")(e.message(), "Ok Invalid resource");
         }
 
         try
@@ -129,7 +129,7 @@ class HttpException : HttpServerException
         catch (Exception)
         {
             test!("==")(e.status, HttpResponseCode.NotFound);
-            test!("==")(getMsg(e), "Not Found Unable to locate URI path: /path/with/errors");
+            test!("==")(e.message(), "Not Found Unable to locate URI path: /path/with/errors");
         }
     }
 }

--- a/src/ocean/net/server/unix/UnixListener.d
+++ b/src/ocean/net/server/unix/UnixListener.d
@@ -156,7 +156,7 @@ public class UnixSocketListener ( CommandHandlerType ) : SelectListener!(
         catch (Exception e)
         {
             log.error("Unable to bind to or listen on \"{}\": {}",
-                      address_path, getMsg(e));
+                      address_path, e.message());
             throw e;
         }
     }

--- a/src/ocean/sys/ErrnoException.d
+++ b/src/ocean/sys/ErrnoException.d
@@ -130,7 +130,7 @@ public class ErrnoException : Exception
         }
         catch (ErrnoException e)
         {
-            test!("==")(getMsg(e),
+            test!("==")(e.message(),
                         "FUNCTION: Too many open files (extra)"[]);
             test!("==")(e.errorNumber(), EMFILE);
         }
@@ -210,7 +210,7 @@ public class ErrnoException : Exception
         }
         catch (ErrnoException e)
         {
-            test!("==")(getMsg(e), "func: Too many open files"[]);
+            test!("==")(e.message(), "func: Too many open files"[]);
             test!("==")(e.line, __LINE__ - 6);
         }
     }
@@ -257,7 +257,7 @@ public class ErrnoException : Exception
         }
         catch (ErrnoException e)
         {
-            test!("==")(getMsg(e), "func: Too many open files"[]);
+            test!("==")(e.message(), "func: Too many open files"[]);
             test!("==")(e.failedFunctionName(), "func"[]);
             test!("==")(e.line, __LINE__ - 7);
         }
@@ -291,7 +291,7 @@ public class ErrnoException : Exception
         .errno = ENOTBLK;
         auto e = new ErrnoException;
         test!("==")(
-            getMsg(e.useGlobalErrno("func").append(" str1").append(" str2")),
+            e.useGlobalErrno("func").append(" str1").append(" str2").message(),
             "func: Block device required str1 str2"[]
         );
         test!("==")(.errno, ENOTBLK);
@@ -336,7 +336,7 @@ public class ErrnoException : Exception
     {
         auto e = new ErrnoException;
         e.set(0);
-        test!("==")(getMsg(e), "Expected non-zero errno after failure"[]);
+        test!("==")(e.message(), "Expected non-zero errno after failure"[]);
     }
 
     /**************************************************************************
@@ -367,7 +367,7 @@ public class ErrnoException : Exception
     {
         auto e = new ErrnoException;
         e.set(ENOTBLK).addMessage("msg");
-        test!("==")(getMsg(e), "Block device required (msg)"[]);
+        test!("==")(e.message(), "Block device required (msg)"[]);
     }
 }
 

--- a/src/ocean/sys/Process.d
+++ b/src/ocean/sys/Process.d
@@ -1623,7 +1623,7 @@ unittest
     }
     catch (ProcessException e)
     {
-        test(false, getMsg(e));
+        test(false, e.message());
     }
 }
 

--- a/src/ocean/sys/Stats.d
+++ b/src/ocean/sys/Stats.d
@@ -170,7 +170,7 @@ public class CpuMemoryStats
         catch (Exception e)
         {
             .stats_module_logger.error("Couldn't get stats for the process: {}@{}:{}",
-                getMsg(e), e.file, e.line);
+                e.message(), e.file, e.line);
 
             return stats;
         }

--- a/src/ocean/task/Task.d
+++ b/src/ocean/task/Task.d
@@ -521,7 +521,7 @@ public abstract class Task : ISuspendable
         catch (Exception e)
         {
             debug_trace("<{}> termination (uncaught exception): {} ({}:{})",
-                cast(void*) this, getMsg(e), e.file, e.line);
+                cast(void*) this, e.message(), e.file, e.line);
             assert (Task.task_pending_cleanup is null);
             Task.task_pending_cleanup = this;
             this.fiber.yieldAndThrow(e);

--- a/src/ocean/text/Text.d
+++ b/src/ocean/text/Text.d
@@ -929,7 +929,7 @@ deprecated class Text(T) : TextView!(T)
                 return Util.jhash (cast(ubyte*) content.ptr, contentLength * T.sizeof);    }
             catch (Exception e)
             {
-                throw new Error(idup(getMsg(e)), e.file, e.line, e);
+                throw new Error(idup(e.message()), e.file, e.line, e);
             }
         }
         ");

--- a/src/ocean/text/json/JsonExtractor.d
+++ b/src/ocean/text/json/JsonExtractor.d
@@ -988,7 +988,7 @@ struct JsonExtractor
         }
         catch (JsonException e)
         {
-            t.test!("==")(getMsg(e), "type mismatch"[]);
+            t.test!("==")(e.message(), "type mismatch"[]);
         }
 
         bool fun (uint i, Type type, cstring value)

--- a/src/ocean/util/app/Application.d
+++ b/src/ocean/util/app/Application.d
@@ -299,17 +299,17 @@ class Application : IApplication
 
     protected void printExitException ( ExitException e )
     {
-        if (getMsg(e) == "")
+        if (e.message() == "")
         {
             return;
         }
         if (e.status == 0)
         {
-            Stdout.formatln("{}", getMsg(e));
+            Stdout.formatln("{}", e.message());
         }
         else
         {
-            Stderr.red.format("{}", getMsg(e)).default_colour.newline;
+            Stderr.red.format("{}", e.message()).default_colour.newline;
         }
     }
 

--- a/src/ocean/util/app/ext/ConfigExt.d
+++ b/src/ocean/util/app/ext/ConfigExt.d
@@ -305,7 +305,7 @@ class ConfigExt : IApplicationExtension, IArgumentsExtExtension
             catch (IOException e)
             {
                 app.exit(3, "Error reading config file '" ~ config_file ~
-                        "': " ~ idup(getMsg(e)));
+                        "': " ~ idup(e.message()));
             }
         }
 

--- a/src/ocean/util/config/ConfigFiller.d
+++ b/src/ocean/util/config/ConfigFiller.d
@@ -103,7 +103,7 @@
         }
         catch ( Exception e )
         {
-            Stdout.formatln("Required parameter wasn't set: {}", getMsg(e));
+            Stdout.formatln("Required parameter wasn't set: {}", e.message());
         }
     }
     -------

--- a/src/ocean/util/config/ConfigParser.d
+++ b/src/ocean/util/config/ConfigParser.d
@@ -1278,7 +1278,7 @@ bool_arr = true
     }
     catch ( IllegalArgumentException e )
     {
-        test!("==")(getMsg(e), "Config.toBool :: invalid boolean value"[]);
+        test!("==")(e.message(), "Config.toBool :: invalid boolean value"[]);
     }
 
     // Manually set a property (new category).

--- a/src/ocean/util/container/queue/FlexibleFileQueue.d
+++ b/src/ocean/util/container/queue/FlexibleFileQueue.d
@@ -333,7 +333,7 @@ public class FlexibleFileQueue : IByteQueue
             try this.ext_out.flush();
             catch (Exception e)
             {
-                log.error("## ERROR: Can't flush file buffer: {}", getMsg(e));
+                log.error("## ERROR: Can't flush file buffer: {}", e.message());
                 return null;
             }
 
@@ -368,7 +368,7 @@ public class FlexibleFileQueue : IByteQueue
         catch (Exception e)
         {
             log.error("## ERROR: Failsafe catch triggered by exception: {} ({}:{})",
-                      getMsg(e), e.file, e.line);
+                      e.message(), e.file, e.line);
         }
 
         return null;
@@ -594,7 +594,7 @@ public class FlexibleFileQueue : IByteQueue
         }
         catch (Exception e)
         {
-            log.error("## ERROR: Exception happened while writing to disk: {}", getMsg(e));
+            log.error("## ERROR: Exception happened while writing to disk: {}", e.message());
             return false;
         }
     }

--- a/src/ocean/util/container/queue/FlexibleRingQueue.d
+++ b/src/ocean/util/container/queue/FlexibleRingQueue.d
@@ -803,7 +803,7 @@ class FlexibleByteRingQueue : IRingQueue!(IByteQueue)
                 catch (ValidationError e)
                 {
                     auto msg = "Error reading record " ~ itoa(i + i) ~ "/" ~
-                        itoa(meta.items) ~ ": " ~ getMsg(e);
+                        itoa(meta.items) ~ ": " ~ e.message();
                     e.msg = assumeUnique(msg);
                     throw e;
                 }

--- a/src/ocean/util/serialize/contiguous/Deserializer.d
+++ b/src/ocean/util/serialize/contiguous/Deserializer.d
@@ -118,7 +118,7 @@ class DeserializationException : Exception
         }
         catch ( DeserializationException e )
         {
-            test(getMsg(e) == "Error deserializing 'S' : length 3 exceeds limit 2");
+            test(e.message() == "Error deserializing 'S' : length 3 exceeds limit 2");
         }
     }
 }

--- a/src/ocean/util/serialize/contiguous/MultiVersionDecorator.d
+++ b/src/ocean/util/serialize/contiguous/MultiVersionDecorator.d
@@ -780,7 +780,7 @@ Dst testConv(Src, Dst)(Src src, size_t limit = 10)
             e.classinfo.name,
             e.file,
             e.line,
-            getMsg(e)
+            e.message()
         );
         test.file = __FILE__;
         test.line = __LINE__;
@@ -838,7 +838,7 @@ Dst testConvMemory(Src, Dst)(Src src, size_t limit = 10)
                 e.classinfo.name,
                 e.file,
                 e.line,
-                getMsg(e)
+                e.message()
                 );
             test.file = __FILE__;
             test.line = __LINE__;


### PR DESCRIPTION
Nowadays, `ocean.transition : getMsg()` always resolves to `Exception.message()`,
so there is no reason to have this indirection anymore.
While we cannot yet deprecate `getMsg()` because of how widely used it is downstream,
we can start by switching ocean to not use it anymore.