### PR TITLE
Fix eraseStaticLines() if the terminal output is null

### DIFF
--- a/src/ocean/io/console/AppStatus.d
+++ b/src/ocean/io/console/AppStatus.d
@@ -480,6 +480,11 @@ public class AppStatus
 
     public void eraseStaticLines ( )
     {
+        if (this.terminal_output is null)
+        {
+            return;
+        }
+
         // Add +2: One for header and one for footer
         for (size_t i = 0; i < this.static_lines.length + 2; i++)
         {


### PR DESCRIPTION
If the terminal output is initialized to null in the AppStatus
constructor, then a program will segfault if the `eraseStaticLines()`
is called.