### PR TITLE
Always set the date in the HTTP response header

### DIFF
--- a/src/ocean/net/http/HttpResponse.d
+++ b/src/ocean/net/http/HttpResponse.d
@@ -310,8 +310,7 @@ class HttpResponse : HttpHeader
 
     /**************************************************************************
 
-        Sets the Date message header to the current wall clock time if it is not
-        already set.
+        Sets the Date message header to the current wall clock time.
 
      **************************************************************************/
 
@@ -319,10 +318,7 @@ class HttpResponse : HttpHeader
     {
         super.access(HeaderFieldNames.General.Names.Date, (cstring, ref cstring val)
         {
-            if (!val)
-            {
-                val = this.time.format();
-            }
+            val = this.time.format();
         });
     }
 


### PR DESCRIPTION
If this is not done, then only the first HTTP response will have the
correct date and time. All subsequent responses will just reuse the
value in that first response.