### PR TITLE
Add suspendables to throttler in consistent state 

### DIFF
--- a/src/ocean/io/model/ISuspendableThrottler.d
+++ b/src/ocean/io/model/ISuspendableThrottler.d
@@ -91,6 +91,63 @@ abstract public class ISuspendableThrottler
         }
     }
 
+    version (UnitTest){
+        import ocean.core.Test;
+    }
+    unittest
+    {
+        class SuspendableThrottler : ISuspendableThrottler
+        {
+            override protected bool suspend ( )
+            {
+                return false;
+            }
+
+            override protected bool resume ( )
+            {
+                return false;
+            }
+        }
+
+        class Suspendable : ISuspendable
+        {
+            bool suspended_ = false;
+
+            public void suspend ( )
+            {
+                this.suspended_ = true;
+            }
+
+            public void resume ( )
+            {
+                this.suspended_ = false;
+            }
+
+            public bool suspended ( )
+            {
+                return suspended_;
+            }
+        }
+
+        auto suspendable_throttler = new SuspendableThrottler;
+        auto suspendable = new Suspendable;
+
+        // add a suspended ISuspendable to a non suspended throttler
+        suspendable.suspend();
+        suspendable_throttler.addSuspendable(suspendable);
+
+        test!("==")(suspendable.suspended(), false,
+            "Suspended suspendable not resumed.");
+
+        suspendable_throttler.suspendAll();
+
+        // add a resumed ISuspendable to a suspended throttler
+        suspendable.resume();
+        suspendable_throttler.addSuspendable(suspendable);
+
+        test!("==")(suspendable.suspended(), true,
+            "Resumed suspendable not suspended.");
+    }
 
     /***************************************************************************
 

--- a/src/ocean/io/model/ISuspendableThrottler.d
+++ b/src/ocean/io/model/ISuspendableThrottler.d
@@ -65,7 +65,9 @@ abstract public class ISuspendableThrottler
     /***************************************************************************
 
         Adds a suspendable to the list of suspendables which are to be
-        throttled. If it is already in the list, nothing happens.
+        throttled if it's not already in there.
+        Also ensures that the state of the added suspendable is consistent
+        with the state of the throttler.
 
         Params:
             s = suspendable
@@ -77,10 +79,15 @@ abstract public class ISuspendableThrottler
         if ( !this.suspendables.contains(s) )
         {
             this.suspendables ~= s;
-            if (this.suspended_)
-            {
-                s.suspend();
-            }
+        }
+
+        if (this.suspended_ && !s.suspended())
+        {
+            s.suspend();
+        }
+        else if (!this.suspended_ && s.suspended())
+        {
+            s.resume();
         }
     }
 


### PR DESCRIPTION
This change ensures that the suspend state of an ISuspendable instance
when added to the throttler is consistent with the throttler state.

This patch somehow also works around the the following problem.

If a RequestSuspender instance is reused by a new Request it'll set the suspend_requested flag to false.

https://github.com/sociomantic-tsunami/dhtproto/blob/v14.x.x/src/dhtproto/client/legacy/internal/request/model/IBulkGetRequest.d#L133
https://github.com/sociomantic-tsunami/swarm/blob/v5.x.x/src/swarm/client/request/helper/RequestSuspender.d#L148

When adding this instance to the throttlers list of suspendables it will be already present and therefore neither appended to the list of suspendables nor suspended.

https://github.com/sociomantic-tsunami/ocean/blob/v4.x.x/src/ocean/io/model/ISuspendableThrottler.d#L77

Now if at the same time the application (i.e. the applications throttler) is in suspended state, the request will be started in a non suspended state and will not get suspended at least until the throttler resumes and suspends again.

https://github.com/sociomantic-tsunami/ocean/blob/v4.x.x/src/ocean/io/model/ISuspendableThrottler.d#L139

**Note** that that doesn't address the issue that a suspendable is kept in the list of suspendables when a request finishes (compere also the comment below). The possibility for clients to unregister suspendables from the Throttller when a request finishes will be addressed later.