### PR TITLE
Fix hasMethod trait requiring exact match

### DIFF
--- a/src/ocean/meta/traits/Aggregates.d
+++ b/src/ocean/meta/traits/Aggregates.d
@@ -80,7 +80,7 @@ public template hasMethod ( T, istring name, F )
 {
     static if (hasMember!(T, name))
     {
-        const hasMethod = is(typeof(mixin("&T.init." ~ name)) == F);
+        const hasMethod = is(typeof(mixin("&T.init." ~ name)) : F);
     }
     else
         const hasMethod = false;

--- a/src/ocean/meta/traits/Aggregates_test.d
+++ b/src/ocean/meta/traits/Aggregates_test.d
@@ -1,0 +1,15 @@
+module ocean.meta.traits.Aggregates_test;
+
+import ocean.meta.traits.Aggregates;
+
+// https://github.com/sociomantic-tsunami/ocean/issues/492
+
+struct Test(T)
+{
+    void foo ( T x ) { }
+}
+
+unittest
+{
+    static assert (hasMethod!(Test!(int), "foo", void delegate(int)));
+}


### PR DESCRIPTION
Doesn't work well with D2 and attribute inference, regression
from ocean.core.Traits

Fixes #492