### PR TITLE
Specify exact d1to2fix version to use

### DIFF
--- a/docker/build
+++ b/docker/build
@@ -3,6 +3,7 @@ set -xeu
 
 # Install dependencies
 apt-get install -y \
+    d1to2fix=0.10.* \
     libglib2.0-dev \
     libpcre3-dev \
     libxml2-dev \


### PR DESCRIPTION
Currently used docker base image has too old d1to2fix fix version
installed which affects auto-generated +d2 tag content.