### PR TITLE
Add thread workers support to ocean

### DIFF
--- a/integrationtest/asyncio/main.d
+++ b/integrationtest/asyncio/main.d
@@ -1,0 +1,134 @@
+/*******************************************************************************
+
+    Test for AsyncIO.
+
+    Copyright:
+        Copyright (c) 2018 dunnhumby Germany GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+        Alternatively, this file may be distributed under the terms of the Tango
+        3-Clause BSD License (see LICENSE_BSD.txt for details).
+
+*******************************************************************************/
+
+module integrationtest.asyncio.main;
+
+import ocean.transition;
+
+import core.sys.posix.sys.stat;
+import core.sys.posix.pthread;
+import ocean.core.Test;
+import ocean.sys.ErrnoException;
+import ocean.util.app.DaemonApp;
+import ocean.task.Scheduler;
+import ocean.task.Task;
+import ocean.util.aio.AsyncIO;
+import ocean.io.device.File;
+import ocean.util.test.DirectorySandbox;
+
+extern(C) int pthread_getattr_np(pthread_t thread, pthread_attr_t* attr);
+
+class AsyncIOUsingApp: DaemonApp
+{
+    AsyncIO async_io;
+
+    this ( )
+    {
+
+        istring name = "Application";
+        istring desc = "Testing async IO";
+
+        DaemonApp.OptionalSettings settings;
+        settings.use_task_ext = true;
+
+        super(name, desc, VersionInfo.init, settings);
+    }
+
+
+    /// Per-thread context to be used by the delegate
+    class AioContext: AsyncIO.Context
+    {
+        void* thread_sp;
+    }
+
+    /// Delegate to call once per thread to create and
+    /// initialize the thread context. Normally used
+    /// to initialize libraries needed for the callback
+    /// delegates
+    AsyncIO.Context makeContext()
+    {
+        auto ctx = new AioContext;
+
+        pthread_attr_t attr;
+        void* stack_addr;
+        size_t stack_size;
+
+        pthread_getattr_np(pthread_self(), &attr);
+        pthread_attr_getstack(&attr, &stack_addr, &stack_size);
+        pthread_attr_destroy(&attr);
+
+        ctx.thread_sp = stack_addr;
+
+        return ctx;
+    }
+
+    /// counter value to set from the working thread
+    int counter;
+
+    /// last thread's sp value
+    void* thread_sp;
+
+    /// Callback called from another thread to set the counter
+    private void setCounter (AsyncIO.Context ctx)
+    {
+        auto myctx = cast(AioContext)ctx;
+
+        this.thread_sp = myctx.thread_sp;
+        this.counter++;
+    }
+
+    // Called after arguments and config file parsing.
+    override protected int run ( Arguments args, ConfigParser config )
+    {
+        this.async_io = new AsyncIO(theScheduler.epoll, 10, &makeContext);
+
+        // open a new file
+        auto f = new File("var/output.txt", File.ReadWriteAppending);
+
+        char[] buf = "Hello darkness, my old friend.".dup;
+        this.async_io.blocking.write(buf, f.fileHandle());
+
+        buf[] = '\0';
+        this.async_io.blocking.pread(buf, f.fileHandle(), 0);
+
+        test!("==")(buf[], "Hello darkness, my old friend.");
+        test!("==")(f.length, buf.length);
+
+        this.async_io.blocking.callDelegate(&setCounter);
+        test!("==")(this.counter, 1);
+        test!("!is")(this.thread_sp, null);
+
+        theScheduler.shutdown();
+        return 0; // return code to OS
+    }
+}
+
+version(UnitTest) {} else
+void main(istring[] args)
+{
+
+    initScheduler(SchedulerConfiguration.init);
+    theScheduler.exception_handler = (Task t, Exception e) {
+        throw e;
+    };
+
+    auto sandbox = DirectorySandbox.create(["etc", "log", "var"]);
+
+    File.set("etc/config.ini", "[LOG.Root]\n" ~
+               "console = false\n\n");
+
+    auto app = new AsyncIOUsingApp;
+    auto ret = app.main(args);
+}

