### PR TITLE
Revert back to AppendFile in VersionArgsExt

### DIFF
--- a/relnotes/appendfile.feature.md
+++ b/relnotes/appendfile.feature.md
@@ -1,0 +1,6 @@
+### AppendFile provides reference to underlying File instance
+
+`ocean.util.log.AppendFile`
+
+`AppendFile` class now provides a reference to the underlying File instance
+(useful for reopening the file) via `file` method.

--- a/src/ocean/util/app/ext/VersionArgsExt.d
+++ b/src/ocean/util/app/ext/VersionArgsExt.d
@@ -39,7 +39,7 @@ import ocean.core.Array: startsWith, map;
 import ocean.transition;
 import ocean.core.Verify;
 import ocean.util.log.Logger;
-import ocean.util.log.Appender;
+import ocean.util.log.AppendFile;
 import ocean.util.log.LayoutDate;
 import ocean.core.Array: sort;
 
@@ -361,15 +361,14 @@ class VersionArgsExt : IApplicationExtension, IArgumentsExtExtension,
 
         if (this.default_logging)
         {
-            auto stream = new File(this.default_file, File.WriteAppending);
+            auto appender = new AppendFile(this.default_file, new LayoutDate);
 
             if ( auto reopenable_files_ext =
                 (cast(Application)app).getExtension!(ReopenableFilesExt) )
             {
-                reopenable_files_ext.register(stream);
+                reopenable_files_ext.register(appender.file());
             }
 
-            auto appender = new AppendStream(stream, true, new LayoutDate);
             this.ver_log.add(appender);
         }
     }

--- a/src/ocean/util/log/AppendFile.d
+++ b/src/ocean/util/log/AppendFile.d
@@ -40,6 +40,9 @@ class AppendFile : Filer
 {
         private Mask    mask_;
 
+        /// File to append to
+        private File    file_;
+
         /***********************************************************************
 
                 Create a basic FileAppender to a file with the specified
@@ -55,7 +58,8 @@ class AppendFile : Filer
                 // make it shareable for read
                 File.Style style = File.WriteAppending;
                 style.share = File.Share.Read;
-                configure (new File (fp, style));
+                this.file_ = new File(fp, style);
+                configure (this.file_);
                 layout (how);
         }
 
@@ -92,6 +96,18 @@ class AppendFile : Filer
             layout.format (event, &buffer.write);
             buffer.append (FileConst.NewlineString)
                   .flush;
+        }
+
+
+        /***********************************************************************
+
+                File that this appender appends to.
+
+        ***********************************************************************/
+
+        File file ()
+        {
+            return this.file_;
         }
 }
 


### PR DESCRIPTION
There's something weird with the logger hierarchy when it comes to the difference between `AppendStream` and `AppendFile` (see #511), and that change is too risky and big for the bug fix release IMHO. So, this reverts the VersionArgsExt to use AppendFile, but with keeping it registered with the `ReopenableFilesExt`.