### PR TITLE
Disconnect AppStatus from Stdout and allow writing to unix domain socket

### DIFF
--- a/relnotes/appstatus.feature.md
+++ b/relnotes/appstatus.feature.md
@@ -1,0 +1,8 @@
+### Allow changing of the output streams for AppStatus
+
+* `ocean.io.console.AppStatus`, `ocean.util.log.InsertConsole`
+
+  `AppStatus` and `InsertConsole` now support connecting and disconnecting
+  to/from the output streams at runtime, decoupling them from the Stdout. This
+  allows for connecting various output devices, such as unix domain sockets at
+  runtime.

--- a/relnotes/appstatussocket.feature.md
+++ b/relnotes/appstatussocket.feature.md
@@ -1,0 +1,8 @@
+### Add UnixSocketExt handler to display the AppStatus to socket
+
+* `ocean.io.console.AppStatus`
+
+  `AppStatus` now allows program to register the AppStatus instance
+  with the Unix domain socket's handler and print the app status there
+  until the socket is connected. The usage example is as simple as
+  `this.unix_socket_ext.addHandler("show_status", &this.app_status.connectedSocketHandler)`

--- a/relnotes/filefd.feature.md
+++ b/relnotes/filefd.feature.md
@@ -1,0 +1,10 @@
+### Wrap already open file descriptor in File instance
+
+* `ocean.io.device.File`
+
+  `File` class implements all ocean's IO interfaces, so it's
+  very convenient to wrap a file descriptor of previously
+  opened device into `File` instance for easy composition
+  in the rest of the IO framework. `File` class now implements
+  `setFileHandle` method which allows user to wrap the
+  `File` around it.

--- a/src/ocean/io/device/File.d
+++ b/src/ocean/io/device/File.d
@@ -573,6 +573,21 @@ class File : Device, Device.Seek, Device.Truncate
 
         /***********************************************************************
 
+            Wraps the already open file descriptor into a File instance.
+
+            Params:
+                fd = file descriptor to wrap the file around
+
+        ***********************************************************************/
+
+        void setFileHandle ( int fd )
+        {
+            verify (fd > 0);
+            this.handle = fd;
+        }
+
+        /***********************************************************************
+
             Set the file size to be that of the current seek position.
             The file must be writable for this to succeed.
 

--- a/src/ocean/util/log/InsertConsole.d
+++ b/src/ocean/util/log/InsertConsole.d
@@ -79,12 +79,26 @@ public class InsertConsole: Appender
         verify (stream !is null);
 
         mask_ = register(name ~ stream.classinfo.name);
-        stream_ = stream;
+        this.connectOutput(stream);
         flush_ = flush;
         layout(how);
 
         this.buffer = new char[Terminal.columns];
         this.buffer[] = '\0';
+    }
+
+    /***********************************************************************
+
+        Sets the output stream to the different stream.
+
+        Params:
+            output = stream to output to.
+
+    ***********************************************************************/
+
+    void connectOutput ( OutputStream stream )
+    {
+        this.stream_ = stream;
     }
 
     /***********************************************************************


### PR DESCRIPTION
`DaemonApp` now allows program to register the AppStatus instance
to which unix domain socket will be connected when `show_appstatus`
command is issued via `registerAppStatus` command.

Blocked on #538 