--- a/src/ocean/util/aio/AsyncIO.d
+++ b/src/ocean/util/aio/AsyncIO.d
@@ -1,0 +1,730 @@
+/******************************************************************************
+
+    Module for doing non-blocking reads supported by threads.
+
+    This module contains AsyncIO definition. Intented usage of AsyncIO is to
+    perform normally blocking IO calls (disk requests) in fiber-blocking
+    manner.
+
+    Fiber wanting to perform a request should submit its request to AsyncIO
+    using public interface, passing all the arguments normally used by the
+    blocking call and JobNotification instance on which it will be
+    blocked.  After issuing the request, request will be put in the queue and
+    the fiber will block immidiatelly, giving chance to other fibers to run.
+
+    In the background, fixed amount of worker threads are taking request from
+    the queue, and performing it (using blocking call which will in turn block
+    this thread). When finished, the worker thread will resume the blocked fiber,
+    and block on the semaphore waiting for the next request.
+
+    Copyright:
+        Copyright (c) 2018 dunnhumby Germany GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+******************************************************************************/
+
+module ocean.util.aio.AsyncIO;
+
+import ocean.transition;
+import ocean.core.Verify;
+
+import core.stdc.errno;
+import core.sys.posix.semaphore;
+import core.sys.posix.pthread;
+import core.sys.posix.unistd;
+import core.stdc.stdint;
+import core.stdc.stdio;
+import ocean.core.array.Mutation: copy;
+import ocean.sys.ErrnoException;
+import ocean.io.select.EpollSelectDispatcher;
+
+import ocean.util.aio.internal.JobQueue;
+import ocean.util.aio.internal.ThreadWorker;
+import ocean.util.aio.internal.MutexOps;
+import ocean.util.aio.internal.AioScheduler;
+import ocean.util.aio.JobNotification;
+
+version (UnitTest)
+{
+    import ocean.core.Test;
+    import ocean.task.Scheduler;
+    import ocean.io.device.File;
+}
+
+/******************************************************************************
+
+    Class implementing AsyncIO support.
+
+******************************************************************************/
+
+class AsyncIO
+{
+    /**************************************************************************
+
+        Base class for the thread worker context
+
+    **************************************************************************/
+
+    public static class Context
+    {
+
+    }
+
+    /**************************************************************************
+
+        Ernno exception instance
+
+        NOTE: must be thrown and catched only from/in main thread, as it is not
+              multithreaded-safe
+
+    **************************************************************************/
+
+    private ErrnoException exception;
+
+
+    /**************************************************************************
+
+        Job queue
+
+   ***************************************************************************/
+
+    private JobQueue jobs;
+
+    /**************************************************************************
+
+        AioScheduler used to wake the ready jobs.
+
+    **************************************************************************/
+
+    private AioScheduler scheduler;
+
+    /**************************************************************************
+
+        Handles of worker threads.
+
+    **************************************************************************/
+
+    private pthread_t[] threads;
+
+    /**************************************************************************
+
+        Indicator if the AsyncIO is destroyed
+
+    **************************************************************************/
+
+    private bool destroyed;
+
+    /**************************************************************************
+
+        Struct providing the initialization data for the thread.
+
+    **************************************************************************/
+
+    public struct ThreadInitializationContext
+    {
+        JobQueue job_queue;
+        AsyncIO.Context delegate() makeContext;
+        pthread_mutex_t init_mutex;
+        pthread_cond_t init_cond;
+        int to_create;
+    }
+
+    /**************************************************************************
+
+        Ditto
+
+    **************************************************************************/
+
+    private ThreadInitializationContext thread_init_context;
+
+    /**************************************************************************
+
+        Constructor.
+
+        Params:
+            epoll = epoll select dispatcher instance
+            number_of_threads = number of worker threads to allocate
+            make_context = delegate to create a context within a thread
+            thread_stack_size = default stack size to allocate
+
+    **************************************************************************/
+
+    public this (EpollSelectDispatcher epoll, int number_of_threads,
+            AsyncIO.Context delegate() makeContext = null,
+            long thread_stack_size = 256 * 1024)
+    {
+
+        this.exception = new ErrnoException;
+
+        this.scheduler = new AioScheduler(this.exception);
+        this.jobs = new JobQueue(this.exception, this.scheduler);
+        this.nonblocking = new typeof(this.nonblocking);
+        this.blocking = new typeof(this.blocking);
+
+        // create worker threads
+        this.threads.length = number_of_threads;
+        this.thread_init_context.to_create = number_of_threads;
+
+        this.thread_init_context.job_queue = this.jobs;
+        this.thread_init_context.makeContext = makeContext;
+        exception.enforceRetCode!(pthread_mutex_init).call(
+                &this.thread_init_context.init_mutex, null);
+        exception.enforceRetCode!(pthread_cond_init).call(
+                &this.thread_init_context.init_cond, null);
+
+        pthread_attr_t attr;
+        pthread_attr_setstacksize(&attr, thread_stack_size);
+
+        foreach (i, tid; this.threads)
+        {
+            // Create a thread passing this instance as a parameter
+            // to thread's entry point
+            this.exception.enforceRetCode!(pthread_create).call(&this.threads[i],
+                &attr,
+                &thread_entry_point!(ThreadInitializationContext),
+                cast(void*)&this.thread_init_context);
+        }
+
+        // wait all threads to create
+        pthread_mutex_lock(&this.thread_init_context.init_mutex);
+        while (this.thread_init_context.to_create > 0)
+        {
+            pthread_cond_wait(&thread_init_context.init_cond, &this.thread_init_context.init_mutex);
+        }
+
+        pthread_mutex_unlock(&this.thread_init_context.init_mutex);
+
+        epoll.register(this.scheduler);
+    }
+
+    /**************************************************************************
+
+        Issues a pread request, blocking the fiber connected to the provided
+        suspended_job until the request finishes.
+
+        This will read buf.length number of bytes from fd to buf, starting
+        from offset.
+
+        Params:
+            buf = buffer to fill
+            fd = file descriptor to read from
+            offset = offset in the file to read from
+            suspended_job = JobNotification instance to
+                block the fiber on
+
+        Returns:
+            number of the bytes read
+
+        Throws:
+            ErrnoException with appropriate errno set in case of failure
+
+    **************************************************************************/
+
+    public size_t pread (void[] buf, int fd, size_t offset,
+            JobNotification suspended_job)
+    {
+        ssize_t ret_val;
+        int errno_val;
+        auto job = this.jobs.reserveJobSlot(&lock_mutex,
+                &unlock_mutex);
+
+        job.recv_buffer.length = buf.length;
+        enableStomping(job.recv_buffer);
+        job.fd = fd;
+        job.suspended_job = suspended_job;
+        job.offset = offset;
+        job.cmd = Job.Command.Read;
+        job.ret_val = &ret_val;
+        job.errno_val = &errno_val;
+        job.user_buffer = buf;
+        job.finalize_results = &finalizeRead;
+
+        // Let the threads waiting on the semaphore know that they
+        // can start doing single read
+        post_semaphore(&this.jobs.jobs_available);
+
+        // Block the fiber
+        suspended_job.wait(job, &this.scheduler.discardResults);
+
+        // At this point, fiber is resumed,
+        // check the return value and throw if needed
+        if (ret_val == -1)
+        {
+            throw this.exception.set(errno_val,
+                    "pread");
+        }
+
+        assert(ret_val >= 0);
+        return cast(size_t)ret_val;
+    }
+
+    /***************************************************************************
+
+        Appends a buffer to the file.
+
+        Buffer must be alive during the lifetime of the request (until the
+        notification fires)
+
+        Returns:
+            number of bytes written
+
+    **************************************************************************/
+    
+    public size_t write (void[] buf, int fd, JobNotification notification)
+    {
+        ssize_t ret_val;
+        int errno_val;
+        auto job = this.jobs.reserveJobSlot(&lock_mutex, &unlock_mutex);
+
+        job.recv_buffer = buf;
+        job.fd = fd;
+        job.suspended_job = notification;
+        job.cmd = Job.Command.Write;
+        job.ret_val = &ret_val;
+        job.errno_val = &errno_val;
+
+        post_semaphore(&this.jobs.jobs_available); 
+        notification.wait(job, &this.scheduler.discardResults);
+
+        if (ret_val == -1)
+        {
+            throw this.exception.set(errno_val, "write");
+        }
+
+        verify(ret_val >= 0);
+        return cast(size_t)ret_val;
+    }
+
+    /***************************************************************************
+
+        Calls an user provided delegate. The delegate is called from within a
+        separate thread and it should not do anything non-thread safe (for example,
+        using GC must be avoided) from the runtime's perspective. Delegate receives
+        a reference to the per-thread context which it can use.
+
+        Params:
+            user_delegate = delegate to call
+            JobNotification = notification used to resume/suspend the caller
+
+    **************************************************************************/
+
+    public void callDelegate (void delegate(AsyncIO.Context) user_delegate,
+            JobNotification notification)
+    {
+        ssize_t ret_val;
+        int errno_val;
+        auto job = this.jobs.reserveJobSlot(&lock_mutex, &unlock_mutex);
+
+        job.user_delegate = user_delegate;
+        job.suspended_job = notification;
+        job.cmd = Job.Command.CallDelegate;
+        job.ret_val = &ret_val;
+        job.errno_val = &errno_val;
+
+        post_semaphore(&this.jobs.jobs_available);
+        notification.wait(job, &this.scheduler.discardResults);
+
+        if (ret_val == -1)
+        {
+            throw this.exception.set(errno_val, "delegate call");
+        }
+
+        verify(ret_val >= 0);
+    }
+
+    /***************************************************************************
+
+        Finalizes the read request - copies the contents of receive buffer
+        to user provided buffer.
+
+        Params:
+            job = job to finalize.
+
+    ***************************************************************************/
+
+    private static void finalizeRead (Job* job)
+    {
+        if (job.ret_val !is null)
+        {
+            *job.ret_val = job.return_value;
+        }
+
+        if (job.return_value >= 0)
+        {
+            auto dest = (job.user_buffer.ptr)[0..job.return_value];
+            copy(dest, job.recv_buffer[0..job.return_value]);
+        }
+    }
+
+    /***************************************************************************
+
+        Set of non-blocking methods. The user is responsible to suspend the fiber,
+        and AsyncIO will not resume it. Instead, the callback will be called
+        where the user can do whatever is required.
+
+    ***************************************************************************/
+
+    public final class Nonblocking
+    {
+        /**************************************************************************
+
+            Issues a pread request, filling the buffer as much as possible,
+            expecting the user to suspend the caller manually.
+
+            This will read buf.length number of bytes from fd to buf, starting
+            from offset.
+
+            Params:
+                buf = buffer to fill
+                ret_val = return value to fill
+                fd = file descriptor to read from
+                offset = offset in the file to read from
+                finish_callback_dg = method to call when the request has finished,
+                    passing the return value of the pread call
+                suspended_job = suspended job to resume upon finishing the
+                    IO operation and calling finish_callback_dg
+
+            Returns:
+                Job that's scheduled
+
+            Throws:
+                ErrnoException with appropriate errno set in case of failure
+
+        **************************************************************************/
+
+        public Job* pread (void[] buf,
+                int fd, size_t offset,
+                JobNotification suspended_job)
+        {
+            auto job = this.outer.jobs.reserveJobSlot(&lock_mutex,
+                    &unlock_mutex);
+
+            job.recv_buffer.length = buf.length;
+            enableStomping(job.recv_buffer);
+
+            job.fd = fd;
+            job.offset = offset;
+            job.cmd = Job.Command.Read;
+            job.user_buffer = buf;
+            job.finalize_results = &finalizeRead;
+            job.suspended_job = suspended_job;
+            suspended_job.register(job, &this.outer.scheduler.discardResults);
+
+            // Let the threads waiting on the semaphore know that they
+            // can start doing single read
+            post_semaphore(&this.outer.jobs.jobs_available);
+
+            return job;
+        }
+    }
+
+    /// Ditto
+    public Nonblocking nonblocking;
+
+    /// Task wrapper
+    public final class TaskBlocking
+    {
+        import ocean.util.aio.TaskJobNotification;
+        import ocean.task.Task;
+
+        public size_t write (void[] buf, int fd)
+        {
+            assert (Task.getThis() !is null);
+            scope JobNotification notification = new TaskJobNotification;
+            return this.outer.write(buf, fd, notification);
+        }
+
+        public size_t pread (void[] buf, int fd, size_t offset)
+        {
+            assert (Task.getThis() !is null);
+            scope JobNotification notification = new TaskJobNotification;
+            return this.outer.pread(buf, fd, offset, notification);
+        }
+
+        public void callDelegate (void delegate(AsyncIO.Context) user_delegate)
+        {
+            assert (Task.getThis() !is null);
+            scope JobNotification notification = new TaskJobNotification;
+            this.outer.callDelegate(user_delegate, notification);
+        }
+    }
+
+    /// ditto
+    public TaskBlocking blocking;
+
+    /**************************************************************************
+
+        Issues a fsync request, blocking the fiber connected to the provided
+        suspended_job until the request finishes.
+
+        Synchronize a file's in-core state with storage device.
+
+        Params:
+            fd = file descriptor to perform fsync on
+            suspended_job = JobNotification instance to
+                block the fiber on
+
+        Throws:
+            ErrnoException with appropriate errno set in the case of failure
+
+    **************************************************************************/
+
+    public void fsync (int fd,
+            JobNotification suspended_job)
+    {
+        long ret_val;
+        int errno_val;
+
+        auto job = this.jobs.reserveJobSlot(&lock_mutex,
+                &unlock_mutex);
+
+        job.fd = fd;
+        job.suspended_job = suspended_job;
+        job.cmd = Job.Command.Fsync;
+        job.ret_val = &ret_val;
+        job.errno_val = &errno_val;
+        job.finalize_results = null;
+
+        // Let the threads waiting on the semaphore that they
+        // can perform fsync
+        post_semaphore(&this.jobs.jobs_available);
+
+        // Block the fiber
+        suspended_job.wait(job, &this.scheduler.discardResults);
+
+        // At this point, fiber is resumed,
+        // check the return value and throw if needed
+        if (ret_val == -1)
+        {
+            throw this.exception.set(errno_val,
+                    "fsync");
+        }
+    }
+
+    /**************************************************************************
+
+        Issues a close request, blocking the fiber connected to the provided
+        suspendable request handler until the request finishes.
+
+        Synchronize a file's in-core state with storage device.
+
+        Params:
+            fd = file descriptor to close
+            suspended_job = JobNotification instance to
+                block the caller on
+
+        Throws:
+            ErrnoException with appropriate errno set in the case of failure
+
+    **************************************************************************/
+
+    public void close (int fd,
+            JobNotification suspended_job)
+    {
+        long ret_val;
+        int errno_val;
+
+        auto job = this.jobs.reserveJobSlot(&lock_mutex,
+                &unlock_mutex);
+
+        job.fd = fd;
+        job.suspended_job = suspended_job;
+        job.cmd = Job.Command.Close;
+        job.ret_val = &ret_val;
+        job.errno_val = &errno_val;
+        job.finalize_results = null;
+
+        post_semaphore(&this.jobs.jobs_available);
+
+        // Block the fiber
+        suspended_job.wait(job, &this.scheduler.discardResults);
+
+        // At this point, fiber is resumed,
+        // check the return value and throw if needed
+        if (ret_val == -1)
+        {
+            throw this.exception.set(errno_val,
+                    "close");
+        }
+    }
+
+    /*********************************************************************
+
+        Destroys entire AsyncIO object.
+        It's unusable after this point.
+
+        NOTE: this blocks the calling thread
+
+        Throws:
+            ErrnoException if one of the underlying system calls
+            failed
+
+    *********************************************************************/
+
+    public void destroy ()
+    {
+        assert(!this.destroyed);
+
+        // Stop all workers
+        // and wait for all threads to exit
+        this.join();
+
+        this.jobs.destroy(this.exception);
+        this.destroyed = true;
+    }
+
+    /**************************************************************************
+
+        Indicate worker threads not to take any more jobs.
+
+        Throws:
+            ErrnoException if one of the underlying system calls
+            failed
+
+    **************************************************************************/
+
+    private void stopAll ()
+    {
+        this.jobs.stop(&lock_mutex,
+                &unlock_mutex);
+
+        // Let all potential threads blocked on semaphore
+        // move forward and exit
+        for (int i; i < this.threads.length; i++)
+        {
+            post_semaphore(&this.jobs.jobs_available);
+        }
+    }
+
+    /**************************************************************************
+
+        Waits for all threads to finish and checks the exit codes.
+
+        Throws:
+            ErrnoException if one of the underlying system calls
+            failed
+
+    **************************************************************************/
+
+    private void join ()
+    {
+        // We need to tell threads actually to stop working
+        this.stopAll();
+
+        for (int i = 0; i < this.threads.length; i++)
+        {
+            // Note: no need for mutex guarding this
+            // as this is just an array of ids which
+            // will not change during the program's lifetime
+            void* ret_from_thread;
+            int ret = pthread_join(this.threads[i], &ret_from_thread);
+
+            switch (ret)
+            {
+                case 0:
+                    break;
+                default:
+                    throw this.exception.set(ret, "pthread_join");
+                case EDEADLK:
+                    assert(false, "Deadlock was detected");
+                case EINVAL:
+                    assert(false, "Join performed on non-joinable thread" ~
+                            " or another thread is already waiting on it");
+                case ESRCH:
+                    assert(false, "No thread with this tid can be found");
+            }
+
+            // Check the return value from the thread routine
+            if (cast(intptr_t)ret_from_thread != 0)
+            {
+                throw this.exception.set(cast(int)ret_from_thread,
+                        "thread_method");
+            }
+        }
+    }
+
+    /*********************************************************************
+
+        Helper function for posting the semaphore value
+        and checking for the return value
+
+        Params:
+            sem = pointer to the semaphore handle
+
+
+    *********************************************************************/
+
+    private void post_semaphore (sem_t* sem)
+    {
+        int ret = sem_post(sem);
+
+        switch (ret)
+        {
+            case 0:
+                break;
+            default:
+                throw this.exception.set(ret, "sem_post");
+            case EINVAL:
+                assert(false, "The semaphore is not valid");
+        }
+    }
+}
+
+/// Example showing the task-blocking API
+unittest
+{
+    /// Per-thread context. Can be anything, but it needs to inherit
+    // from AsyncIO.Context
+    class AioContext: AsyncIO.Context
+    {
+        int i;
+    }
+
+    // Creates the per thread context. This is executed inside
+    // each worker thread. Useful to initialize C libraries (e.g.
+    // curl_easy_init)
+    // This method is synchronized, so everything here is thread safe
+    // One must only pay attention not to call methods that need
+    // thread-local state
+    AsyncIO.Context makeContext()
+    {
+        auto ctx = new AioContext;
+
+        // set some things
+        ctx.i = 0;
+
+        return ctx;
+    }
+    /// Callback called from another thread to set the counter
+    void setCounter (AsyncIO.Context ctx)
+    {
+        // cast the per-thread context
+        auto myctx = cast(AioContext)ctx;
+        myctx.i++;
+    }
+
+    void example()
+    {
+        auto async_io = new AsyncIO(theScheduler.epoll, 10, &makeContext);
+
+        // open a new file
+        auto f = new File("var/output.txt", File.ReadWriteAppending);
+
+        // write a file in another thread
+        char[] buf = "Hello darkness, my old friend.".dup;
+        async_io.blocking.write(buf, f.fileHandle());
+
+        // read the file from another thread
+        buf[] = '\0';
+        async_io.blocking.pread(buf, f.fileHandle(), 0);
+
+        test!("==")(buf[], "Hello darkness, my old friend.");
+        test!("==")(f.length, buf.length);
+
+        // call the delegate from another thread
+        async_io.blocking.callDelegate(&setCounter);
+    }
+}

