### PR TITLE
D2: fix compilation error when Map key is a class

### DIFF
--- a/src/ocean/util/container/map/Map.d
+++ b/src/ocean/util/container/map/Map.d
@@ -1227,6 +1227,32 @@ unittest
     test!("is")(v, null);
 }
 
+unittest
+{
+    // ensure class keys work
+    class Key
+    {
+        int x;
+
+        this ( int x )
+        {
+            this.x = x;
+        }
+
+        override hash_t toHash ( )
+        {
+            return x;
+        }
+    }
+
+    auto map = new StandardKeyHashingMap!(int, Key)(5);
+    auto key = new Key(42);
+    map[key] = 24;
+    auto v = key in map;
+    test!("!is")(v, null);
+    test!("==")(*v, 24);
+}
+
 /*******************************************************************************
 
     Instantiate the bucket element allocator templates.

--- a/src/ocean/util/container/map/model/StandardHash.d
+++ b/src/ocean/util/container/map/model/StandardHash.d
@@ -80,7 +80,12 @@ struct StandardHash
                          ~ "classes/interfaces/structs/unions implementing "
                          ~ "toHash() supported, not '" ~ K.stringof ~ '\'');
 
-            return key.toHash();
+            // HACK: we don't want to start implementing all our class `toHash`
+            // methods as `const` yet, have to cast to silence druntime
+            static if (is(K == class) || is(K == interface))
+                return (cast(Unqual!(K)) key).toHash();
+            else
+                return key.toHash();
         }
     }
 


### PR DESCRIPTION
Hacky workaround for regression introduced via https://github.com/sociomantic-tsunami/ocean/commit/1787cf2f98a4896193ca85fa39a496e194c88d44

Formally it may introduce Undefined Behaviour if underlying class
instance was immutable but we know to never do that :)