### PR TITLE
Fix multiple shutdown attempt corrupting state

### DIFF
--- a/src/ocean/task/Scheduler.d
+++ b/src/ocean/task/Scheduler.d
@@ -260,6 +260,10 @@ final class Scheduler : IScheduler
 
     public void shutdown ( )
     {
+        // no-op if already shutting down
+        if (this.state == State.Shutdown)
+            return;
+
         debug_trace(
             "Shutting down initiated. {} queued tasks will be " ~
                 " discarded, {} suspended tasks will be killed",


### PR DESCRIPTION
`shutdown` is expected to be called only once, which will result in all
tasks being killed eventually. Calling it again does not serve any extra
purpose but can mess with internal task queue states.