--- a/src/ocean/util/aio/DelegateJobNotification.d
+++ b/src/ocean/util/aio/DelegateJobNotification.d
@@ -1,0 +1,115 @@
+/*******************************************************************************
+
+    DelegateJobNotification. Used for notifying jobs from the AsyncIO.
+    Allows the job to specify how it will be suspended and resumed via
+    delegates.
+
+    resume_job delegate is always requried, unlike suspend_job delegate: in
+    the case where the job needs to suspend itself at the convenient
+    location, no suspend_job delegate should be passed. One usage of this
+    behaviour would be to allow resuming the job from the several
+    external systems (e.g. from the disk IO and from the network), allowing
+    the job to suspend itself at the convenient point where it's possible
+    to distinguish if the job is resumed from the network or from the
+    AsyncIO.
+
+    Copyright:
+        Copyright (c) 2018 dunnhumby Germany GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+*******************************************************************************/
+
+module ocean.util.aio.DelegateJobNotification;
+
+import ocean.util.aio.JobNotification;
+import ocean.core.Verify;
+
+/// ditto
+class DelegateJobNotification: JobNotification
+{
+    import ocean.core.Enforce: enforce;
+
+    /***************************************************************************
+
+        Delegate to resume the suspended job.
+
+    ***************************************************************************/
+
+    private void delegate() resume_job;
+
+    /***************************************************************************
+
+        Delegate to suspend the running job.
+
+    ***************************************************************************/
+
+    private void delegate() suspend_job;
+
+
+    /***************************************************************************
+
+        Constructor. Initializes DelegateJobNotification.
+
+        Params:
+            resume_job = delegate to call to resume suspended job
+            suspend_job = delegate to call to suspend current job, null
+                              if that should not be possible
+
+    ***************************************************************************/
+
+    public this (void delegate() resume_job,
+            void delegate() suspend_job = null)
+    {
+        this.initialise(resume_job, suspend_job);
+    }
+
+
+    /***************************************************************************
+
+        Initialization method. Initializes ManualJobNotification (separated
+        from constructor for convenient use in reusable pool).
+
+        Params:
+            resume_job = delegate to call to resume suspended job
+            suspend_job = delegate to call to suspend current job, null
+                              if that should not be possible
+
+    ***************************************************************************/
+
+    public typeof(this) initialise (void delegate() resume_job,
+            void delegate() suspend_job = null)
+    {
+        this.resume_job = resume_job;
+        this.suspend_job = suspend_job;
+        return this;
+    }
+
+    /***************************************************************************
+
+        Yields the control to the suspended job, indicating that the aio
+        operation has been done.
+
+    ***************************************************************************/
+
+    public override void wake_ ()
+    {
+        this.resume_job();
+    }
+
+    /***************************************************************************
+
+        Cedes the control from the suspendable job, waiting for the aio
+        operation to be done.
+
+    ***************************************************************************/
+
+    public override void wait_ ()
+    {
+        verify(&this.suspend_job !is null,
+                "This job is not allowed to be suspended.");
+        this.suspend_job();
+    }
+}

