### PR TITLE
Investigate suspicious behavior of specialized task pools

### DIFF
--- a/relnotes/await.bug.md
+++ b/relnotes/await.bug.md
@@ -1,0 +1,25 @@
+### Fix `await` interaction with specialized task pools
+
+Previosuly all `await` family functions used unconditional `theScheduler.queue`
+call internally which adds the task to default worker fiber pool queue.
+
+With specialized worker fiber pools, however, it would result in awaited task
+surprisingly being queued using default pool instead of specialized one for that
+task:
+
+```D
+SchedulerConfiguration config;
+with (config)
+{
+    specialized_pools = [
+        PoolDescription(Task1.classinfo.name, 10240)
+    ];
+}
+
+// ...
+
+theScheduler.await(new Task1); // NOT scheduled using Task1 dedicated pool!
+```
+
+This was fixed by enhancing Scheduler implementation to use `schedule`
+internally which results in the expected behaviour.

--- a/src/ocean/task/Scheduler.d
+++ b/src/ocean/task/Scheduler.d
@@ -404,14 +404,17 @@ final class Scheduler : IScheduler
 
         // this methods stack is guaranteed to still be valid by the time
         // task finishes, so we can reference `task` from delegate
-        task.terminationHook({ theScheduler.delayedResume(context); });
+        task.terminationHook({
+            if (context.suspended())
+                theScheduler.delayedResume(context);
+        });
+
         if (finished_dg !is null)
             task.terminationHook({ finished_dg(task); });
 
-        // force async scheduling to avoid checking if this context needs
-        // suspend/resume and do it unconditionally
-        this.queue(task);
-        context.suspend();
+        this.schedule(task);
+        if (!task.finished())
+            context.suspend();
     }
 
     ///

--- a/src/ocean/task/internal/FiberPoolEager.d
+++ b/src/ocean/task/internal/FiberPoolEager.d
@@ -63,13 +63,23 @@ public class FiberPoolEager : FiberPool
         debug_trace("running task <{}> via worker fiber <{}>",
             cast(void*) task, cast(void*) fiber);
         task.assignTo(fiber);
-        task.terminationHook({
-            auto fiber = cast(WorkerFiber) Fiber.getThis();
-            auto task = fiber.activeTask();
-            this.recycle(fiber);
-            task.fiber = null;
-        });
+        task.terminationHook(&this.recycleHook);
         task.resume();
+    }
+
+    /***************************************************************************
+
+        Used as an argument to `task.terminationHook` to recycle worker fiber
+        back to pool.
+
+    ***************************************************************************/
+
+    private void recycleHook ( )
+    {
+        auto fiber = cast(WorkerFiber) Fiber.getThis();
+        auto task = fiber.activeTask();
+        this.recycle(fiber);
+        task.fiber = null;
     }
 }
 


### PR DESCRIPTION

Test case by @daniel-zullo-sociomantic : 

```D
import ocean.io.Stdout;
import ocean.task.TaskPool;

unittest
{
    static class SubTaskB : Task
    {
        int counter;

        override void run ()
        {
            Stdout.formatln("{}: Running B", this.counter);
            .wait(20);
            Stdout.formatln("{}: Finish B", this.counter);
        }

        void copyArguments (int counter)
        {
            this.counter = counter;
        }
    }

    static class SubTaskC : Task
    {
        int counter;

        override void run ()
        {
            Stdout.formatln("{}: Running C", this.counter);
            .wait(50);
            Stdout.formatln("{}: Finish C", this.counter);
        }

        void copyArguments (int counter)
        {
            this.counter = counter;
        }
    }

    static class SubTaskA : Task
    {
        static int counter;

        override void run ()
        {
            this.counter++;

            auto task_b = new SubTaskB();
            task_b.copyArguments(this.counter);
            theScheduler.await(task_b);
            theScheduler.processEvents();

            auto task_c = new SubTaskC();
            task_b.copyArguments(this.counter);
            theScheduler.await(task_c);
            theScheduler.processEvents();

            .wait(10);
        }

        void copyArguments ()
        {
        }
    }

    static class MainTask : Task
    {
        override void run ()
        {
            // suspend once because `await` safeguards against being run
            // before the scheduler starts
            theScheduler.processEvents();

            auto pool = new TaskPool!(SubTaskA);

            const NUM_RECORDS = 100;
            for (int i = 0; i < NUM_RECORDS; i++)
            {
                pool.start();
            }
        }
    }

    SchedulerConfiguration config;
    config.task_queue_limit = 10_000;
    config.worker_fiber_limit = 100;
    config.suspended_task_limit = 200;
    with (config)
    {
        specialized_pools = [
            PoolDescription(SubTaskB.classinfo.name, 102400),
            PoolDescription(SubTaskC.classinfo.name, 102400)
        ];
    }

    initScheduler(config);

    theScheduler.schedule(new MainTask);

    theScheduler.eventLoop();
}
```