### PR TITLE
Refactor public methods to avoid in contract

### DIFF
--- a/src/ocean/core/array/Mutation.d
+++ b/src/ocean/core/array/Mutation.d
@@ -29,6 +29,7 @@ import core.stdc.math; // fabs;
 import ocean.core.Traits;
 import ocean.core.Buffer;
 import ocean.core.array.DefaultPredicates;
+import ocean.core.Verify;
 
 version (UnitTest)
 {
@@ -1140,13 +1141,11 @@ unittest
 
 public T[] removeShift ( T ) ( ref Buffer!(T) buffer, size_t index,
     size_t remove_elems = 1 )
-in
 {
-    assert(index < buffer.length, "removeShift: index is >= buffer length");
-    assert(index + remove_elems - 1 < buffer.length, "removeShift: end is >= buffer length");
-}
-body
-{
+    verify(index < buffer.length, "removeShift: index is >= buffer length");
+    verify(index + remove_elems - 1 < buffer.length,
+        "removeShift: end is >= buffer length");
+
     if ( remove_elems == 0 )
         return buffer[];
 
@@ -1209,12 +1208,9 @@ unittest
 
 public T[] insertShift ( T ) ( ref Buffer!(T) buffer, size_t index,
     size_t insert_elems = 1)
-in
 {
-    assert(index <= buffer.length, "insertShift: index is > buffer length");
-}
-body
-{
+    verify(index <= buffer.length, "insertShift: index is > buffer length");
+
     if ( insert_elems == 0 )
         return buffer[];
 
@@ -1814,13 +1810,10 @@ unittest
  ******************************************************************************/
 
 public T[] clear ( T ) ( T[] array )
-in
 {
-    assert(isClearable!(T), T.stringof ~ ".init contains a non-zero byte so " ~
-           (T[]).stringof ~ " cannot be simply cleared");
-}
-body
-{
+    verify(isClearable!(T), T.stringof ~ ".init contains a non-zero byte so " ~
+        (T[]).stringof ~ " cannot be simply cleared");
+
     memset(array.ptr, 0, array.length * array[0].sizeof);
 
     return array;

--- a/src/ocean/core/array/Search.d
+++ b/src/ocean/core/array/Search.d
@@ -30,6 +30,7 @@ import ocean.stdc.posix.sys.types; // ssize_t;
 import ocean.core.Traits;
 import ocean.core.Buffer;
 import ocean.core.array.DefaultPredicates;
+import ocean.core.Verify;
 
 version (UnitTest)
 {
@@ -1152,12 +1153,6 @@ unittest
 *******************************************************************************/
 
 public bool bsearchCustom ( size_t array_length, ssize_t delegate ( size_t i ) cmp, out size_t position )
-in
-{
-    assert (cast (ssize_t) array_length >= 0,
-            "bsearchCustom: array_length integer overflow (maximum is " ~
-            ssize_t.stringof ~ ".max = " ~ ssize_t.max.stringof ~ ')');
-}
 out (found)
 {
     if (found)
@@ -1171,6 +1166,10 @@ out (found)
 }
 body
 {
+    verify(cast (ssize_t) array_length >= 0,
+        "bsearchCustom: array_length integer overflow (maximum is " ~
+        ssize_t.stringof ~ ".max = " ~ ssize_t.max.stringof ~ ')');
+
     if ( array_length == 0 )
     {
         return false;

--- a/src/ocean/task/IScheduler.d
+++ b/src/ocean/task/IScheduler.d
@@ -307,12 +307,9 @@ public interface IScheduler
 *******************************************************************************/
 
 public IScheduler theScheduler ( )
-in
 {
     assert(_scheduler !is null, "Scheduler is null, initScheduler must be called before using it");
-}
-body
-{
+
     return _scheduler;
 }
 

--- a/src/ocean/task/Scheduler.d
+++ b/src/ocean/task/Scheduler.d
@@ -868,12 +868,9 @@ unittest
 *******************************************************************************/
 
 public Scheduler theScheduler ( )
-in
 {
     assert(_scheduler !is null, "Scheduler is null, initScheduler must be called before using it");
-}
-body
-{
+
     return _scheduler;
 }
 


### PR DESCRIPTION
`in` contracts containing asserts should only be used on private
methods which are called via a public API including verify/enforce
checks as they will be completely removed from the program when
compiled in `-release` mode.

All checks in `in` contracts have been converted to verify statements
in the method body.