--- a/src/ocean/util/aio/EventFDJobNotification.d
+++ b/src/ocean/util/aio/EventFDJobNotification.d
@@ -1,0 +1,98 @@
+/*******************************************************************************
+
+    FiberSelectEvent suspend/resume interface for suspendable jobs waiting
+    for AsyncIO to finish.
+
+    Copyright:
+        Copyright (c) 2018 dunnhumby Germany GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+*******************************************************************************/
+
+module ocean.util.aio.EventFDJobNotification;
+
+import ocean.io.select.client.FiberSelectEvent;
+import ocean.io.select.fiber.SelectFiber;
+import ocean.util.aio.DelegateJobNotification;
+
+/// ditto
+class EventFDJobNotification: DelegateJobNotification
+{
+    /***************************************************************************
+
+        Constructor.
+
+        Params:
+            event = FiberSelectEvent to synchronise on.
+
+    ***************************************************************************/
+
+    this (FiberSelectEvent event)
+    {
+        this.event = event;
+        super(&this.trigger, &this.wait);
+    }
+
+    /***************************************************************************
+
+        Constructor.
+
+        Params:
+            fiber = Fiber to create FiberSelectEvent to synchronise on.
+
+    ***************************************************************************/
+
+    this (SelectFiber fiber)
+    {
+        this.event = new FiberSelectEvent(fiber);
+        super(&this.trigger, &this.wait);
+    }
+
+    /***************************************************************************
+
+        Changes the SelectFiber this handler is suspending
+
+        Params:
+            fiber = new SelectFiber to suspend
+
+    ***************************************************************************/
+
+    public void setFiber (SelectFiber fiber)
+    {
+        this.event.fiber = fiber;
+    }
+
+    /**************************************************************************
+
+        Triggers the event.
+
+    **************************************************************************/
+
+    private void trigger ()
+    {
+        this.event.trigger();
+    }
+
+    /**************************************************************************
+
+        Waits on the event.
+
+    **************************************************************************/
+
+    private void wait ()
+    {
+        this.event.wait();
+    }
+
+    /***************************************************************************
+
+        FiberSelectEvent synchronise object.
+
+    ***************************************************************************/
+
+    private FiberSelectEvent event;
+
+}

--- a/src/ocean/util/aio/JobNotification.d
+++ b/src/ocean/util/aio/JobNotification.d
@@ -1,0 +1,138 @@
+/*******************************************************************************
+
+    Common interface for various types of suspendable jobs waiting for
+    AsyncIO to finish.
+
+    Copyright:
+        Copyright (c) 2018 dunnhumby Germany GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+*******************************************************************************/
+
+module ocean.util.aio.JobNotification;
+
+/// Ditto
+abstract class JobNotification
+{
+    import ocean.core.array.Mutation: copy;
+    import ocean.util.aio.internal.JobQueue: Job;
+
+    /***************************************************************************
+
+        AsyncIO's method that should be called to discard the results of scheduled
+        asynchronous method.
+
+    ***************************************************************************/
+
+    private void delegate(Job*) remove_dg;
+
+    /***************************************************************************
+
+        Pointer to the AIO job suspended on this JobNotification.
+        Used for canceling the jobs. TODO: is the closure possible combining
+        remove_dg and job?
+
+    ***************************************************************************/
+
+    private Job* job;
+
+    /***************************************************************************
+
+        Yields the control to the suspendable job, indicating that the aio
+        operation has been done.
+
+    ***************************************************************************/
+
+    protected abstract void wake_ ();
+
+    /***************************************************************************
+
+        Cedes the control from the suspendable job, waiting for the aio
+        operation to be done. Implementation is defined by the concrete classes.
+
+    ***************************************************************************/
+
+    protected abstract void wait_();
+
+    /***************************************************************************
+
+        Cedes the control from the suspendable job, waiting for the aio
+        operation to be done. Called by AsyncIO framework internally.
+
+        Params:
+            remove_dg = delegate to call to inform AIO that results of this job
+                        can be discarded.
+
+    ***************************************************************************/
+
+    public final void wait (Job* job, typeof(this.remove_dg) remove_dg)
+    {
+        scope (failure)
+            this.discardResults();
+
+        this.register(job, remove_dg);
+        this.wait_();
+    }
+
+    /**************************************************************************
+
+        Registers the Job instance with this job notification and sets up
+        removal delegate.
+
+        Params:
+            job = instance of the job that this job notification is waiting on
+            remove_dg = delegate to call to inform AIO that results of this job
+                        can be discarded.
+
+    ***************************************************************************/
+
+    public final void register (Job* job, typeof(this.remove_dg) remove_dg)
+    {
+        this.job = job;
+        this.remove_dg = remove_dg;
+    }
+
+    /***************************************************************************
+
+        Detaches the Job instance from this JobNotification (the opposite of
+        register).
+
+    ***************************************************************************/
+
+    public final void unregister ()
+    {
+        this.job = null;
+    }
+
+    /***************************************************************************
+
+        Yields the control to the suspended job, indicating that the aio
+        operation has been done. Called by the AsyncIO framework internally.
+
+    ***************************************************************************/
+
+    public final void wake ()
+    {
+        this.unregister();
+        this.wake_();
+    }
+
+    /***************************************************************************
+
+        Should be called by the concrete classes to inform the AIO that
+        results of this operation are no longer needed.
+
+    ***************************************************************************/
+
+    public final void discardResults ()
+    {
+        if (this.job)
+        {
+            this.remove_dg(this.job);
+            this.job = null;
+        }
+    }
+}

