### PR TITLE
Make UnixListener command response a delegate in a integration test

### DIFF
--- a/integrationtest/unixlistener/main.d
+++ b/integrationtest/unixlistener/main.d
@@ -270,7 +270,7 @@ int main ( )
         };
 
         // Simple echo command, non-interactive
-        scope handleEcho = ( cstring args,
+        scope handleEcho = delegate ( cstring args,
                 void delegate (cstring response) send_response)
         {
             send_response(args);


### PR DESCRIPTION
UnixListener uses delegates for the commands, and the provided command
didn't use the outer context, so it was deducted to be a function
instead. This explicitly sets it to be delegate.

Fixes #514