### PR TITLE
Scheduler: Remove redundant assertion

### DIFF
--- a/src/ocean/task/Scheduler.d
+++ b/src/ocean/task/Scheduler.d
@@ -392,8 +392,6 @@ final class Scheduler : IScheduler
 
     public void await ( Task task, void delegate (Task) finished_dg = null )
     {
-        assert (Task.getThis() !is null);
-
         auto context = Task.getThis();
         assert (context !is null);
         assert (context !is task);


### PR DESCRIPTION
The current task is checked for nullity twice.