### PR TITLE
Validation of overridden config value 

### DIFF
--- a/relnotes/cli_override.migration.md
+++ b/relnotes/cli_override.migration.md
@@ -1,0 +1,10 @@
+### Trying to override non-existent config value will error
+
+`ocean.util.app.ext.ConfigExt`
+
+Previously ocean application framework would allow to specify config override
+via command-line flag even for non-existent config values. This was reported
+as confusing as there is nothing to "override" in such case.
+
+Starting with this ocean release such attempt will result in an error and any
+scripts doing it by accident should be adjusted.


### PR DESCRIPTION
It is possible to override a config value which doesn't exist in the config file, e.g. 

`./myapp -O non.existent=value`

Is this intended behavior or should it perhaps be handled in [ConfigExt.validateArgs()](https://github.com/sociomantic-tsunami/ocean/blob/53aa6a8970366c4d7d23e362b026540825bc6488/src/ocean/util/app/ext/ConfigExt.d#L241)?