### PR TITLE
Support copying empty Contiguous instances

### DIFF
--- a/src/ocean/util/serialize/contiguous/Util.d
+++ b/src/ocean/util/serialize/contiguous/Util.d
@@ -43,7 +43,19 @@ import ocean.core.Test;
 
 public Contiguous!(S) copy(S) ( in Contiguous!(S) src, ref Contiguous!(S) dst )
 {
-    Deserializer.deserialize(src.data, dst);
+    // We have to cast away `const` here since the `ptr`
+    // method does not support it.  We are not modifying
+    // anything so we do not break the `in` promise of
+    // the function signature.
+    if ((cast(Contiguous!(S)) src).ptr is null)
+    {
+        dst.reset();
+    }
+    else
+    {
+        Deserializer.deserialize(src.data, dst);
+    }
+
     return dst;
 }
 
@@ -104,6 +116,13 @@ unittest
 
     test!("==")(two.ptr.arr, t.arr);
     two.enforceIntegrity();
+
+    one.reset();
+    test!("is")(one.ptr, null);
+    test!("!is")(two.ptr, null);
+
+    copy(one, two);
+    test!("is")(two.ptr, null);
 }
 
 unittest


### PR DESCRIPTION
The original implementation of `ocean.serialize.contiguous.Util.copy` will throw a `SanityException` if `src` contains no data, because the `Deserializer.deserialize` method requires that underlying struct data is present.

This patch fixes the issue by ensuring `copy` checks `src.ptr` and then if it is `null` resets `dst` instead of deep-copying to it.

Note that we need to temporarily cast away `const`-ness of `src` to work around the fact that the `ptr` method does not currently support it.  We do not modify any underlying data, so this should not break the promise of the `copy` function signature.

Fixes https://github.com/sociomantic-tsunami/ocean/issues/652.