### PR TITLE
Do not enable SIGTERM unconditionally

### DIFF
--- a/relnotes/signal.migration.md
+++ b/relnotes/signal.migration.md
@@ -1,0 +1,10 @@
+### DaemonApp doesn't append SIGTERM to signal list
+
+Previously `DaemonApp` would append `SIGTERM` to handled signal
+list even if there is already an app-defined one. It was a bug - automatic
+handling of `SIGTERM` was only intended to happen if there is no custom
+signal handling defined in derived application.
+
+Starting with 5.0.0 `DaemonApp` will behave as originally intended - if your
+application was relying on old behaviour, make sure to add `SIGTERM` to signal
+list explicitly now.

--- a/src/ocean/util/app/DaemonApp.d
+++ b/src/ocean/util/app/DaemonApp.d
@@ -368,8 +368,10 @@ public abstract class DaemonApp : Application,
     {
         super(name, desc);
 
-        // DaemonApp always handles SIGTERM:
-        settings.signals ~= core.sys.posix.signal.SIGTERM;
+        // If derived app does not handle signals explicitly, default
+        // DaemonApp handler will be used which handles SIGTERM
+        if (settings.signals.length == 0)
+            settings.signals = [ core.sys.posix.signal.SIGTERM ];
 
         // Create and register arguments extension
         this.args_ext = new ArgumentsExt(name, desc, settings.usage,


### PR DESCRIPTION
Original logic was flawed - if derived application overrides
`onSignal` it may decide to not handle `SIGTERM` there. Thus it is
only necessary to add it to default signals if no custom ones are
defined.

See also https://github.com/sociomantic-tsunami/ocean/issues/542