### PR TITLE
Fix equality expression in ocean/core/Traits

### DIFF
--- a/src/ocean/core/Traits.d
+++ b/src/ocean/core/Traits.d
@@ -2019,7 +2019,7 @@ template ParameterTupleOf( Fn )
         alias Tuple!(Params) ParameterTupleOf;
     else static if( is( Fn Params == delegate ) )
         alias Tuple!(ParameterTupleOf!(Params)) ParameterTupleOf;
-    else static if( is( Fn Params == Params* ) )
+    else static if( is( Fn Params : Params* ) )
         alias Tuple!(ParameterTupleOf!(Params)) ParameterTupleOf;
     else
         static assert( false, "Argument has no parameters." );


### PR DESCRIPTION
This is currently blocking [1]. Short explanation: is expression currently has a bug where if a type is checked for equality with another type, the alias this is considered an exact match. The modified code took advantage of this bug.

[1] https://github.com/dlang/dmd/pull/8839