### PR TITLE
travis: Fix testing of D2 tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,35 +24,37 @@ env:
 # Basic config is inherited from the global scope
 jobs:
     templates:
-        - &test-matrix
+        - &test-matrix-d2
           stage: Test
-          # Don't build tags already converted to D2
-          if: NOT tag =~ \+d2$
           after_success: beaver dlang codecov
           install: beaver dlang install
           script: beaver dlang make
+        - &test-matrix-d1
+          <<: *test-matrix-d2
+          # Don't build tags already converted to D2
+          if: NOT tag =~ \+d2$
     include:
         # Test matrix
-        - <<: *test-matrix
+        - <<: *test-matrix-d1
           env: DMD=1.081.* F=production
-        - <<: *test-matrix
+        - <<: *test-matrix-d1
           env: DMD=1.081.* F=production DFLAGS=-release
-        - <<: *test-matrix
+        - <<: *test-matrix-d1
           env: DMD=1.081.* F=production DFLAGS=-debug=ISelectClient
           script: 2>/dev/null beaver dlang make
-        - <<: *test-matrix
+        - <<: *test-matrix-d1
           env: DMD=1.081.* F=devel
-        - <<: *test-matrix
+        - <<: *test-matrix-d2
           env: DMD=2.071.2.s* F=production
-        - <<: *test-matrix
+        - <<: *test-matrix-d2
           env: DMD=2.071.2.s* F=devel
-        - <<: *test-matrix
+        - <<: *test-matrix-d2
           env: DMD=2.078.3.s* F=production
-        - <<: *test-matrix
+        - <<: *test-matrix-d2
           env: DMD=2.078.3.s* F=devel
-        - <<: *test-matrix
+        - <<: *test-matrix-d2
           env: DMD=2.078.* F=production
-        - <<: *test-matrix
+        - <<: *test-matrix-d2
           env: DMD=2.078.* F=devel
 
         # Additional stages

--- a/ci/closures.sh
+++ b/ci/closures.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
-set -x
+set -xe
 
 # Enables printing of all potential GC allocation sources to stdout
 export DFLAGS=-vgc
 
 # Prepare sources
-beaver dlang make || exit 1
+beaver dlang make
 
 # Run tests and write compiler output to temporary file
 compiler_output=`mktemp`
-beaver dlang make fasttest 2>&1 > $compiler_output || exit 1
+beaver dlang make fasttest 2>&1 > $compiler_output
 
 # Ensure there are no lines about closure allocations in the output.
 # Note explicit check for `grep` exit status 1, i.e. no lines found.
-grep -e "closure" $compiler_output
-test $? -eq 1 || exit 1
+! grep -e "closure" $compiler_output

--- a/ci/closures.sh
+++ b/ci/closures.sh
@@ -5,7 +5,7 @@ set -x
 export DFLAGS=-vgc
 
 # Prepare sources
-beaver dlang make d2conv || exit 1
+beaver dlang make || exit 1
 
 # Run tests and write compiler output to temporary file
 compiler_output=`mktemp`


### PR DESCRIPTION
D2 tags weren't really tested, only checked for closures. Also they were
re-converted due to a combination of a beaver bug and a misuse of beaver
commands.

This commit should fix both problems.

Fixes #674.

```
* submodules/beaver v0.5.2(e3b3351)...v0.6.3+1(bf4ecca) (12 commits)
  > dlang/d2-release: Mark repository as D2_ONLY
  > Fix nested test condition
  > Update copyright owner
  > Create .neptune.yml
  > Merge tag v0.5.2 into v0.6.x v0.5.2
  (...)
```