### PR TITLE
Fix closure for D2 builds

### DIFF
--- a/src/ocean/io/select/EpollSelectDispatcher.d
+++ b/src/ocean/io/select/EpollSelectDispatcher.d
@@ -402,12 +402,11 @@ public class EpollSelectDispatcher : IEpollSelectDispatcherInfo
                 {
                     /// Predicate for finding the ISelectClient inside
                     /// array of epoll_event_t entries.
-                    bool entry_to_client (Const!(epoll_event_t) entry)
-                    {
+                    scope entry_to_client = (Const!(epoll_event_t) entry) {
                         return entry.data.ptr == cast(void*)client;
-                    }
+                    };
 
-                    auto index = this.selected_set.findIf(&entry_to_client);
+                    auto index = this.selected_set.findIf(entry_to_client);
                     // Instead of removing the array entry, we'll just invalidate
                     // it. This is to avoid problems with both the fact that
                     // SelectedKeysHandler might be foreach-iterating over

--- a/src/ocean/task/util/Timer.d
+++ b/src/ocean/task/util/Timer.d
@@ -102,7 +102,7 @@ public bool awaitOrTimeout ( Task task, uint micro_seconds )
 
     auto scheduled_event = registerResumeEvent(context, micro_seconds);
     task.terminationHook(&scheduled_event.unregister);
-    auto resumer = {
+    scope resumer = {
         if (context.suspended())
             theScheduler.delayedResume(context);
     };


### PR DESCRIPTION
Using closure causes GC allocation in D2 builds.
The problem was found setting the flag -vgc for DFLAGS.