### PR TITLE
EmailSender: Fix the envelope sender address

### DIFF
--- a/src/ocean/net/email/EmailSender.d
+++ b/src/ocean/net/email/EmailSender.d
@@ -57,7 +57,7 @@ class EmailSender
 
     public this ( )
     {
-        this.process = new Process("sendmail -t", null);
+        this.process = new Process();
     }
 
 
@@ -162,7 +162,8 @@ class EmailSender
         {
             try
             {
-                execute;
+                setArgs("sendmail", "-t", "-f", sender).execute();
+
                 stdin.write("From: ");
                 stdin.write(sender);
                 stdin.write("\nTo: ");


### PR DESCRIPTION
Set the envelope sender address as it was empty and
this is where delivery problems are sent to.
Merely setting `From` in the header will not be
sufficient and bounces will return to the wrong place.

Also if `From` in the header does not match the envelope
sender, the e-mail could be considered spoofing and gets
rejected.