--- a/src/ocean/util/aio/TaskJobNotification.d
+++ b/src/ocean/util/aio/TaskJobNotification.d
@@ -1,0 +1,85 @@
+/*******************************************************************************
+
+    Task suspend/resume interface for suspendable jobs waiting
+    for AsyncIO to finish.
+
+    Copyright:
+        Copyright (c) 2018 dunnhumby Germany GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+*******************************************************************************/
+
+module ocean.util.aio.TaskJobNotification;
+
+import ocean.task.Task;
+import ocean.task.util.Event;
+import ocean.core.Verify;
+import ocean.util.aio.DelegateJobNotification;
+
+/// ditto
+class TaskJobNotification: DelegateJobNotification
+{
+    /***************************************************************************
+
+        Constructor.
+
+    ***************************************************************************/
+
+    this ()
+    {
+        this.task = Task.getThis();
+        super(&this.trigger, &this.wait);
+    }
+
+    /**************************************************************************
+
+        Triggers the event.
+
+    **************************************************************************/
+
+    private void trigger ()
+    {
+        this.event.trigger();
+    }
+
+    /**************************************************************************
+
+        Waits on the event.
+
+    **************************************************************************/
+
+    private void wait ()
+    {
+        this.event.wait();
+    }
+
+    /**************************************************************************
+
+        Resets the notification to a current task.
+
+    **************************************************************************/
+
+    public void reset ()
+    {
+        this.task = Task.getThis();
+    }
+
+    /**************************************************************************
+
+        Task to be resumed.
+
+    **************************************************************************/
+
+    private Task task;
+
+    /**************************************************************************
+
+        TaskTriggerEvent used to resume a task.
+
+    **************************************************************************/
+
+    private TaskEvent event;
+}

--- a/src/ocean/util/aio/internal/AioScheduler.d
+++ b/src/ocean/util/aio/internal/AioScheduler.d
@@ -1,0 +1,235 @@
+/*******************************************************************************
+
+    AioScheduler that is informed when the aio operations are done and ready
+    to be continued.
+
+    Scheduler internally has two queues: queue that's accessible to main thread
+    and the queue that's accessible to all worker threads. At no point in time
+    single queue is available to both main thread and worker threads. As a
+    consequence of this, main thread never needs to acquire mutex while
+    accessing its queue, and worker threads are only synchronizing between
+    themselves while accessing the queue.
+
+    At the beginning, both queues are empty. When worker thread is finished
+    processing the request, JobNotification is put into the workers'
+    queue and notifies the main thread that there are request that it needs to
+    wake up. However, since the main thread may not immediately do this, more
+    than one request could end up in the queue. Once main thread is ready to
+    wake up the request, it will obtain the mutex and swap these two queues.
+    Now, main thread contains queue of all request ready to be woken up, and
+    the workers' queue is empty, and main thread now can wake up all the
+    request without interruptions from other threads, and worker threads can
+    schedule new request to be woken up without interfering with the main
+    thread. Once main thread finish processing its queue, and there is at least
+    one request in the workers' queue, it will swap the queues again, and the
+    same procedure will be performed again.
+
+    Copyright:
+        Copyright (c) 2018 dunnhumby Germany GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+*******************************************************************************/
+
+module ocean.util.aio.internal.AioScheduler;
+
+import ocean.transition;
+import ocean.io.select.client.SelectEvent;
+
+/// Ditto
+class AioScheduler: ISelectEvent
+{
+    import ocean.sys.ErrnoException;
+    import core.sys.posix.pthread;
+    import ocean.util.aio.JobNotification;
+    import ocean.util.aio.internal.MutexOps;
+    import ocean.util.container.LinkedList;
+    import ocean.util.aio.internal.JobQueue: Job;
+
+    /***************************************************************************
+
+        Mutex protecting request queue
+
+    ***************************************************************************/
+
+    private pthread_mutex_t queue_mutex;
+
+    /***************************************************************************
+
+        See ready_queue's documentation.
+
+    ***************************************************************************/
+
+    private LinkedList!(Job*)[2] queues;
+
+    /***************************************************************************
+
+        Queue of requests being ready. NOTE: this is just a pointer to a queue
+        of requests that are finished processing and they will be woken up
+        in the next AioScheduler cycle. On every AioScheduler cycle, pointers
+        to `ready_queue` and `waking_queue` are swapped. During a single cycle,
+        only the worker threads are accessing ready_queue (inserting references
+        to the jobs that are finish) and only the main thread access the
+        waking_queue (popping the requests from it and resuming the fibers
+        waiting for the IO to complete).
+
+    ***************************************************************************/
+
+    private LinkedList!(Job*)* ready_queue;
+
+    /***************************************************************************
+
+        Queue of requests that are in process of waking up. For more details,
+        see comment for ready_queue, above.
+
+    ***************************************************************************/
+
+    private LinkedList!(Job*)* waking_queue;
+
+    /***************************************************************************
+
+        Queue of the request whose results should be discarded.
+
+    ***************************************************************************/
+
+    private LinkedList!(Job*) discarded_queue;
+
+    /***************************************************************************
+
+        Constructor.
+
+        Params:
+            exception = exception to throw in case of error
+
+    ***************************************************************************/
+
+    public this (ErrnoException exception)
+    {
+        exception.enforceRetCode!(pthread_mutex_init).call(
+                &this.queue_mutex, null);
+
+        this.queues[0] = new LinkedList!(Job*);
+        this.queues[1] = new LinkedList!(Job*);
+        this.discarded_queue = new LinkedList!(Job*);
+        this.ready_queue = &this.queues[0];
+        this.waking_queue = &this.queues[1];
+    }
+
+    /***************************************************************************
+
+        Mark the request ready to be woken up by scheduler
+
+        Params:
+            job = job that has completed, that needs to be finalized and whose
+                suspended request should be resumed
+            lock_mutex = function or delegate to lock the mutex
+            unlock_mutex = function or delegate to unlock the mutex
+
+    ***************************************************************************/
+
+    public void requestReady (MutexOp)(Job* req,
+            MutexOp lock_mutex, MutexOp unlock_mutex)
+    {
+        lock_mutex(&this.queue_mutex);
+        scope (exit)
+        {
+            unlock_mutex(&this.queue_mutex);
+        }
+
+        // Check if the results of this request was marked as not needed
+        if (!this.discarded_queue.remove(req))
+        {
+            this.ready_queue.append(req);
+            this.trigger();
+        }
+        else
+        {
+            req.recycle();
+        }
+    }
+
+    /***************************************************************************
+
+        Discards the results of the given AIO operation.
+
+        Params:
+            req = JobNotification instance that was waiting for results
+
+    ***************************************************************************/
+
+    public void discardResults (Job* req)
+    {
+        lock_mutex(&this.queue_mutex);
+        scope (exit)
+        {
+            unlock_mutex(&this.queue_mutex);
+        }
+
+        // Since we're guarded by lock above, two scenarios might happen:
+        // 1) The given ThreadWorker already submitted the results for this
+        //    operation, which we will simply remove from the ready queue.
+        // 2) No worker thread was assigned for this request, or the operation
+        //    was not yet completed. In this case tell the AioScheduler to discard
+        //    these results as soon as they arrive
+        if (!this.ready_queue.remove(req))
+        {
+            this.discarded_queue.append(req);
+        }
+        else
+        {
+            req.recycle();
+        }
+    }
+
+
+    /***************************************************************************
+
+        Called from handle() when the event fires.
+
+        Params:
+            n = number of the times this event has been triggered.
+
+    ***************************************************************************/
+
+    protected override bool handle_ ( ulong n )
+    {
+        this.swapQueues();
+
+        foreach (job; *this.waking_queue)
+        {
+            auto req = job.suspended_job;
+            assert (req);
+
+            job.finished();
+            req.wake();
+            job.recycle();
+        }
+
+        this.waking_queue.clear();
+
+        return true;
+    }
+
+    /***************************************************************************
+
+      Swaps the waking and ready queue.
+
+    ***************************************************************************/
+
+    private void swapQueues ()
+    {
+        lock_mutex(&this.queue_mutex);
+        scope (exit)
+        {
+            unlock_mutex(&this.queue_mutex);
+        }
+
+        assert (this.waking_queue.size() == 0);
+
+        auto tmp = this.waking_queue;
+        this.waking_queue = this.ready_queue;
+        this.ready_queue = tmp;
+    }
+}

