### PR TITLE
Remove `OwnedTask` from task pools

### DIFF
--- a/relnotes/taskpool.feature.md
+++ b/relnotes/taskpool.feature.md
@@ -1,0 +1,15 @@
+### Change of `StreamProcessor`, `TaskPool` and `ThrottledTaskPool` internals
+
+Also affects `StreamProcessor` as it uses `ThrottledTaskPool` internally.
+
+Both `TaskPool` and `ThrottledTaskPool` stopped defining internal private
+`OwnedTask` to wrap user-supplied type in. Instead, regular termination hook
+infrastructure is used.
+
+Both also don't try to catch and rethrow exceptions arising from a task. This is
+not needed because recycling is already done by the termination hook system.
+
+Overall, only expected observable impact is fixed interaction between
+specialized worker fiber pools and `TaskPool`. However, because of how different
+internal logic is now, it is highly recommended to carefully test applications
+when upgrading.

--- a/relnotes/tasksuspendable.breaking.md
+++ b/relnotes/tasksuspendable.breaking.md
@@ -1,0 +1,19 @@
+### Tasks do not implement ISuspendable interface anymore
+
+This is a breaking change that may cause compilation errors.
+
+Marking `Task` class as implementing `ISuspendable` was a historical mistake
+coming from similarity of methods - and it indeed worked for very simple use
+cases. However, tasks are much more restrictive about when exactly it is legal
+to call `suspend` and `resume` methods while `ISuspendable` expects both to be
+callable at any arbitrary moment.
+
+As a result, trying to use tasks as suspendables has caused several extremely
+hard to debug issues and needs to be prohibited. Originally this change was
+scheduled for v5.0.0 because it is a breaking one, but negative impact of bugs
+occuring because of this mistake has proven to be strong enough to warrant
+immediate upgrade effort.
+
+Any affected code has to be adjusted to use raw epoll events (which are
+registered on `resume` calls and unregistered on `suspend` calls) instead of a
+task.

--- a/src/ocean/task/Task.d
+++ b/src/ocean/task/Task.d
@@ -30,7 +30,6 @@ import ocean.transition;
 import ocean.core.array.Mutation : moveToEnd, reverse;
 import ocean.core.Buffer;
 import ocean.core.Verify;
-import ocean.io.model.ISuspendable;
 import ocean.task.internal.TaskExtensionMixins;
 import ocean.task.IScheduler;
 
@@ -148,7 +147,7 @@ public class TaskKillException : Exception
 
 *******************************************************************************/
 
-public abstract class Task : ISuspendable
+public abstract class Task
 {
     /***************************************************************************
 

--- a/src/ocean/task/util/StreamProcessor_test.d
+++ b/src/ocean/task/util/StreamProcessor_test.d
@@ -78,7 +78,7 @@ class Generator : ISuspendable
 
     void start ( )
     {
-        this.timer.set(0, 10, 0, 10);
+        this.timer.set(0, 1, 0, 1);
         this.resume();
     }
 


### PR DESCRIPTION
It was added as a trick to recycle tasks before termination hook
existed. Now it has become liability.