### PR TITLE
Fix segfault in AppStatus.num_static_lines when terminal_output is null

### DIFF
--- a/src/ocean/io/console/AppStatus.d
+++ b/src/ocean/io/console/AppStatus.d
@@ -530,7 +530,7 @@ public class AppStatus
     {
         this.resetStaticLines();
 
-        if ( this.is_redirected )
+        if ( this.is_redirected || this.terminal_output is null )
         {
             this.static_lines.length = size;
 


### PR DESCRIPTION
AppStatus.terminal_output could be null.
num_static_lines() needs the same check that displayStaticLines() has, to avoid a segfault.

This is important because when writing to a socket instead of the console, it is common for terminal_output to be null.