### PR TITLE
 Support Unix socket handlers that accept the socket instance 

### DIFF
--- a/relnotes/unixextraw.feature.md
+++ b/relnotes/unixextraw.feature.md
@@ -1,0 +1,5 @@
+### Support registering handlers that accept unix socket in UnixSocketExt
+
+`UnixSocketExt` now provides an interface for the user to register the
+unix socket command handlers which receive both read/write delegates and
+the "raw" instance of the socket.

--- a/relnotes/unixraw.feature.md
+++ b/relnotes/unixraw.feature.md
@@ -1,0 +1,7 @@
+### Allow "raw" handlers for UnixSocketListener
+
+* `ocean.net.server.unix.UnixConnectionHandler`
+
+Unix connection handler now accept handler delegates which accept unix socket
+device instance (and not just read/write delegates). this allows for more
+advanced controls that require a file descriptor of the unix socket.

--- a/src/ocean/net/server/unix/UnixConnectionHandler.d
+++ b/src/ocean/net/server/unix/UnixConnectionHandler.d
@@ -58,6 +58,7 @@ import ocean.io.select.protocol.generic.ErrnoIOException : SocketError;
 import ocean.util.log.Logger;
 import ocean.text.util.SplitIterator: ChrSplitIterator;
 import ocean.core.array.Mutation : copy;
+import ocean.meta.types.Function;
 
 /// Provides basic command handling functionality for unix socket commands.
 public class BasicCommandHandler
@@ -406,8 +407,12 @@ public class UnixSocketConnectionHandler ( CommandHandlerType ) : IFiberConnecti
 
         cstring cmd = split_cmd.trim(split_cmd.next());
 
-        this.handler.handle(cmd, split_cmd.remaining, &this.sendResponse,
-                &this.waitReply);
+        static if (ParametersOf!(typeof(this.handler.handle)).length == 4)
+            this.handler.handle(cmd, split_cmd.remaining, &this.sendResponse,
+                    &this.waitReply);
+        else
+            this.handler.handle(cmd, split_cmd.remaining, &this.sendResponse,
+                    &this.waitReply, this.socket);
     }
 
     /***************************************************************************

--- a/src/ocean/util/app/ext/UnixSocketExt.d
+++ b/src/ocean/util/app/ext/UnixSocketExt.d
@@ -58,6 +58,9 @@ public class UnixSocketExt : IApplicationExtension, IConfigExtExtension
     /// Interactive handler delegate
     public alias CommandsRegistry.InteractiveHandler InteractiveHandler;
 
+    /// RawSocketHandler delegate
+    public alias CommandsRegistry.RawSocketHandler RawSocketHandler;
+
     /// Unix listener with dynamic command handling.
     private UnixSocketListener!(CommandsRegistry) unix_listener;
 
@@ -149,6 +152,21 @@ public class UnixSocketExt : IApplicationExtension, IConfigExtExtension
     ***************************************************************************/
 
     public void addHandler ( istring command, InteractiveHandler handler )
+    {
+        this.commands.addHandler(command, handler);
+    }
+
+    /***************************************************************************
+
+        Register a command and raw handler to the unix listener.
+
+        Params:
+            command = The command to listen for in the socket listener.
+            handler = The handler to call when command is received.
+
+    ***************************************************************************/
+
+    public void addHandler ( istring command, RawSocketHandler handler )
     {
         this.commands.addHandler(command, handler);
     }


### PR DESCRIPTION
`UnixConnectionHandler` and `UnixSocketExt` now accept handler delegates which accept unix socket
device instance (and not just read/write delegates). this allows for more
advanced controls that require a file descriptor of the unix socket.

Blocked on #534 