### PR TITLE
Extract the Unix socket command system from the application

### DIFF
--- a/relnotes/unixcommand.feature.md
+++ b/relnotes/unixcommand.feature.md
@@ -1,0 +1,7 @@
+### Extract the Unix socket command system from the application
+
+The only convenient way to use the Unix domain socket as a control point was
+through the `UnixSocketExt`, which was limiting this to a single socket per
+application. Now the `UnixSocketExt` is only instantiating and configuring the
+instance of `UnixSocketListener` and `ComandsRegistry`, which can also be
+instantiated and configured manually as many times as needed.

--- a/relnotes/unixlistenmode.feature.md
+++ b/relnotes/unixlistenmode.feature.md
@@ -1,0 +1,9 @@
+### Pass the desired file mode to UnixSocketListener
+
+* `ocean.net.server.UnixListener`
+
+Constructors of `UnixListener` and `UnixSocketListener` now accept
+the optional `mode` parameter with the mode to apply on the socket
+after creation, if needed. Normally the socket will be created
+with 002 umask (so it will default to rw-rw-r-- which should be
+enough for everybody), but that can now be overriden.

--- a/relnotes/unixsockethandler.deprecation.md
+++ b/relnotes/unixsockethandler.deprecation.md
@@ -1,0 +1,5 @@
+### Deprecate UnixSocketExt.add/removeInteractiveHandler
+
+There's no need to separate addHandler/removeHandler for
+different types of handlers, instead overloads of `addHandler`/
+`removeHandler` should be used.

--- a/src/ocean/net/server/unix/CommandRegistry.d
+++ b/src/ocean/net/server/unix/CommandRegistry.d
@@ -1,0 +1,135 @@
+/*******************************************************************************
+
+    Utility for handling requests via a unix socket.
+
+    Commands can be registered to the registry and when the command is received
+    the provided delegate will be called. Any provided arguments will be split
+    by the space character and provided as an array.
+
+    Copyright:
+        Copyright (c) 2009-2018 Sociomantic Labs GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+        Alternatively, this file may be distributed under the terms of the Tango
+        3-Clause BSD License (see LICENSE_BSD.txt for details).
+
+*******************************************************************************/
+
+module ocean.net.server.unix.CommandRegistry;
+
+import ocean.transition;
+
+/// ditto
+public class CommandsRegistry
+{
+    import ocean.core.array.Mutation: filterInPlace;
+    import ocean.core.array.Transformation: split;
+    import ocean.core.Buffer;
+    import ocean.core.Enforce;
+    import ocean.core.Verify;
+    import ocean.text.convert.Integer;
+
+    /// Alias for our interactive handler delegate.
+    public alias void delegate ( cstring[],
+            void delegate (cstring),
+            void delegate (ref mstring) ) InteractiveHandler;
+
+    /// Alias for our non-interactive handler delegate.
+    public alias void delegate ( cstring[],
+            void delegate (cstring) ) Handler;
+
+    /// Our registered map of interactive handlers by command.
+    private InteractiveHandler[istring] interactive_handlers;
+
+    /// Our registered map of handlers by command.
+    private Handler[istring] handlers;
+
+    /// Stores the command arguments split by " ";
+    private cstring[] args_buf;
+
+    /***************************************************************************
+
+        Receives all commands from the socket and splits the command by " ".
+        If a matching command is registered then the command will be called with
+        the remaining arguments. This method will be called by the
+        UnixSocketListener whenever a command is received.
+
+        Params:
+            command = The command received by the unix socket.
+            args = The arguments provided with the command.
+            send_response = Delegate to call with response string.
+            wait_reply = Delegate to call to obtain the reply from the user
+
+    ***************************************************************************/
+
+    public void handle ( cstring command, cstring args,
+                 void delegate (cstring) send_response,
+                 void delegate (ref mstring buf) wait_reply )
+    {
+        if (auto handler = command in this.interactive_handlers)
+        {
+            split(args, " ", this.args_buf);
+            scope predicate = (cstring v) { return !v.length; };
+            auto arguments = this.args_buf[0..filterInPlace(this.args_buf[], predicate)];
+            (*handler)(arguments, send_response, wait_reply);
+        }
+        else if (auto handler = command in this.handlers)
+        {
+            split(args, " ", this.args_buf);
+            scope predicate = (cstring v) { return !v.length; };
+            auto arguments = this.args_buf[0..filterInPlace(this.args_buf[], predicate)];
+            (*handler)(arguments, send_response);
+        }
+        else
+        {
+            send_response("Command not found\n");
+        }
+    }
+
+    /***************************************************************************
+
+        Register a command and interactive handler to the unix listener.
+
+        Params:
+            command = The command to listen for in the socket listener.
+            handler = The interactive handler to call when command is received.
+
+    ***************************************************************************/
+
+    public void addHandler ( istring command,
+        InteractiveHandler handler )
+    {
+        this.interactive_handlers[command] = handler;
+    }
+
+    /***************************************************************************
+
+        Register a command and a handler the registry.
+
+        Params:
+            command = The command name
+            handler = The handler to call when command is received.
+
+    ***************************************************************************/
+
+    public void addHandler ( istring command, Handler handler )
+    {
+        this.handlers[command] = handler;
+    }
+
+    /***************************************************************************
+
+        Register a command and handler to the unix listener.
+
+        Params:
+            command = The command name of the command to remove from the registry
+
+    ***************************************************************************/
+
+    public void removeHandler ( istring command )
+    {
+        this.handlers.remove(command);
+    }
+}

