### PR TITLE
Don't schedule the timer interval to that very moment

### DIFF
--- a/relnotes/timer.migration.md
+++ b/relnotes/timer.migration.md
@@ -1,0 +1,8 @@
+### onStatsTimer will never trigger after zero seconds
+
+`ocean.util.app.DaemonApp`
+
+Previously, to align the stats on 0/30s mark, `onStatsTimer` could fire
+as soon as `startEventlHandling` is called. Ocean now delayes the first
+onStatsTimer call, meaning that it will be called in `[1, interval]`, instead
+of `[0, interval)` range.

--- a/src/ocean/util/app/DaemonApp.d
+++ b/src/ocean/util/app/DaemonApp.d
@@ -507,7 +507,7 @@ public abstract class DaemonApp : Application,
 
     private static ulong timeToNextInterval (ulong interval, time_t current = time(null))
     {
-        return (current % interval) ? (interval - (current % interval)) : 0;
+        return (current % interval) ? (interval - (current % interval)) : interval;
     }
 
     unittest
@@ -517,7 +517,7 @@ public abstract class DaemonApp : Application,
         test!("==")(timeToNextInterval(20, orig), 6);
         test!("==")(timeToNextInterval(30, orig), 16);
         test!("==")(timeToNextInterval(60, orig), 46);
-        test!("==")(timeToNextInterval(15, orig + 1), 0);
+        test!("==")(timeToNextInterval(15, orig + 1), 15);
     }
 
     /***************************************************************************


### PR DESCRIPTION
Due to the application's misdesign, it might happen
that not all resources that are used in `onStatsTimer` are
initialized at the point when the `startEventHandling` is
called. This leads then to the issue when the Application
starts at the time which would be the aligned time point
and there's no wait between next onStatsTimer call.

This ensures that there's at least one second of the
delay between onStatsTimer and startEventHandling.