### PR TITLE
Ensure closures script fails if make fails

### DIFF
--- a/ci/closures.sh
+++ b/ci/closures.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
-set -xe
-set -o pipefail
+set -x
 
 # Enables printing of all potential GC allocation sources to stdout
 export DFLAGS=-vgc
 
 # Prepare sources
-beaver dlang make d2conv
+beaver dlang make d2conv || exit 1
 
-# Ensure that there are no lines about closure allocations in the output
-! beaver dlang make fasttest 2>&1 | grep "closure"
+# Run tests and write compiler output to temporary file
+compiler_output=`mktemp`
+beaver dlang make fasttest 2>&1 > $compiler_output || exit 1
+
+# Ensure there are no lines about closure allocations in the output.
+# Note explicit check for `grep` exit status 1, i.e. no lines found.
+grep -e "closure" $compiler_output
+test $? -eq 1 || exit 1


### PR DESCRIPTION
The intent of the script here, and the use of `set -o pipeline`, is that the script should fail if either `make fasttest` fails or `grep` finds a matching line; in other words, if the exit status of `make` is non-zero or that of `grep` is zero.

`-o pipeline` means that non-zero exit statuses from `make` propagate to the exit status of `grep`, but the leading `!` means this is inverted to result in a (falsely) passing test.

Applying the `!` only to the output status of `grep` itself would fix this, but leaves a second problem: `grep` may itself fail, in which case it will report exit status 2.

This patch therefore rewrites the check to use `test` to ensure that the exit status of `grep` is 1.

This should mean that the exit status of the pipeline will be non-zero in any of the following circumstances:

  * `make` fails
  * `grep` fails
  * `grep` finds at least one line containing `closure`

... while if `make` passes and `grep` does not find `closure`, we will get the zero exit status wanted to pass the test.

Note that this may mean that the closure script will now fail for `+d2` auto-converted releases, since the script will apply double conversion to the source code and `make` will hence fail.