### PR TITLE
Compile ocean with -debug=ISelectClient in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
         - DMD=1.081.* F=production
         - DMD=1.081.* F=devel
         - DMD=1.081.* F=production DFLAGS=-release
+        - DMD=1.081.* F=devel DFLAGS=-debug=ISelectClient
         - DMD=2.070.2.s* F=production
         - DMD=2.070.2.s* F=devel
         - DMD=2.071.2.s* F=production


### PR DESCRIPTION
Approximately every time someone needs to use debug=ISelectClient to
debug their application, they find it broken. This patch compiles Ocean
in Travis with this debug flag set.