--- a/src/ocean/util/aio/internal/JobQueue.d
+++ b/src/ocean/util/aio/internal/JobQueue.d
@@ -1,0 +1,548 @@
+/******************************************************************************
+
+    Module containing implementation of the request queue for AsyncIO.
+
+    Copyright:
+        Copyright (c) 2018 dunnhumby Germany GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+******************************************************************************/
+
+module ocean.util.aio.internal.JobQueue;
+
+import ocean.transition;
+
+import core.stdc.errno;
+import core.stdc.stdint;
+import core.sys.posix.unistd;
+import core.sys.posix.semaphore;
+import core.sys.posix.pthread;
+
+import ocean.sys.ErrnoException;
+
+import ocean.util.aio.AsyncIO;
+import ocean.util.aio.JobNotification;
+import ocean.util.aio.internal.AioScheduler;
+
+/**********************************************************************
+
+    Single job definition
+
+**********************************************************************/
+
+public static struct Job
+{
+    import ocean.core.array.Mutation: copy;
+    import ocean.util.aio.internal.MutexOps;
+
+    /******************************************************************
+
+        Command to be executed for the current request.
+
+    *******************************************************************/
+
+    public enum Command
+    {
+        Read,
+        Write,
+        Fsync,
+        Close,
+        CallDelegate,
+    }
+
+    /******************************************************************
+
+        Command to run for this request
+
+    ******************************************************************/
+
+    public Command cmd;
+
+    /****************************************************************
+
+        File descriptor of the file to perform
+        the request on
+
+    ****************************************************************/
+
+    public int fd;
+
+    /****************************************************************
+
+        Offset from the file to perform the request
+
+    ****************************************************************/
+
+    public size_t offset;
+
+    /****************************************************************
+
+        User supplied delegate to call.
+
+    ****************************************************************/
+
+    public void delegate (AsyncIO.Context) user_delegate;
+
+    /****************************************************************
+
+        The field to store the return value of the system call.
+
+    ****************************************************************/
+
+    public ssize_t return_value;
+
+    /****************************************************************
+
+        Pointer to variable which should receive the return value of
+        the system call.
+
+    ****************************************************************/
+
+    public ssize_t* ret_val;
+
+    /****************************************************************
+
+        Pinter to variable which should receive the errno value
+        after the system call
+
+    ****************************************************************/
+
+    public int* errno_val;
+
+    /****************************************************************
+
+        JobNotification used to wake the job.
+
+    ****************************************************************/
+
+    public JobNotification suspended_job;
+
+    /****************************************************************
+
+        Indicates if the job is being handled within one
+        of the threads
+
+    ****************************************************************/
+
+    private bool is_taken;
+
+    /****************************************************************
+
+        Indicates if this slot in the queue is empty
+        and can be taken
+
+    ****************************************************************/
+
+    private bool is_slot_free;
+
+    /****************************************************************
+
+        Buffer to be filled by the worker thread. When the job is
+        finalised, the contents are copied into user_buffer.
+
+    ****************************************************************/
+
+    public void[] recv_buffer;
+
+    /***************************************************************
+
+        User buffer to copy the results to. NOTE: the reason to have
+        recv_buffer and user_buffer separate is because it might happen
+        that user discards the job and the buffer, while thread is
+        writing into it, in which case the contents of recv_buffer
+        are discarded.
+
+    ****************************************************************/
+
+    public void[] user_buffer;
+
+    /***************************************************************************
+
+        Prepares the results, called upon the completion of the request,
+        if the jobs has not been cancelled while waiting for the completion.
+
+    ***************************************************************************/
+
+    public void function(Job* job) finalize_results;
+
+    /***************************************************************************
+
+        User-provided method to call when the job has been completed.
+
+    ***************************************************************************/
+
+    public void delegate(ssize_t)[]  finish_callback_dgs;
+
+    /***************************************************************************
+
+        Job queue where this jobs is currently resident. Used for recycling.
+
+    ***************************************************************************/
+
+    private JobQueue owner_queue;
+
+    /***************************************************************************
+
+        Performs any actions at the end of the AIO operation.
+
+    ***************************************************************************/
+
+    public void finished ()
+    {
+        if (this.finalize_results)
+        {
+            this.finalize_results(this);
+        }
+
+        if (this.finish_callback_dgs.length)
+        {
+            foreach (dg; this.finish_callback_dgs)
+            {
+                dg(this.return_value);
+            }
+        }
+    }
+
+    /***************************************************************************
+
+        Registers the callback to call after finishing the job.
+
+        Params:
+            dg = delegate to call when the job is finished.
+
+    ***************************************************************************/
+
+    public Job* registerCallback (void delegate(ssize_t) dg)
+    {
+        this.finish_callback_dgs ~= dg;
+        return this;
+    }
+
+    /***************************************************************************
+
+        Recycles the job and marks it free to use by the AIO for the next
+        operation.
+
+    ***************************************************************************/
+
+    public void recycle ()
+    {
+        this.owner_queue.recycleJob(this, &lock_mutex, &unlock_mutex);
+    }
+}
+
+/**************************************************************************
+
+    Pending jobs queue.
+
+**************************************************************************/
+
+public static class JobQueue
+{
+    import ocean.util.container.LinkedList;
+
+
+    /********************************************************************
+
+        List containing requests.
+        Note that, since the worker threads are taking
+        pointers to jobs, moving container must not be used
+        as that would invalidate pointers to the exiting jobs
+        held by other threads
+
+    *********************************************************************/
+
+    private LinkedList!(Job*) jobs;
+
+
+    /********************************************************************
+
+        Mutex protecting job queue.
+
+    ********************************************************************/
+
+    private pthread_mutex_t jobs_mutex;
+
+
+    /*********************************************************************
+
+        Indicator if workers should
+        stop doing more work
+
+    *********************************************************************/
+
+    private bool cancel_further_jobs;
+
+
+    /*********************************************************************
+
+        AioScheduler used to wake the ready jobs.
+
+    *********************************************************************/
+
+    private AioScheduler scheduler;
+
+    /*********************************************************************
+
+        Constructor
+
+        Params:
+            exception = ErrnoException instance to throw in case
+                        initialization failed
+            scheduler = AioScheduler to schedule waking the jobs on
+
+    *********************************************************************/
+
+    public this (ErrnoException exception, AioScheduler scheduler)
+    {
+        this.jobs = new typeof(this.jobs);
+        this.scheduler = scheduler;
+
+        exception.enforceRetCode!(pthread_mutex_init).call(
+                &this.jobs_mutex, null);
+
+        exception.enforceRetCode!(sem_init).call
+            (&this.jobs_available, 0, 0); // No jobs are ready initially
+    }
+
+
+    /*********************************************************************
+
+        Takes the first jobs in the queue that's not being
+        served by any other thread.
+
+        Params:
+            MutexOp = function or delegate mutex accepting the pointer to the
+                mutex. Used so this method works both with delegate and
+                function.
+            lock_mutex = method to be called to lock a mutex and perform
+                         error checking
+            unlock_mutex = method to be called to unlock a mutex and perform
+                         error checking
+
+    *********************************************************************/
+
+    public Job* takeFirstNonTakenJob(MutexOp)(MutexOp lock_mutex,
+            MutexOp unlock_mutex)
+    {
+        lock_mutex(&this.jobs_mutex);
+        scope (exit)
+        {
+            unlock_mutex(&this.jobs_mutex);
+        }
+
+        if (this.cancel_further_jobs)
+        {
+            return null;
+        }
+
+        foreach (ref job; this.jobs)
+        {
+            if (job.is_slot_free == false && job.is_taken == false)
+            {
+                job.is_taken = true;
+                return job;
+            }
+        }
+
+        return null;
+    }
+
+    /*********************************************************************
+
+        Reserves a job slot in the queue. It either reuses
+        existing slot, or allocates a new one if all
+        existing slots are occupied
+
+        Params:
+            MutexOp = function or delegate mutex accepting the pointer to the
+                mutex. Used so this method works both with delegate and
+                function.
+            lock_mutex = method to be called to lock a mutex and perform
+                         error checking
+            unlock_mutex = method to be called to unlock a mutex and perform
+                         error checking
+
+        Returns:
+            pointer to the job slot in the queue
+
+    *********************************************************************/
+
+    public Job* reserveJobSlot(MutexOp)(MutexOp lock_mutex,
+            MutexOp unlock_mutex)
+    {
+        lock_mutex(&this.jobs_mutex);
+        scope (exit)
+        {
+            unlock_mutex(&this.jobs_mutex);
+        }
+
+        Job* free_job = null;
+
+        foreach (ref job; this.jobs)
+        {
+            if (job.is_slot_free && !job.is_taken)
+            {
+                free_job = job;
+                break;
+            }
+        }
+
+        if (!free_job)
+        {
+            // adds at the beginning
+            auto new_job = new Job();
+            this.jobs.add(new_job);
+            free_job = this.jobs.get(0);
+        }
+
+        free_job.is_taken = false;
+        free_job.is_slot_free = false;
+        free_job.owner_queue = this;
+        free_job.finish_callback_dgs.length = 0;
+        enableStomping(free_job.finish_callback_dgs);
+        free_job.ret_val = null;
+        free_job.errno_val = null;
+
+        return free_job;
+    }
+
+    /*********************************************************************
+
+        Marks the job as ready and schedules the routine to be waken
+        up by the scheduler.
+
+        Params:
+            job = job that has completed
+            lock_mutex = function or delegate to lock the mutex
+            unlock_mutex = function or delegate to unlock the mutex
+
+    *********************************************************************/
+
+    public void markJobReady(MutexOp) ( Job* job,
+            MutexOp lock_mutex, MutexOp unlock_mutex )
+    {
+        this.scheduler.requestReady(job,
+                lock_mutex, unlock_mutex);
+    }
+
+    /*********************************************************************
+
+        Recycles the job slot and checks if there are any more jobs to
+        be served.
+
+        Params:
+            MutexOp = function or delegate mutex accepting the pointer to the
+                mutex. Used so this method works both with delegate and
+                function.
+            job = job to recycle
+            lock_mutex = method to be called to lock a mutex and perform
+                         error checking
+            unlock_mutex = method to be called to unlock a mutex and perform
+                         error checking
+
+        Returns:
+            true if there will be more jobs, false otherwise
+
+
+    *********************************************************************/
+
+    public bool recycleJob(MutexOp) (Job* job, MutexOp lock_mutex,
+            MutexOp unlock_mutex)
+    {
+        if (this.cancel_further_jobs)
+            return false;
+
+        lock_mutex(&this.jobs_mutex);
+        scope(exit)
+        {
+            unlock_mutex(&this.jobs_mutex);
+        }
+
+        job.is_taken = false;
+        job.is_slot_free = true;
+
+        return !this.cancel_further_jobs;
+    }
+
+    /*********************************************************************
+
+        Tells the queue to stop serving more jobs to workers.
+
+        Params:
+            MutexOp = function or delegate mutex accepting the pointer to the
+                mutex. Used so this method works both with delegate and
+                function.
+            lock_mutex = method to be called to lock a mutex and perform
+                         error checking
+            unlock_mutex = method to be called to unlock a mutex and perform
+                         error checking
+
+
+    *********************************************************************/
+
+    public void stop(MutexOp) (MutexOp lock_mutex,
+            MutexOp unlock_mutex)
+    {
+        lock_mutex(&this.jobs_mutex);
+        scope(exit)
+        {
+            unlock_mutex(&this.jobs_mutex);
+        }
+
+        this.cancel_further_jobs = true;
+    }
+
+    /*********************************************************************
+
+        Destructor
+
+        Params:
+            exception = ErrnoException instance to throw in case destruction
+            failed
+
+    *********************************************************************/
+
+    public void destroy (ErrnoException exception)
+    {
+        // Can only fail if the mutex is still held somewhere.  Since users
+        // should already be joined on all threads, that should not be
+        // possible.
+        auto ret = pthread_mutex_destroy(&this.jobs_mutex);
+
+        switch (ret)
+        {
+            case 0:
+                break;
+            default:
+                throw exception.set(ret, "pthread_mutex_destroy");
+            case EBUSY:
+                assert(false, "Mutex still held");
+            case EINVAL:
+                assert(false, "Mutex reference is invalid");
+        }
+
+        ret = sem_destroy(&this.jobs_available);
+
+        switch (ret)
+        {
+            case 0:
+                break;
+            default:
+                throw exception.set(ret, "sem_destroy");
+            case EINVAL:
+                assert(false, "Semaphore is not valid.");
+        }
+    }
+
+    /********************************************************************
+
+        Semaphore indicating number of jobs in the request queue.
+
+    ********************************************************************/
+
+    public sem_t jobs_available;
+}

