### PR TITLE
Implement support for awaiting already started task

### DIFF
--- a/relnotes/await.feature.md
+++ b/relnotes/await.feature.md
@@ -1,0 +1,20 @@
+### Awaiting on already running task
+
+It is now possible to write code like this:
+
+```D
+  auto sub = new SubTask;
+  // first await spawns sub task
+  bool timeout = theScheduler.awaitOrTimeout(sub, 2_000);
+  test(timeout);
+  // waits for the same sub task a bit more but also timeouts
+  timeout = theScheduler.awaitOrTimeout(sub, 2_000);
+  test(timeout);
+  // awaits unconditionally for the same sub task
+  theScheduler.await(sub);
+```
+
+Previously attempt to run `await` or `awaitOrTimeout` with already scheduled
+task would result in rather unhelpful assertion violation as this scenario was neither
+intended to work nor had a proper error message. Now such code "just works", skipping
+scheduling of awaited task if it is already running.

--- a/src/ocean/task/Scheduler.d
+++ b/src/ocean/task/Scheduler.d
@@ -379,6 +379,9 @@ final class Scheduler : IScheduler
 
         This method must not be called outside of a task.
 
+        If `task` is already scheduled, it will not be re-scheduled again but
+        awaiting will still occur.
+
         Because of how termination hooks are implemented, by the time `await`
         returns, the task object is not yet completely recycled - it will only
         happen during next context switch. Caller of `await` must either ensure
@@ -412,7 +415,9 @@ final class Scheduler : IScheduler
         if (finished_dg !is null)
             task.terminationHook({ finished_dg(task); });
 
-        this.schedule(task);
+        if (!task.suspended())
+            this.schedule(task);
+
         if (!task.finished())
             context.suspend();
     }
@@ -457,6 +462,9 @@ final class Scheduler : IScheduler
 
         Convenience shortcut on top of `await` to await for a task and return
         some value type as a result.
+
+        If `task` is already scheduled, it will not be re-scheduled again but
+        awaiting will still occur.
 
         Params:
             task = any task that defines `result` public field  of type with no
@@ -510,6 +518,9 @@ final class Scheduler : IScheduler
         Similar to `await` but also has waiting timeout. Calling task will be
         resumed either if awaited task finished or timeout is hit, whichever
         happens first.
+
+        If `task` is already scheduled, it will not be re-scheduled again but
+        awaiting will still occur.
 
         Params:
             task = task to await

--- a/src/ocean/task/Scheduler.d
+++ b/src/ocean/task/Scheduler.d
@@ -382,13 +382,6 @@ final class Scheduler : IScheduler
         If `task` is already scheduled, it will not be re-scheduled again but
         awaiting will still occur.
 
-        Because of how termination hooks are implemented, by the time `await`
-        returns, the task object is not yet completely recycled - it will only
-        happen during next context switch. Caller of `await` must either ensure
-        that the task object lives long enough for that or call
-        `theScheduler.processEvents` right after `await` to ensure immediate
-        recycle (at the performance cost of an extra context switch).
-
         Params:
             task = task to schedule and wait for
             finished_dg = optional delegate called after task finishes but

--- a/src/ocean/task/util/Timer.d
+++ b/src/ocean/task/util/Timer.d
@@ -91,6 +91,9 @@ unittest
     will be resumed either if awaited task finished or timeout is hit, whichever
     happens first.
 
+    If `task` is already scheduled, it will not be re-scheduled again but
+    awaiting will still occur.
+
     Params:
         task = task to await
         micro_seconds = timeout duration
@@ -113,7 +116,8 @@ public bool awaitOrTimeout ( Task task, uint micro_seconds )
     };
     task.terminationHook(resumer);
 
-    theScheduler.schedule(task);
+    if (!task.suspended())
+        theScheduler.schedule(task);
 
     // suspend if not finished immediately
     if (!task.finished())

--- a/src/ocean/task/util/Timer_test.d
+++ b/src/ocean/task/util/Timer_test.d
@@ -120,7 +120,7 @@ unittest
 
         override public void run ( )
         {
-            bool timeout = .awaitOrTimeout(this.to_wait_for, 5000);
+            bool timeout = .awaitOrTimeout(this.to_wait_for, 1_000_000);
             test(!timeout);
             test(this.to_wait_for.finished());
         }


### PR DESCRIPTION
@matthias-wende-sociomantic this should make your original example "just work". If you don't want to wait for the next ocean release, the following function can be used for emulating same behavior:

```D
void myAwait ( Task task )
{
    auto context = Task.getThis();
    task.terminationHook({
            if (context.suspended())
                theScheduler.delayedResume(context);
    });
    if (!task.finished())
            context.suspend();
}
```