### PR TITLE
`json.JsonEscape.unescape` throws non-reusable exceptions

### DIFF
--- a/src/ocean/text/json/JsonEscape.d
+++ b/src/ocean/text/json/JsonEscape.d
@@ -196,7 +196,7 @@ void unescape(T, TC) (T[] src, void delegate(TC[]) emit)
                            break;
 
                       default:
-                           throw new Exception ("invalid escape");
+                           throw invalid_escape;
                      }
 
               s += 2;
@@ -267,4 +267,11 @@ void escape(T, TC) (T[] src, void delegate(TC[]) emit)
             emit (src);
         else
            emit (t [0 .. e - t]);
+}
+
+private Exception invalid_escape;
+
+static this ( )
+{
+    invalid_escape = new Exception ("invalid escape");
 }


### PR DESCRIPTION
If `ocean.text.json.JsonEscape.unescape` encounters an invalid escape character, it executes `throw new Exception ("invalid escape");`. As this exception doesn't contain any information, it's rather useless. When parsing text with a large number of invalid escape characters it causes unnecessary pressure on the garbage collector.

Perhaps it should be using a `ReusableException` but since it doesn't actually contain any information it might not even need that.

Apart from the memory leak, I have doubts about the general approach. That's maybe a different issue but I discuss it below.

- - -

It's not clear to me that throwing an exception is desirable behaviour.

There are not actually many circumstances where a string has invalid escapes but is otherwise valid JSON. I've only seen it in two cases:
(a) Simple mistake. `\` was used where `/` was intended.
(b) Currency symbol that wasn't correctly converted to UTF-8. In many character sets in South Korea, `\` is displayed as the currency Won (₩), and in Japan it is displayed as `¥` In such cases it will be followed by one or more digits, possibly preceded by a space.

There's a third case, which I have not personally seen:
(c) Programmer has used an incorrect escape function. Eg `\v` is a valid C escape but it is not a valid JSON escape.

It will often be desirable to treat invalid escapes as simply being a `\\` -- this is exactly what was intended in the first case, and isn't unreasonable in the second case. But the current behaviour isn't flexible enough to allow that.