--- a/src/ocean/util/aio/internal/MutexOps.d
+++ b/src/ocean/util/aio/internal/MutexOps.d
@@ -1,0 +1,80 @@
+/*********************************************************************
+
+    Implementation of common mutex operations
+
+    Copyright:
+        Copyright (c) 2018 dunnhumby Germany GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+*********************************************************************/
+
+module ocean.util.aio.internal.MutexOps;
+
+import core.sys.posix.pthread;
+import core.sys.posix.unistd;
+import core.stdc.errno;
+import ocean.sys.ErrnoException;
+
+/*********************************************************************
+
+    Helper function to lock the mutex with the check for
+    the return value and throwing in the case of the error
+    This method must can be executed *ONLY* inside main thread.
+    Otherwise, GC holding glibc's mutex can deadlock, because
+    assert internally allocates memory from GC.
+
+    Params:
+        mutex = pointer to the mutex handle
+        exception = ErrnoException instance to throw
+
+*********************************************************************/
+
+public void lock_mutex (pthread_mutex_t* mutex)
+{
+    int ret = pthread_mutex_lock(mutex);
+
+    switch (ret)
+    {
+        case 0:
+            break;
+        default:
+            throw (new ErrnoException).set(ret, "pthread_mutex_lock");
+        case EINVAL:
+            assert(false, "Mutex reference is invalid");
+        case EDEADLK:
+            assert(false, "The mutex is already locked by this thread");
+    }
+}
+
+/*********************************************************************
+
+    Helper function to unlock the mutex with the check for
+    the return value and throwing in the case of the error
+    This method must be executed *ONLY* inside main thread.
+    Otherwise, GC holding glibc's mutex can deadlock, because
+    assert internally allocates memory from GC.
+
+    Params:
+        mutex = pointer to the mutex handle
+
+*********************************************************************/
+
+public void unlock_mutex (pthread_mutex_t* mutex)
+{
+    int ret = pthread_mutex_unlock(mutex);
+
+    switch (ret)
+    {
+        case 0:
+            break;
+        default:
+            throw (new ErrnoException).set(ret, "pthread_mutex_unlock");
+        case EINVAL:
+            assert(false, "Mutex reference is invalid");
+        case EPERM:
+            assert(false, "The calling thread does not own the mutex");
+    }
+}

