### PR TITLE
Add note about the delay in handling the signal using SignalExt

### DIFF
--- a/src/ocean/util/app/DaemonApp.d
+++ b/src/ocean/util/app/DaemonApp.d
@@ -286,6 +286,13 @@ public abstract class DaemonApp : Application,
 
             Set of signals to handle.
 
+            Note that the signals will be handled with a delay of up to
+            single epoll cycle. This is because the signal extension is synced
+            with the EpollSelectDispatcher. This makes it unsuitable to handle
+            critical signals (like `SIGABRT` or `SIGSEGV`) where the application
+            shouldn't be allowed to proceed in the general case; for these
+            cases setup an asynchronous signal handler using `sigaction` instead.
+
         ***********************************************************************/
 
         int[] signals;

--- a/src/ocean/util/app/ext/SignalExt.d
+++ b/src/ocean/util/app/ext/SignalExt.d
@@ -249,6 +249,13 @@ public class SignalExt : IApplicationExtension
         The list of signals handled may be extended after construction by
         calling the register() method.
 
+        Note that the signals will be handled with a delay of up to single
+        epoll cycle. This is because the signal extension is synced with the
+        EpollSelectDispatcher. This makes it unsuitable to handle critical
+        signals (like `SIGABRT` or `SIGSEGV`) where the application shouldn't
+        be allowed to proceed in the general case; for these cases setup an
+        asynchronous signal handler using `sigaction` instead.
+
         Params:
             signals = list of signals to handle
             ignore_signals = list of signals to ignore


### PR DESCRIPTION
DaemonApp's `SignalExt` is not asynchronous, meaning that there's a
potential delay between raising of the signal and serving of the signal,
which makes it unsuitable for serving critical signals. The
documentation is now extended to mention this.