--- a/src/ocean/net/server/unix/UnixConnectionHandler.d
+++ b/src/ocean/net/server/unix/UnixConnectionHandler.d
@@ -184,7 +184,7 @@ public class UnixConnectionHandler : UnixSocketConnectionHandler!(BasicCommandHa
 
     public this ( FinalizeDg finalize_dg, EpollSelectDispatcher epoll,
                   BasicCommandHandler.Handler[istring] handlers,
-                  istring address_path )
+                  cstring address_path )
     {
         super(finalize_dg, epoll, new BasicCommandHandler(handlers),
             address_path);
@@ -251,7 +251,7 @@ public class UnixSocketConnectionHandler ( CommandHandlerType ) : IFiberConnecti
 
     ***************************************************************************/
 
-    private istring address_path;
+    private cstring address_path;
 
     /***************************************************************************
 
@@ -278,7 +278,7 @@ public class UnixSocketConnectionHandler ( CommandHandlerType ) : IFiberConnecti
     ***************************************************************************/
 
     public this ( FinalizeDg finalize_dg, EpollSelectDispatcher epoll,
-                  CommandHandlerType handler, istring address_path )
+                  CommandHandlerType handler, cstring address_path )
     {
         super(epoll, new UnixSocket, finalize_dg);
         auto e = new SocketError(this.socket);

--- a/src/ocean/net/server/unix/UnixListener.d
+++ b/src/ocean/net/server/unix/UnixListener.d
@@ -48,7 +48,7 @@ public class UnixListener : UnixSocketListener!( BasicCommandHandler )
 
     ***********************************************************************/
 
-    public this ( istring address_path, EpollSelectDispatcher epoll,
+    public this ( cstring address_path, EpollSelectDispatcher epoll,
                   BasicCommandHandler.Handler[istring] handlers )
     {
         this.handler = new BasicCommandHandler(handlers);
@@ -100,12 +100,13 @@ public class UnixListener : UnixSocketListener!( BasicCommandHandler )
 public class UnixSocketListener ( CommandHandlerType ) : SelectListener!(
     UnixSocketConnectionHandler!(CommandHandlerType), EpollSelectDispatcher,
     CommandHandlerType,
-    istring // address_path
+    cstring // address_path
 )
 {
     import ocean.sys.socket.UnixSocket;
     import ocean.stdc.posix.sys.un: sockaddr_un;
     import ocean.stdc.posix.sys.socket: AF_UNIX, sockaddr;
+    import ocean.text.convert.Formatter;
 
     import core.sys.posix.unistd: unlink;
     import core.stdc.errno: errno;
@@ -124,7 +125,7 @@ public class UnixSocketListener ( CommandHandlerType ) : SelectListener!(
 
     ***************************************************************************/
 
-    private istring address_pathnul;
+    private char[sockaddr_un.sun_path.length] address_pathnul;
 
     /***************************************************************************
 
@@ -148,13 +149,13 @@ public class UnixSocketListener ( CommandHandlerType ) : SelectListener!(
 
     ***************************************************************************/
 
-    public this ( istring address_path, EpollSelectDispatcher epoll,
+    public this ( cstring address_path, EpollSelectDispatcher epoll,
                   CommandHandlerType handler )
     {
         enforce(address_path.length < sockaddr_un.sun_path.length,
-                "Unix socket path too long: " ~ address_path);
+                format("Unix socket path too long: {}", address_path));
 
-        this.address_pathnul = address_path ~ '\0';
+        snformat(this.address_pathnul, "{}\0", address_path);
 
         auto log = Log.lookup("ocean.net.server.unixsocket");
 

--- a/src/ocean/util/app/ext/UnixSocketExt.d
+++ b/src/ocean/util/app/ext/UnixSocketExt.d
@@ -92,14 +92,7 @@ public class UnixSocketExt : IApplicationExtension, IConfigExtExtension
         if ( this.path.length > 0 )
         {
             this.unix_listener =
-                new UnixSocketListener!(UnixSocketExt)(this.path, epoll, this);
-
-            if (this.mode >= 0)
-            {
-                auto mpath = this.path.dup;
-                enforce(chmod(StringC.toCString(mpath), this.mode) == 0,
-                        "Couldn't change UnixSocket mode.");
-            }
+                new UnixSocketListener!(UnixSocketExt)(this.path, epoll, this, this.mode);
 
             epoll.register(this.unix_listener);
         }

--- a/src/ocean/util/app/ext/UnixSocketExt.d
+++ b/src/ocean/util/app/ext/UnixSocketExt.d
@@ -121,6 +121,7 @@ public class UnixSocketExt : IApplicationExtension, IConfigExtExtension
 
     ***************************************************************************/
 
+    deprecated ("Use the appropriate overload of UnixSocketExt.addHandler.")
     public void addInteractiveHandler ( istring command, InteractiveHandler handler )
     {
         this.commands.addHandler(command, handler);
@@ -141,6 +142,19 @@ public class UnixSocketExt : IApplicationExtension, IConfigExtExtension
 
     /***************************************************************************
 
+        Params:
+            command = The command to listen for in the socket listener.
+            handler = The handler to call when command is received.
+
+    ***************************************************************************/
+
+    public void addHandler ( istring command, InteractiveHandler handler )
+    {
+        this.commands.addHandler(command, handler);
+    }
+
+    /***************************************************************************
+
         Unregister a command and handler from the unix listener.
 
         Params:
@@ -148,6 +162,7 @@ public class UnixSocketExt : IApplicationExtension, IConfigExtExtension
 
     ***************************************************************************/
 
+    deprecated ("Use UnixSocketExt.removeHandler instead.")
     public void removeInteractiveHandler ( istring command )
     {
         this.commands.removeHandler(command);
@@ -276,7 +291,7 @@ unittest
         override public int run ( Arguments args, ConfigParser config )
         {
             this.startEventHandling(new EpollSelectDispatcher);
-            this.unix_socket_ext.addInteractiveHandler("test", &this.test);
+            this.unix_socket_ext.addHandler("test", &this.test);
 
             return 0;
         }


### PR DESCRIPTION
The only convenient way to use the Unix domain socket as a control point
was through the `UnixSocketExt`, which was limiting this to a single
socket per application. Now the `UnixSocketExt` is only instantiating and
configuring the instance of `UnixSocketControlInterface`, which can
also be instantiated and configured manually as many times as needed.