--- a/src/ocean/util/aio/internal/ThreadWorker.d
+++ b/src/ocean/util/aio/internal/ThreadWorker.d
@@ -1,0 +1,400 @@
+/******************************************************************************
+
+    Module containing worker thread implementation of AsyncIO.
+
+    In async IO framework, fixed amount of worker threads are taking request
+    from the queue, and performing it (using blocking call which will in turn
+    block this thread). When finished, the worker thread will resume the
+    blocked fiber, and block on the semaphore waiting for the next request.
+
+    Copyright:
+        Copyright (c) 2018 dunnhumby Germany GmbH.
+        All rights reserved.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+******************************************************************************/
+
+module ocean.util.aio.internal.ThreadWorker;
+
+import core.memory;
+import core.stdc.errno;
+import core.sys.posix.semaphore;
+import core.sys.posix.pthread;
+import core.sys.posix.unistd;
+import core.stdc.stdint;
+import core.stdc.stdio;
+import ocean.util.aio.AsyncIO;
+
+import ocean.util.aio.internal.JobQueue;
+
+import core.sys.posix.signal: SIGRTMIN;
+
+extern(C) int pthread_getattr_np(pthread_t thread, pthread_attr_t* attr);
+
+/**************************************************************************
+
+    Thread's entry point.
+
+**************************************************************************/
+
+extern (C) static void* thread_entry_point(ThreadInitializationContext)(void* init_context_ptr)
+{
+    ThreadInitializationContext* init_context = cast(ThreadInitializationContext*)init_context_ptr;
+    JobQueue jobs = init_context.job_queue;
+    typeof(ThreadInitializationContext.makeContext()) context;
+
+    // Block all signals delivered to this thread
+    sigset_t block_set;
+
+    // Return value is ignored here, as this can fail only
+    // because programming error, and we can't use assert here
+    cast(void) sigfillset(&block_set);
+    cast(void)pthread_sigmask(SIG_BLOCK, &block_set, null);
+
+    {
+        thread_lock_mutex(&init_context.init_mutex);
+        scope (exit)
+            thread_unlock_mutex(&init_context.init_mutex);
+
+        if (init_context.makeContext !is null)
+        {
+            context = init_context.makeContext();
+        }
+
+        pthread_attr_t attr;
+        void* stack_addr;
+        size_t stack_size;
+
+        pthread_getattr_np(pthread_self(), &attr);
+        pthread_attr_getstack(&attr, &stack_addr, &stack_size);
+        pthread_attr_destroy(&attr);
+
+        GC.addRange(stack_addr, stack_size);
+
+        init_context.to_create--;
+    }
+
+    pthread_cond_signal(&init_context.init_cond);
+
+    // Wait for new jobs and execute them
+    while (true)
+    {
+        // Current job
+        Job* job;
+
+        // Wait on the semaphore for new jobs
+        while (true)
+        {
+            auto ret = sem_wait(&(jobs.jobs_available));
+
+            if (ret == -1 && .errno != EINTR)
+            {
+                exit_thread(-1);
+            }
+            else if (ret == 0)
+            {
+                break;
+            }
+        }
+
+        // Get the next job, if any
+        job = jobs.takeFirstNonTakenJob(&thread_lock_mutex,
+                &thread_unlock_mutex);
+
+        // No more jobs
+        if (job == null)
+        {
+            break;
+        }
+
+        ssize_t ret_value;
+        switch (job.cmd)
+        {
+            case Job.Command.Read:
+                ret_value = do_pread(job);
+                break;
+            case Job.Command.Write:
+                ret_value = do_write(job);
+                break;
+            case Job.Command.Fsync:
+                ret_value = do_fsync(job);
+                break;
+            case Job.Command.Close:
+                ret_value = do_close(job);
+                break;
+            case Job.Command.CallDelegate:
+                ret_value = do_call_delegate(context, job);
+                break;
+            default:
+                break;
+        }
+
+        job.return_value = ret_value;
+
+        if (ret_value != 0 && job.ret_val !is null)
+        {
+            *job.errno_val = .errno;
+            *job.ret_val = ret_value;
+        }
+
+        // Signal that you have done the job
+        signalJobDone(jobs, job);
+    }
+
+    return cast(void*)0;
+}
+
+
+/**************************************************************************
+
+    Wrapper around fsync call.
+
+    Params:
+        job = job for which the request is executed.
+
+    Returns:
+        0 in case of success, -1 in case of failure
+
+**************************************************************************/
+
+private static ssize_t do_fsync (Job* job)
+{
+    while (true)
+    {
+        auto ret = .fsync(job.fd);
+
+        if (ret == 0 || .errno != EINTR)
+        {
+            return ret;
+        }
+    }
+}
+
+/**************************************************************************
+
+    Wrapper around close call.
+
+    Params:
+        job = job for which the request is executed.
+
+    Returns:
+        0 in case of success, -1 in case of failure
+
+**************************************************************************/
+
+private static ssize_t do_close (Job* job)
+{
+    ssize_t ret;
+
+    do
+    {
+        ret = .close(job.fd);
+    }
+    while (ret != 0 && .errno == EINTR);
+
+    return ret;
+}
+
+/**************************************************************************
+
+    Wrapper around pread call.
+
+    Params:
+        job = job for which the request is executed.
+
+    Returns:
+        number of bytes read, or -1 in case of error.
+
+**************************************************************************/
+
+private static ssize_t do_pread (Job* job)
+{
+    // Now, do the reading!
+    size_t count = 0;
+    while (count < job.recv_buffer.length)
+    {
+        ssize_t read;
+
+        while (true)
+        {
+            read = .pread(job.fd, job.recv_buffer.ptr + count,
+                        job.recv_buffer.length - count, job.offset + count);
+
+            if (read >= 0 || .errno != EINTR)
+            {
+                break;
+            }
+        }
+
+        // Check for the error
+        if (read < 0)
+        {
+            return read;
+        }
+
+        if (read == 0)
+        {
+            // No more data
+            break;
+        }
+
+        count += read;
+    }
+
+    return count;
+}
+
+/**************************************************************************
+
+    Wrapper around write call.
+
+    Params:
+        job = job for which the request is executed.
+
+    Returns:
+        number of bytes writen, or -1 in case of error.
+
+**************************************************************************/
+
+private static ssize_t do_write (Job* job)
+{
+    size_t count = 0;
+    // TODO: check sync_writes here
+    while (count < job.recv_buffer.length)
+    {
+        ssize_t ret;
+
+        while (true)
+        {
+            ret = .write(job.fd, job.recv_buffer.ptr + count,
+                        job.recv_buffer.length - count);
+
+            if (ret >= 0 || .errno != EINTR)
+            {
+                break;
+            }
+        }
+
+        // Check for the error
+        if (ret < 0)
+        {
+            return ret;
+        }
+
+        count += ret;
+    }
+
+    return count;
+}
+
+/**************************************************************************
+
+    Wrapper around call of the arbitrary delegate.
+
+    Params:
+        job = job for which the request is executed.
+
+    Returns:
+        non-zero if the delegate call finishes successfully, zero
+        if the delegate thrown an exception
+
+**************************************************************************/
+
+private static ssize_t do_call_delegate (AsyncIO.Context context, Job* job)
+{
+    try
+    {
+        job.user_delegate(context);
+        return 1;
+    }
+    catch (Exception)
+    {
+        return 0;
+    }
+}
+
+/*********************************************************************
+
+    Helper method to exit the thread and raise a signal
+    in parent AsyncIO
+
+    This method will signal the main thread that this thread has
+    performed the invalid operation from which it can't recover
+    and it will exit the current thread with a return code.
+
+*********************************************************************/
+
+private void exit_thread(int return_code)
+{
+    // getpid is always successful
+    int parent_id = getpid();
+    pthread_kill(parent_id, SIGRTMIN);
+    pthread_exit(cast(void*)return_code);
+}
+
+/*********************************************************************
+
+    Method implementing locking the mutex with non-allocating and non
+    throwing error handling.
+
+    Since this method will be called from the pthread, we must not
+    throw or allocate anything from here.
+
+    Instead, main thread is being signaled and the current thread
+    exits with the -1 value.
+
+    Params:
+        mutex = mutex to perform the operation on
+
+*********************************************************************/
+
+private void thread_lock_mutex (pthread_mutex_t* mutex)
+{
+    if (pthread_mutex_lock(mutex) != 0)
+    {
+        exit_thread(-1);
+    }
+}
+
+/*********************************************************************
+
+    Method implementing unlocking the mutex with non-allocating and non
+    throwing error handling.
+
+    Since this method will be called from the pthread, we must not
+    throw or allocate anything from here.
+
+    Instead, main thread is being signaled and the current thread
+    exits with the -1 value.
+
+    Params:
+        mutex = mutex to perform the operation on
+
+*********************************************************************/
+
+private void thread_unlock_mutex (pthread_mutex_t* mutex)
+{
+    if (pthread_mutex_unlock(mutex) != 0)
+    {
+        exit_thread(-1);
+    }
+}
+
+/**********************************************************************
+
+    Signals that the request has been executed and checks for the
+    cancelation
+
+    Params:
+        jobs = queue containing jobs to be run
+        job = pointer to job containing executed request
+
+**********************************************************************/
+
+private void signalJobDone (JobQueue jobs, Job* job)
+{
+    jobs.markJobReady(job,
+            &thread_lock_mutex, &thread_unlock_mutex);
+}

--- a/src/ocean/util/container/LinkedList.d
+++ b/src/ocean/util/container/LinkedList.d
@@ -950,7 +950,15 @@ class LinkedList (V, alias Reap = Container.reap,
                 bool next (ref V v)
                 {
                         auto n = next;
-                        return (n) ? v = *n, true : false;
+                        if (n)
+                        {
+                            v = *n;
+                            return true;
+                        }
+                        else
+                        {
+                            return false;
+                        }
                 }
 
                 /***************************************************************


### PR DESCRIPTION
This adds support for calling user delegates in a task-blocking fashion which will be then executed in separate threads. This makes it possible to perform blocking system calls (reading from disk or, for example, using `curl_easy_*` API) as a task-blocking operations.

For usage example, see `integrationtests/asyncio/main.d`.  