### PR TITLE
Move assumeUnique helper function to ocean.core.TypeConvert

### DIFF
--- a/relnotes/assume-unique.migration.md
+++ b/relnotes/assume-unique.migration.md
@@ -1,0 +1,13 @@
+### Move `assumeUnique` to `ocean.core.TypeConvert`
+
+`ocean.core.TypeConvert`, `ocean.transition`
+
+This helper function is not merely transitional: as an ocean counterpart
+to the Phobos `std.exception.assumeUnique` function it will continue to
+be useful even in D2-only code.  The function has therefore been moved
+to an appropriate non-transitional module.
+
+`ocean.transition` retains access to the function via a `public import`,
+so there should be no impact on downstream apps or libraries, but code
+transitioning to D2 only can import the new module in order to bypass
+any `ocean.transition` dependency.

--- a/src/ocean/transition.d
+++ b/src/ocean/transition.d
@@ -24,6 +24,7 @@ module ocean.transition;
 import ocean.meta.traits.Basic;
 import ocean.meta.types.Arrays;
 
+public import ocean.core.TypeConvert : assumeUnique;
 public import ocean.meta.types.Qualifiers;
 public import ocean.meta.types.Typedef;
 
@@ -242,36 +243,6 @@ unittest
     {
         static assert (min_normal!(double) == double.min);
     }
-}
-
-/*******************************************************************************
-
-    Trivial wrapper for a cast from any string to immutable string to make code
-    more readable. Is only legal if no one else has reference to `input`
-    contents.
-
-    NB! D1 does not allow overloading on rvalue vs lvalue, nor it has anything
-    similar to D2 `auto ref` feature. At the same time matching Phobos semantics
-    requires to nullify slice that gets casted to immutable. Because of that
-    our assumeUnique accepts only rvalues - use temporary local variables to
-    assign lvalues if those need to be used with assumeUnique
-
-*******************************************************************************/
-
-Immut!(T)[] assumeUnique(T)(ref T[] input)
-{
-    auto tmp = input;
-    input = null;
-    return cast(Immut!(T)[]) tmp;
-}
-
-unittest
-{
-    auto s1  = "aaa".dup;
-    auto s2 = assumeUnique(s1);
-
-    assert (s2 == "aaa");
-    assert (s1 is null);
 }
 
 /*******************************************************************************


### PR DESCRIPTION
This helper function is not merely transitional: it will continue to be useful in D2-only applications.

A selective `public import` has been added to `ocean.transition` so as to avoid any breaking change for downstream apps and libraries, but the change should allow projects moving to D2 only to have a migration path away from `ocean.transition` while continuing to use `assumeUnique`.