### PR TITLE
Automatically resume tasks after exception

### DIFF
--- a/relnotes/continuetask.deprecation.md
+++ b/relnotes/continuetask.deprecation.md
@@ -1,0 +1,10 @@
+### Usage of `Task.continueAfterThrow` is not needed anymore
+
+`ocean.task.Task.continueAfterThrow` method has been deprecated and is now
+implemented as no-op. Calls to this method can simply be removed; the required
+cleanup behaviour is now handled automatically by the scheduler. (A task that
+rethrows an unhandled exception to the caller will now be automatically resumed
+by the scheduler for cleanup, using the delayedResume functionality.)
+
+In rare cases when tasks are used without scheduler, caller must resume task
+directly instead of calling `continueAfterThrow`.

--- a/src/ocean/task/IScheduler.d
+++ b/src/ocean/task/IScheduler.d
@@ -325,6 +325,21 @@ public bool isSchedulerUsed ( )
     return _scheduler !is null;
 }
 
+version (UnitTest)
+{
+    /***************************************************************************
+
+        Occasionally useful in tests to drop reference to already initialized
+        scheduler and test some code as if scheduler is not present.
+
+    ***************************************************************************/
+
+    public void dropScheduler ( )
+    {
+        _scheduler = null;
+    }
+}
+
 /*******************************************************************************
 
     Initialized externally from `ocean.task.Scheduler` to reference the same

--- a/src/ocean/task/Scheduler_test.d
+++ b/src/ocean/task/Scheduler_test.d
@@ -69,7 +69,6 @@ unittest
         else
             test!("==")(e.msg, "scheduler");
         caught++;
-        Task.continueAfterThrow();
     };
 
     for (int i = 0; i < 3; ++i)

--- a/src/ocean/task/Task.d
+++ b/src/ocean/task/Task.d
@@ -28,12 +28,15 @@ static import core.thread;
 
 import ocean.transition;
 import ocean.core.array.Mutation : moveToEnd, reverse;
-import ocean.core.Test;
 import ocean.core.Buffer;
 import ocean.core.Verify;
-import ocean.io.select.EpollSelectDispatcher;
 import ocean.io.model.ISuspendable;
 import ocean.task.internal.TaskExtensionMixins;
+
+version (UnitTest)
+{
+    import ocean.core.Test;
+}
 
 debug (TaskScheduler)
 {


### PR DESCRIPTION
Replaces previous ad-hoc solution which scaled terribly with growing
amount of task kinds. Biggest problem of previous solution was that
rethrown exception could be consumed by another caller task instead of
getting to `theScheduler.exception_handler` and thus
`continueAfterThrow` was not called.