### PR TITLE
Make use of AppStatus.terminal_columns field

### DIFF
--- a/src/ocean/io/console/AppStatus.d
+++ b/src/ocean/io/console/AppStatus.d
@@ -1065,7 +1065,7 @@ public class AppStatus
 
     protected char[] truncateLength ( ref char[] buffer )
     {
-        return this.truncateLength(buffer, Terminal.columns);
+        return this.truncateLength(buffer, this.terminal_columns);
     }
 
 


### PR DESCRIPTION
This field was introduced in AppStatus, but the chunk where it
is actually used was not included in the commit.

This makes AppStatus.truncateLength to actually use this.terminal_columns.