### PR TITLE
Deprecate/remove `ocean.core.Traits`

### DIFF
--- a/relnotes/traits.deprecation.md
+++ b/relnotes/traits.deprecation.md
@@ -1,0 +1,5 @@
+### Deprecation of `ocean.core.Traits`
+
+`ocean.core.TypeConvert`
+
+Now contains `toDg` utility previously present in `ocean.core.Traits`

--- a/relnotes/traits.deprecation.md
+++ b/relnotes/traits.deprecation.md
@@ -17,3 +17,8 @@ of all aggregate members (non-recursively).
 `ocean.meta.traits.Arrays`
 
 Now contains `rankOfArray` utility previously present in `ocean.core.Traits`.
+
+`ocean.meta.types.Enum`
+
+New module providing `EnumBaseType` utility that reduces enum type to its base
+type.

--- a/relnotes/traits.deprecation.md
+++ b/relnotes/traits.deprecation.md
@@ -22,3 +22,10 @@ Now contains `rankOfArray` utility previously present in `ocean.core.Traits`.
 
 New module providing `EnumBaseType` utility that reduces enum type to its base
 type.
+
+`ocean.core.Traits`
+
+All symbols in this module are deprecated now. Symbols that were not used by any
+of downstream applications got immediately removed. Please follow deprecation
+instructions for each of remaining symbols to switch to appropriate `ocean.meta`
+utility or direct `tupleof` usage.

--- a/relnotes/traits.deprecation.md
+++ b/relnotes/traits.deprecation.md
@@ -3,3 +3,8 @@
 `ocean.core.TypeConvert`
 
 Now contains `toDg` utility previously present in `ocean.core.Traits`
+
+`ocean.meta.codegen.Identifier`
+
+Deprecated `fieldIdentifier` because in D2 it is possible to use plain
+`identifier` template from the same module in all relevant cases.

--- a/relnotes/traits.deprecation.md
+++ b/relnotes/traits.deprecation.md
@@ -13,3 +13,7 @@ Deprecated `fieldIdentifier` because in D2 it is possible to use plain
 
 Now provides `totalMemberSize` trait which calculates sum of individual sizes
 of all aggregate members (non-recursively).
+
+`ocean.meta.traits.Arrays`
+
+Now contains `rankOfArray` utility previously present in `ocean.core.Traits`.

--- a/relnotes/traits.deprecation.md
+++ b/relnotes/traits.deprecation.md
@@ -8,3 +8,8 @@ Now contains `toDg` utility previously present in `ocean.core.Traits`
 
 Deprecated `fieldIdentifier` because in D2 it is possible to use plain
 `identifier` template from the same module in all relevant cases.
+
+`ocean.meta.traits.Aggregates`
+
+Now provides `totalMemberSize` trait which calculates sum of individual sizes
+of all aggregate members (non-recursively).

--- a/src/ocean/core/Traits.d
+++ b/src/ocean/core/Traits.d
@@ -24,127 +24,6 @@ import ocean.transition;
 
 import ocean.core.Tuple: Tuple;
 
-version (UnitTest)
-{
-    import ocean.core.Test;
-
-    /***************************************************************************
-
-        Used as aggregate type argument in all tests
-
-    ***************************************************************************/
-
-    struct TestStruct
-    {
-        int a;
-        int b = 42;
-        double c;
-    }
-}
-
-/*******************************************************************************
-
-    Tells whether the passed string is a D 1.0 keyword.
-
-    This function is designed to be used at compile time.
-
-    Note that any string identifier beginning with __ is also reserved by D 1.0.
-    This function does not check for this case.
-
-    Params:
-        str = string to check
-
-    Returns:
-        true if the string is a D 1.0 keyword
-
-*******************************************************************************/
-
-public bool isKeyword ( cstring str )
-{
-    static immutable istring[] keywords = [
-        "abstract",     "alias",        "align",        "asm",
-        "assert",       "auto",         "body",         "bool",
-        "break",        "byte",         "case",         "cast",
-        "catch",        "cdouble",      "cent",         "cfloat",
-        "char",         "class",        "const",        "continue",
-        "creal",        "dchar",        "debug",        "default",
-        "delegate",     "delete",       "deprecated",   "do",
-        "double",       "else",         "enum",         "export",
-        "extern",       "false",        "final",        "finally",
-        "float",        "for",          "foreach",      "foreach_reverse",
-        "function",     "goto",         "idouble",      "if",
-        "ifloat",       "import",       "in",           "inout",
-        "int",          "interface",    "invariant",    "ireal",
-        "is",           "lazy",         "long",         "macro",
-        "mixin",        "module",       "new",          "null",
-        "out",          "override",     "package",      "pragma",
-        "private",      "protected",    "public",       "real",
-        "ref",          "return",       "scope",        "short",
-        "static",       "struct",       "super",        "switch",
-        "synchronized", "template",     "this",         "throw",
-        "true",         "try",          "typedef",      "typeid",
-        "typeof",       "ubyte",        "ucent",        "uint",
-        "ulong",        "union",        "unittest",     "ushort",
-        "version",      "void",         "volatile",     "wchar",
-        "while",        "with"
-    ];
-
-    for ( int i; i < keywords.length; i++ )
-    {
-        if ( str == keywords[i] ) return true;
-    }
-    return false;
-}
-
-
-
-/*******************************************************************************
-
-    Tells whether the passed string is a valid D 1.0 identifier.
-
-    This function is designed to be used at compile time.
-
-    Note that this function does not check whether the passed string is a D
-    keyword (see isKeyword(), above) -- all keywords are also identifiers.
-
-    Params:
-        input = string to check
-
-    Returns:
-        true if the string is a valid D 1.0 identifier
-
-*******************************************************************************/
-
-public bool isIdentifier ( cstring input )
-{
-    bool alphaUnderscore ( char c )
-    {
-        return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
-    }
-
-    bool validChar ( char c )
-    {
-        return alphaUnderscore(c) || (c >= '0' && c <= '9');
-    }
-
-    // Identifiers must have a length
-    if ( input.length == 0 ) return false;
-
-    // Identifiers must begin with an alphabetic or underscore character
-    if ( !alphaUnderscore(input[0]) ) return false;
-
-    // Strings beginning with "__" are reserved (not identifiers)
-    if ( input.length > 1 && input[0] == '_' && input[1] == '_' ) return false;
-
-    // All characters after the first must be alphanumerics or underscores
-    for ( int i = 1; i < input.length; i++ )
-    {
-        if ( !validChar(input[i]) ) return false;
-    }
-
-    return true;
-}
-
 /*******************************************************************************
 
     If T is enum, aliases to its base type. Otherwise aliases to T.
@@ -154,6 +33,7 @@ public bool isIdentifier ( cstring input )
 
 *******************************************************************************/
 
+deprecated("Use ocean.meta.types.Enum.EnumBaseType")
 public template StripEnum(T)
 {
     static if (is(T U == enum))
@@ -164,16 +44,6 @@ public template StripEnum(T)
     {
         alias T StripEnum;
     }
-}
-
-unittest
-{
-    enum Test : int
-    {
-        field = 42
-    }
-
-    static assert (is(StripEnum!(typeof(Test.field)) == int));
 }
 
 /*******************************************************************************
@@ -197,6 +67,7 @@ unittest
 
 *******************************************************************************/
 
+deprecated("Use ocean.meta.traits.Basic.isPrimitiveType")
 public template isPrimitiveType ( T )
 {
     static immutable isPrimitiveType =
@@ -225,6 +96,7 @@ public template isPrimitiveType ( T )
 
 *******************************************************************************/
 
+deprecated("Use ocean.meta.traits.Indirections.hasIndirections")
 public template hasIndirections ( T... )
 {
     static immutable hasIndirections = hasIndirectionsImpl!(T)();
@@ -276,40 +148,7 @@ private bool hasIndirectionsImpl ( T... )()
     assert(false);
 }
 
-unittest
-{
-    static assert (hasIndirections!(int) == false);
-    static assert (hasIndirections!(int[int]) == true);
-    static assert (!hasIndirections!(void));
-    static if (is(int function() F == F*))
-    {
-        static assert (!hasIndirections!(F));
-    }
-    else
-    {
-        static assert(false, "function pointer base type derivation failed");
-    }
-}
-
-
-/*******************************************************************************
-
-    Checks if T or any of its subtypes is a multi-dimensional dynamic array.
-
-    T and all of its subtypes, if any, are expected to be
-      - an atomic type or
-      - a dynamic or static array or
-      - a struct or a union.
-
-    Params:
-        T = type to check
-
-    Returns:
-        true if T or any of its subtypes is a multi-dimensional dynamic array or
-        false otherwise.
-
-*******************************************************************************/
-
+deprecated("Use ocean.meta.traits.containsMultiDimensionalDynamicArrays")
 public template hasMultiDimensionalDynamicArrays ( T )
 {
     /*
@@ -321,11 +160,6 @@ public template hasMultiDimensionalDynamicArrays ( T )
 
     static immutable typeof(hasMultiDimensionalDynamicArraysImpl!(T)()) hasMultiDimensionalDynamicArrays = hasMultiDimensionalDynamicArraysImpl!(T)();
 }
-
-/*
- * This is a CTFE function rather than a template to allow for 'foreach' over
- * a type tuple and prevent the Type alias from interfering.
- */
 
 private bool hasMultiDimensionalDynamicArraysImpl ( T ) ()
 {
@@ -373,68 +207,7 @@ private bool hasMultiDimensionalDynamicArraysImpl ( T ) ()
     }
 }
 
-unittest
-{
-    static assert(!hasMultiDimensionalDynamicArrays!(int));
-    static assert(!hasMultiDimensionalDynamicArrays!(int[ ]));
-    static assert(!hasMultiDimensionalDynamicArrays!(int[3]));
-
-    static assert( hasMultiDimensionalDynamicArrays!(int[ ][ ]));
-    static assert(!hasMultiDimensionalDynamicArrays!(int[3][ ]));
-    static assert(!hasMultiDimensionalDynamicArrays!(int[ ][3]));
-    static assert(!hasMultiDimensionalDynamicArrays!(int[3][3]));
-
-    static assert( hasMultiDimensionalDynamicArrays!(int[ ][ ][ ]));
-    static assert( hasMultiDimensionalDynamicArrays!(int[3][ ][ ]));
-    static assert(!hasMultiDimensionalDynamicArrays!(int[ ][3][ ]));
-    static assert(!hasMultiDimensionalDynamicArrays!(int[3][3][ ]));
-    static assert( hasMultiDimensionalDynamicArrays!(int[ ][ ][3]));
-    static assert(!hasMultiDimensionalDynamicArrays!(int[3][ ][3]));
-    static assert(!hasMultiDimensionalDynamicArrays!(int[ ][3][3]));
-    static assert(!hasMultiDimensionalDynamicArrays!(int[3][3][3]));
-
-    static assert(!hasMultiDimensionalDynamicArrays!(void));
-    static assert(!hasMultiDimensionalDynamicArrays!(void[]));
-    static assert( hasMultiDimensionalDynamicArrays!(void[][]));
-    static assert(!hasMultiDimensionalDynamicArrays!(void[][3]));
-
-    struct A
-    {
-        int x;
-        char[] y;
-        float[][][3][] z;
-    }
-
-    struct B
-    {
-        A[] a;
-    }
-
-    static assert(hasMultiDimensionalDynamicArrays!(A));
-
-    struct C
-    {
-        int x;
-        float[][3][] y;
-        char[] z;
-    }
-
-    static assert(!hasMultiDimensionalDynamicArrays!(C));
-}
-
-/*******************************************************************************
-
-    Template which evaluates to true if the specified type is a compound type
-    (ie a class, struct or union).
-
-    Params:
-        T = type to check
-
-    Evaluates to:
-        true if T is a compound type, false otherwise
-
-*******************************************************************************/
-
+deprecated("Use ocean.meta.traits.Basic.isAggregateType")
 public template isCompoundType ( T )
 {
     static if ( is(T == struct) || is(T == class) || is(T== union) )
@@ -447,25 +220,7 @@ public template isCompoundType ( T )
     }
 }
 
-unittest
-{
-    static assert (!isCompoundType!(int));
-    static assert ( isCompoundType!(TestStruct));
-}
-
-
-/*******************************************************************************
-
-    Template to get the type tuple of compound type T.
-
-    Params:
-        T = type to get type tuple of
-
-    Evaluates to:
-        type tuple of T's members
-
-*******************************************************************************/
-
+deprecated("Use typeof(T.tupleof)")
 public template TypeTuple ( T )
 {
     static if ( !isCompoundType!(T) )
@@ -476,24 +231,7 @@ public template TypeTuple ( T )
     alias typeof(T.tupleof) TypeTuple;
 }
 
-unittest
-{
-    static assert (is(TypeTuple!(TestStruct)[0] == int));
-}
-
-
-/*******************************************************************************
-
-    Template to get the type of the ith data member struct/class T.
-
-    Params:
-        T = type to get field of
-
-    Evaluates to:
-        type of ith member of T
-
-*******************************************************************************/
-
+deprecated("Use T.tupleof[i]")
 public template FieldType ( T, size_t i )
 {
     static if ( !isCompoundType!(T) )
@@ -503,12 +241,6 @@ public template FieldType ( T, size_t i )
 
     alias typeof (T.tupleof)[i] FieldType;
 }
-
-unittest
-{
-    static assert (is(FieldType!(TestStruct, 0) == int));
-}
-
 
 /*******************************************************************************
 
@@ -526,18 +258,11 @@ unittest
 
 *******************************************************************************/
 
+deprecated("Use &t.tupleof[i]")
 public FieldType!(T, i)* GetField ( size_t i, T ) ( T* t )
 {
     return GetField!(i, FieldType!(T, i), T)(t);
 }
-
-unittest
-{
-    TestStruct s;
-    auto x = GetField!(1)(&s);
-    test(*x == 42);
-}
-
 
 /*******************************************************************************
 
@@ -556,6 +281,7 @@ unittest
 
 *******************************************************************************/
 
+deprecated("Use &t.tupleof[i]")
 public M* GetField ( size_t i, M, T ) ( T* t )
 {
     static if ( !isCompoundType!(T) )
@@ -564,13 +290,6 @@ public M* GetField ( size_t i, M, T ) ( T* t )
     }
 
     return cast(M*)((cast(void*)t) + T.tupleof[i].offsetof);
-}
-
-unittest
-{
-    TestStruct s;
-    auto x = GetField!(1, int)(&s);
-    test(*x == 42);
 }
 
 /*******************************************************************************
@@ -586,6 +305,7 @@ unittest
 
 *******************************************************************************/
 
+deprecated("Use ocean.meta.codegen.Identifier.identifier!(T.tupleof[i])")
 public template FieldName ( size_t i, T )
 {
     static if ( !isCompoundType!(T) )
@@ -595,24 +315,6 @@ public template FieldName ( size_t i, T )
 
     static immutable FieldName = StripFieldName!(T.tupleof[i].stringof);
 }
-
-unittest
-{
-    static assert (FieldName!(0, TestStruct) == "a");
-}
-
-/*******************************************************************************
-
-    Template to strip the part after the '.' in a string.
-
-    Template parameter:
-        name = string to scan
-        n = scanning index
-
-    Evaluates to:
-        tail of name after the last '.' character
-
-*******************************************************************************/
 
 private template StripFieldName ( istring name, size_t n = size_t.max )
 {
@@ -634,20 +336,7 @@ private template StripFieldName ( istring name, size_t n = size_t.max )
     }
 }
 
-
-
-/*******************************************************************************
-
-    Template to get the size in bytes of the passed type tuple.
-
-    Template parameter:
-        Tuple = variadic type tuple
-
-    Evaluates to:
-        size_t constant equal to the sizeof each type in the tuple
-
-*******************************************************************************/
-
+deprecated("Use ocean.meta.traits.Aggregates.totalMemberSize")
 public template SizeofTuple ( Tuple ... )
 {
     static if ( Tuple.length > 0 )
@@ -660,31 +349,7 @@ public template SizeofTuple ( Tuple ... )
     }
 }
 
-unittest
-{
-    static assert (SizeofTuple!(Tuple!(byte, byte, byte)) == 3);
-}
-
-/*******************************************************************************
-
-    Function which iterates over the type tuple of T and copies all fields from
-    one instance to another. Note that, for classes, according to:
-
-        http://digitalmars.com/d/1.0/class.html
-
-    "The .tupleof property returns an ExpressionTuple of all the fields in the
-    class, excluding the hidden fields and the fields in the base class."
-
-    (This is not actually true with current versions of the compiler, but
-    anyway.)
-
-    Params:
-        T = type of instances to copy fields from and to
-        dst = instance of type T to be copied into
-        src = instance of type T to be copied from
-
-*******************************************************************************/
-
+deprecated("Use `dst.tupleof[] = src.tupleof[]`")
 public void copyFields ( T ) ( ref T dst, ref T src )
 {
     foreach ( i, t; typeof(dst.tupleof) )
@@ -693,21 +358,7 @@ public void copyFields ( T ) ( ref T dst, ref T src )
     }
 }
 
-///
-unittest
-{
-    TestStruct a, b;
-    copyFields(a, b);
-}
-
-/*******************************************************************************
-
-    Version of `copyFields` with modified declaration so that it doesn't
-    accept class reference by ref. Doing so with plain `copyFields` caused
-    deprecation warning in D2 otherwise, "Deprecation: this is not an lvalue".
-
-*******************************************************************************/
-
+deprecated("Use `dst.tupleof[] = src.tupleof[]`")
 public void copyClassFields ( T ) ( T dst, T src )
 {
     static assert (is(T == class));
@@ -718,187 +369,19 @@ public void copyClassFields ( T ) ( T dst, T src )
     }
 }
 
-///
-unittest
-{
-    static class C
-    {
-        int x;
-
-        void copy ( )
-        {
-            C c = new C;
-            copyClassFields(this, c);
-        }
-    }
-}
-
-/*******************************************************************************
-
-    Function which iterates over the type tuple of T and sets all fields of the
-    provided instance to their default (.init) values. Note that, for classes,
-    according to:
-
-        http://digitalmars.com/d/1.0/class.html
-
-    "The .tupleof property returns an ExpressionTuple of all the fields in the
-    class, excluding the hidden fields and the fields in the base class."
-
-    (This is not actually true with current versions of the compiler, but
-    anyway.)
-
-    Params:
-        T = type of instances to initialise
-        o = instance of type T to be initialised
-
-*******************************************************************************/
-
-public void initFields ( T ) ( ref T o )
-{
-    foreach ( i, t; typeof(o.tupleof) )
-    {
-        o.tupleof[i] = o.tupleof[i].init;
-    }
-}
-
-unittest
-{
-    auto s = TestStruct(10, 10, 10.0);
-    initFields(s);
-    // test(s.b == 42); // DMD1 BUG!
-    test(s.b == 0);
-}
-
-
-/*******************************************************************************
-
-    Template to determine if a type tuple is composed of unique types, with no
-    duplicates.
-
-    Template parameter:
-        Tuple = variadic type tuple
-
-    Evaluates to:
-        true if no duplicate types exist in Tuple
-
-    TODO: could be re-phrased in terms of ocean.core.Tuple : Unique
-
-*******************************************************************************/
-
-public template isUniqueTypesInTuple ( Tuple ... )
-{
-    static if ( Tuple.length > 1 )
-    {
-        static immutable bool isUniqueTypesInTuple = (CountTypesInTuple!(Tuple[0], Tuple) == 1) && isUniqueTypesInTuple!(Tuple[1..$]);
-    }
-    else
-    {
-        static immutable bool isUniqueTypesInTuple = true;
-    }
-}
-
-unittest
-{
-    static assert ( isUniqueTypesInTuple!(Tuple!(int, double, float)));
-    static assert (!isUniqueTypesInTuple!(Tuple!(int, int, float)));
-}
-
-
-/*******************************************************************************
-
-    Template to count the number of times a specific type appears in a tuple.
-
-    Template parameter:
-        Type = type to count
-        Tuple = variadic type tuple
-
-    Evaluates to:
-        number of times Type appears in Tuple
-
-    TODO: could be re-phrased in terms of ocean.core.Tuple : Unique
-
-*******************************************************************************/
-
-public template CountTypesInTuple ( Type, Tuple ... )
-{
-    static if ( Tuple.length > 0 )
-    {
-        static immutable uint CountTypesInTuple = is(Type == Tuple[0]) + CountTypesInTuple!(Type, Tuple[1..$]);
-    }
-    else
-    {
-        static immutable uint CountTypesInTuple = 0;
-    }
-}
-
-unittest
-{
-    static assert (CountTypesInTuple!(int, Tuple!(int, double, int)) == 2);
-}
-
-/*******************************************************************************
-
-    Typedef has been removed in D2 and this template will always evaluate to
-    false.
-
-    Evaluates to:
-        T = type to check
-        true if T is a typedef, false otherwise
-
-*******************************************************************************/
-
+deprecated("Either use ocean.meta.traits.Typedef or remove the check")
 public template isTypedef (T)
 {
     static immutable bool isTypedef = false;
 }
 
-unittest
-{
-    mixin(Typedef!(int, "MyInt"));
-    static assert (!isTypedef!(MyInt)); // just a struct
-}
-
-/*******************************************************************************
-
-    Typedef has been removed in D2 and this template is a no-op
-
-    Params:
-        T = type to strip of typedef
-
-    Evaluates to:
-        alias to either T (if T is not typedeffed) or the base class of T
-
-*******************************************************************************/
-
+deprecated("Either use ocean.meta.traits.Typedef or remove the check")
 public template StripTypedef (T)
 {
     alias T StripTypedef;
 }
 
-unittest
-{
-    mixin(Typedef!(int, "MyInt"));
-    static assert (is(StripTypedef!(MyInt) == MyInt));
-}
-
-/******************************************************************************
-
-    Tells whether the types in T are or contain dynamic arrays, recursing into
-    the member types of structs and union, the element types of dynamic and
-    static arrays and typedefs.
-
-    Reference types other than dynamic arrays (classes, pointers, functions,
-    delegates and associative arrays) are ignored and not recursed into.
-
-    Template parameter:
-        T = types to check
-
-    Evaluates to:
-        true if any type in T is a or contains dynamic arrays or false if not
-        or T is empty.
-
- ******************************************************************************/
-
+deprecated("Use ocean.meta.traits.Indirections.containsDynamicArray")
 template ContainsDynamicArray ( T ... )
 {
     static if (T.length)
@@ -951,29 +434,6 @@ template ContainsDynamicArray ( T ... )
     }
 }
 
-unittest
-{
-    static assert (!ContainsDynamicArray!(TestStruct));
-    mixin (Typedef!(int[], "MyInt"));
-    static assert ( ContainsDynamicArray!(MyInt));
-
-    static struct S
-    {
-        mstring s;
-    }
-
-    static assert ( ContainsDynamicArray!(Const!(S)));
-
-    static struct S2
-    {
-        struct Arr { Const!(int[]) x; }
-        Arr[3][4] arr;
-    }
-
-    static assert(ContainsDynamicArray!(Immut!(S2)));
-}
-
-
 /*******************************************************************************
 
     Evaluates, if T is callable (function, delegate, a class/interface/struct/
@@ -991,6 +451,7 @@ unittest
 
 *******************************************************************************/
 
+deprecated("Use ocean.meta.types.Function.ParametersOf and ReturnTypeOf")
 template ReturnAndArgumentTypesOf ( T )
 {
     static if (isTypedef!(T))
@@ -1015,192 +476,15 @@ template ReturnAndArgumentTypesOf ( T )
     }
 }
 
-/******************************************************************************/
+import ocean.core.TypeConvert;
+deprecated("Use ocean.core.TypeConvert.toDg")
+public alias toDg = ocean.core.TypeConvert.toDg;
 
-unittest
-{
-    static assert(is(ReturnAndArgumentTypesOf!(void) == Tuple!()));
-    static assert(is(ReturnAndArgumentTypesOf!(int) == Tuple!()));
-    static assert(is(ReturnAndArgumentTypesOf!(void function()) == Tuple!(void)));
-    static assert(is(ReturnAndArgumentTypesOf!(int function(char)) == Tuple!(int, char)));
-    static if (is(int function(char) T: T*))
-    {
-        static assert(is(ReturnAndArgumentTypesOf!(T) == Tuple!(int, char)));
-    }
-    static assert(is(ReturnAndArgumentTypesOf!(int delegate(char)) == Tuple!(int, char)));
-
-    class C {int opCall(char){return 0;}}
-    class D {static int opCall(char){return 0;}}
-    class E {int opCall;}
-    interface I {int opCall(char);}
-    struct S {int opCall(char){return 0;}}
-    union U {int opCall(char){return 0;}}
-
-    static assert(is(ReturnAndArgumentTypesOf!(C) == Tuple!(int, char)));
-    static assert(is(ReturnAndArgumentTypesOf!(D) == Tuple!(int, char)));
-    static assert(is(ReturnAndArgumentTypesOf!(E) == Tuple!()));
-    static assert(is(ReturnAndArgumentTypesOf!(I) == Tuple!(int, char)));
-    static assert(is(ReturnAndArgumentTypesOf!(S) == Tuple!(int, char)));
-    static assert(is(ReturnAndArgumentTypesOf!(U) == Tuple!(int, char)));
-
-    // Check hasIndirections
-
-    struct NoIndirections
-    {
-        struct Z
-        {
-            int f,g;
-        }
-        int a;
-        long b;
-        byte c;
-        union U
-        {
-            char e;
-            char[2] arr;
-        }
-
-        U u;
-        Z q;
-    }
-
-    static assert ( hasIndirections!(NoIndirections) == false );
-
-    struct Arrays
-    {
-        int a;
-        int[] b;
-    }
-
-    static assert ( hasIndirections!(Arrays) );
-
-    struct Ptr
-    {
-        int* a;
-    }
-
-    static assert ( hasIndirections!(Arrays) );
-
-    struct Class
-    {
-        class A {}
-        A a;
-    }
-
-    static assert ( hasIndirections!(Class) );
-
-    struct Asso
-    {
-        char[int] a;
-    }
-
-    static assert ( hasIndirections!(Asso) );
-
-    struct Dg
-    {
-        void delegate ( ) a;
-    }
-
-    static assert ( hasIndirections!(Dg) );
-
-    struct Func
-    {
-        void function ( ) a;
-    }
-
-    static assert ( hasIndirections!(Func) );
-}
-
-/*******************************************************************************
-
-    Helper function to wrap any callable type in a delegate. Most useful when
-    you need to pass function pointer as a delegate argument.
-
-    This function allocates a closure class for a delegate.
-
-    NB! toDg does not preserve any argument attributes of Func such as ref or
-    lazy.
-
-    Params:
-        f = function or function pointer or delegate
-
-    Returns:
-        delegate that internally calls f and does nothing else
-
-*******************************************************************************/
-
-ReturnTypeOf!(Func) delegate (ParameterTupleOf!(Func)) toDg ( Func ) ( Func f )
-{
-    static assert (
-        is(Func == ReturnTypeOf!(Func) function (ParameterTupleOf!(Func))),
-        "toDg does not preserve argument attributes!"
-    );
-
-    alias ParameterTupleOf!(Func) ParameterTypes;
-
-    class Closure
-    {
-        private Func func;
-
-        this (Func func)
-        {
-            this.func = func;
-        }
-
-        ReturnTypeOf!(Func) call (ParameterTypes args)
-        {
-            return this.func(args);
-        }
-    }
-
-    auto closure = new Closure(f);
-
-    return &closure.call;
-}
-
-version ( UnitTest )
-{
-    int testToDgFoo() { return 42; }
-
-    void testToDgBar(int a, int b)
-    {
-        assert (a == 3);
-        assert (b == 4);
-    }
-
-    int testToDgBad(ref int x) { return x; }
-}
-
-unittest
-{
-    static assert (is(typeof(toDg(&testToDgFoo)) == int delegate()));
-    test (toDg(&testToDgFoo)() == 42);
-
-    toDg(&testToDgBar)(3, 4);
-
-    static assert(!is(typeof(toDg(&testToDgBad))));
-}
-
-/*******************************************************************************
-
-    Check if a class, struct, interface, or union type contains a method with
-    the given method name, and has the same signature as the given delegate.
-
-    Params:
-        T = The type to check
-        name = The name of the method to look up
-        Dg = The delegate type with the signature of the method to look for
-
-    Evaluates to:
-        True if the given type contains the method, false otherwise
-
-*******************************************************************************/
-
+deprecated("Use ocean.meta.traits.Aggregates.hasMethod")
 template hasMethod ( T, istring name, Dg )
 {
     static assert(is(T == struct) || is(T == class) || is(T == union) ||
         is(T == interface));
-    static assert(isIdentifier(name));
     static assert(is(Dg == delegate));
 
     static if ( is(typeof( { Dg dg = mixin("&T.init." ~ name); } )) )
@@ -1213,85 +497,7 @@ template hasMethod ( T, istring name, Dg )
     }
 }
 
-version ( UnitTest )
-{
-    template Methods ( )
-    {
-        void reset ( ) { }
-        int retint ( ) { return 0; }
-        int retintargs ( int ) { return 0; }
-        int retintargs2 ( int, float, char ) { return 0; }
-    }
-
-    template Tests ( T )
-    {
-        static assert( hasMethod!(T, "reset", void delegate()) );
-        static assert( !hasMethod!(T, "reset", int delegate()) );
-        static assert( !hasMethod!(T, "reset", void delegate(int)) );
-        static assert( !hasMethod!(T, "whatever", void delegate()) );
-        static assert( hasMethod!(T, "retint", int delegate()) );
-        static assert( hasMethod!(T, "retintargs", int delegate(int)) );
-        static assert( hasMethod!(T, "retintargs2", int delegate(int, float, char)) );
-        static assert( !hasMethod!(T, "retintargs2", int delegate(char, float, int)) );
-    }
-}
-
-unittest
-{
-    struct Struct
-    {
-        mixin Methods;
-    }
-
-    mixin Tests!(Struct);
-
-    class Base
-    {
-        void baseMethodVoid ( ) { }
-        int baseMethodInt ( ) { return 0; }
-        int baseMethodIntArgs ( int, float, char ) { return 0; }
-    }
-
-    class Class : Base
-    {
-        mixin Methods;
-    }
-
-    mixin Tests!(Class);
-
-    static assert ( hasMethod!(Class, "baseMethodVoid", void delegate()) );
-    static assert ( !hasMethod!(Class, "baseMethodVoid", int delegate()) );
-    static assert ( !hasMethod!(Class, "baseMethodVoid", void delegate(int)) );
-    static assert ( hasMethod!(Class, "baseMethodInt", int delegate()) );
-    static assert ( hasMethod!(Class, "baseMethodIntArgs", int delegate(int, float, char)) );
-
-    interface Interface
-    {
-        void reset ( );
-        int retint ( );
-        int retintargs ( int );
-        int retintargs2 ( int, float, char );
-    }
-
-    mixin Tests!(Interface);
-
-    union Union
-    {
-        mixin Methods;
-    }
-
-    mixin Tests!(Union);
-}
-
-/*******************************************************************************
-
-    Returns "name" (identifier) of a given symbol as string
-
-    Params:
-        Sym = any symbol alias
-
-*******************************************************************************/
-
+deprecated("Use ocean.meta.codegen.Identifier.identifier")
 public template identifier(alias Sym)
 {
     static immutable identifier = _identifier!(Sym)();
@@ -1316,173 +522,20 @@ private istring _identifier(alias Sym)()
     }
 }
 
-///
-unittest
-{
-    class ClassName { }
-    void funcName ( ) { }
-    extern(C) void funcNameArgs ( int a, double b ) { }
-
-    static assert (identifier!(ClassName) == "ClassName");
-    test (identifier!(ClassName) == "ClassName");
-
-    static assert (identifier!(funcName) == "funcName");
-    test (identifier!(funcName) == "funcName");
-
-    static assert (identifier!(funcNameArgs) == "funcNameArgs");
-    test (identifier!(funcNameArgs) == "funcNameArgs");
-}
-
-unittest
-{
-    // #741 regression test
-
-    static void foo () {}
-    testNoAlloc({ auto str = identifier!(foo); } ());
-}
-
-
-/*******************************************************************************
-
-    Get key and value type of an associative array in D1 (and D2)
-
-    In D2, one would check if a type `T` is an associative array (and
-    get its key / value type in scope) by using an `is` expression:
-
-    ---
-    static if (is(T V : V[K], K))
-        pragma(msg, "Key type: ", K, ", value type: ", V);
-    ---
-
-    Sadly D1 doesn't support this syntax.  However we can use type matching
-    in template argument to work around this problem.
-
-    The above example would then be rewritten as:
-
-    ---
-    static if (is(AAType!(T).Key))
-        pragma(msg, "Key type: ", AAType!(T).Key, ", value type: ",
-                AAType!(T).Value);
-    ---
-
-    Params:
-        T   = Associative array type
-        V   = Type of the AA value (deduced from the first arg)
-        K   = Type of the AA key (deduced from the first arg)
-
-*******************************************************************************/
-
+deprecated("Use ocean.meta.types.Arrays.ElementTypeOf")
 public template AAType (T : V[K], V, K)
 {
-    /***************************************************************************
-
-        Key type for the AA
-
-    ***************************************************************************/
-
     public alias K Key;
-
-
-    /***************************************************************************
-
-        Value type for the AA
-
-    ***************************************************************************/
-
     public alias V Value;
 }
 
-unittest
-{
-    static assert(is(AAType!(ushort[ulong]).Key == ulong));
-    static assert(is(AAType!(ushort[ulong]).Value == ushort));
-
-    static assert(is(AAType!(istring[Object]).Key == Object));
-    static assert(is(AAType!(istring[Object]).Value == istring));
-
-    static assert(!is(AAType!(istring[]).Key));
-    static assert(!is(AAType!(istring[]).Value));
-
-    static assert(!is(AAType!(int[42]).Key));
-    static assert(!is(AAType!(int[42]).Value));
-
-    static assert(!is(AAType!(Object).Key));
-    static assert(!is(AAType!(Object).Value));
-}
-
-/*******************************************************************************
-
-    Emulates `static if (Type : Template!(Args), Args...)`, which is a D2
-    feature
-
-    Given a template and an instance of it, allows to get the arguments used
-    to instantiate this type.
-
-    An example use case is when you want to wrap an aggregate which is templated
-    and need your `Wrapper` class to be templated on the aggregate's template
-    arguments:
-    ---
-    class Wrapper (TArgs...) { /+ Magic stuff +/ }
-    class Aggregate (TArgs...) { /+ Some more magic +/ }
-
-    Wrapper!(TemplateInstanceArgs!(Aggregate, Inst)) wrap (Inst) (Inst i)
-    {
-        auto wrapper = new Wrapper!(TemplateInstanceArgs!(Aggregate, Inst))(i);
-        return wrapper;
-    }
-    ---
-
-    This can also be used to see if a given symbol is an instance of a template:
-    `static if (is(TemplateInstanceArgs!(Template, PossibleInstance)))`
-
-    Note that eponymous templates can lead to surprising behaviour:
-    ---
-    template Identity (T)
-    {
-        alias T Identity;
-    }
-
-    // The following will fail, because `Identity!(char)` resolves to `char` !
-    static assert(is(TemplateInstanceArgs!(Identity, Identity!(char))));
-    ---
-
-    As a result, this template is better suited for template aggregates,
-    or templates with multiple members.
-
-    Params:
-        Template = The template symbol (uninstantiated)
-        Type     = An instance of `Template`
-
-*******************************************************************************/
-
+deprecated("Use ocean.meta.traits.Templates.TemplateInstanceArgs")
 public template TemplateInstanceArgs (alias Template, Type : Template!(TA), TA...)
 {
     public alias TA TemplateInstanceArgs;
 }
 
-version (UnitTest)
-{
-    private class BaseTestClass (T) {}
-    private class DerivedTestClass (T) : BaseTestClass!(T) {}
-}
-
-unittest
-{
-    // Same type
-    static assert (is(TemplateInstanceArgs!(BaseTestClass, BaseTestClass!(cstring))));
-    // Derives
-    static assert (is(TemplateInstanceArgs!(BaseTestClass, DerivedTestClass!(cstring))));
-    // Not a template
-    static assert (!is(TemplateInstanceArgs!(Object, BaseTestClass!(int))));
-    // Not a type
-    static assert (!is(TemplateInstanceArgs!(BaseTestClass, BaseTestClass)));
-    // Doesn't derive / convert
-    static assert (!is(TemplateInstanceArgs!(int, BaseTestClass)));
-}
-
-/**
- * Evaluates to true if T is char[], wchar[], or dchar[].
- */
+deprecated("Use ocean.meta.traits.Basic.isStringType")
 template isStringType( T )
 {
     static immutable bool isStringType = is( T : char[] )  ||
@@ -1493,16 +546,7 @@ template isStringType( T )
                               is( T : mstring );
 }
 
-unittest
-{
-    static assert (isStringType!(dchar[]));
-    static assert (isStringType!(istring));
-    static assert (isStringType!(cstring));
-}
-
-/**
- * Evaluates to true if T is char, wchar, or dchar.
- */
+deprecated("Use ocean.meta.traits.Basic.isCharType")
 template isCharType( T )
 {
     static immutable bool isCharType =
@@ -1511,16 +555,7 @@ template isCharType( T )
      || is( Unqual!(T) == dchar );
 }
 
-unittest
-{
-    static assert (isCharType!(wchar));
-    static assert (isCharType!(Const!(char)));
-}
-
-
-/**
- * Evaluates to true if T is a signed integer type.
- */
+deprecated("Use ocean.meta.traits.Basic.isSignedIntegerType")
 template isSignedIntegerType( T )
 {
     static immutable bool isSignedIntegerType =
@@ -1530,17 +565,7 @@ template isSignedIntegerType( T )
      || is( Unqual!(T) == long );
 }
 
-unittest
-{
-    static assert ( isSignedIntegerType!(int));
-    static assert ( isSignedIntegerType!(Const!(long)));
-    static assert (!isSignedIntegerType!(ubyte));
-}
-
-
-/**
- * Evaluates to true if T is an unsigned integer type.
- */
+deprecated("Use ocean.meta.traits.Basic.isUnsignedIntegerType")
 template isUnsignedIntegerType( T )
 {
     static immutable bool isUnsignedIntegerType =
@@ -1550,32 +575,14 @@ template isUnsignedIntegerType( T )
      || is( Unqual!(T) == ulong );
 }
 
-unittest
-{
-    static assert (!isUnsignedIntegerType!(int));
-    static assert ( isUnsignedIntegerType!(ubyte));
-    static assert ( isUnsignedIntegerType!(Const!(ulong)));
-}
-
-/**
- * Evaluates to true if T is a signed or unsigned integer type.
- */
+deprecated("Use ocean.meta.traits.Basic.isIntegerType")
 template isIntegerType( T )
 {
     static immutable bool isIntegerType = isSignedIntegerType!(T) ||
                                isUnsignedIntegerType!(T);
 }
 
-unittest
-{
-    static assert ( isIntegerType!(long));
-    static assert ( isIntegerType!(ubyte));
-    static assert (!isIntegerType!(char));
-}
-
-/**
- * Evaluates to true if T is a real floating-point type.
- */
+deprecated("Use ocean.meta.traits.Basic.isRealType")
 template isRealType( T )
 {
     static immutable bool isRealType =
@@ -1584,17 +591,7 @@ template isRealType( T )
      || is( Unqual!(T) == real );
 }
 
-unittest
-{
-    static assert ( isRealType!(double));
-    static assert (!isRealType!(long));
-    static assert (!isRealType!(cdouble));
-}
-
-
-/**
- * Evaluates to true if T is a complex floating-point type.
- */
+deprecated("Use ocean.meta.traits.Basic.isComplexType")
 template isComplexType( T )
 {
     static immutable bool isComplexType =
@@ -1603,16 +600,7 @@ template isComplexType( T )
      || is( Unqual!(T) == creal );
 }
 
-unittest
-{
-    static assert ( isComplexType!(cdouble));
-    static assert ( isComplexType!(Const!(cdouble)));
-    static assert (!isComplexType!(double));
-}
-
-/**
- * Evaluates to true if T is an imaginary floating-point type.
- */
+deprecated("Use ocean.meta.traits.Basic.isImaginaryType")
 template isImaginaryType( T )
 {
     static immutable bool isImaginaryType =
@@ -1621,17 +609,7 @@ template isImaginaryType( T )
      || is( Unqual!(T) == ireal );
 }
 
-unittest
-{
-    static assert ( isImaginaryType!(idouble));
-    static assert ( isImaginaryType!(Const!(idouble)));
-    static assert (!isImaginaryType!(double));
-}
-
-/**
- * Evaluates to true if T is any floating-point type: real, complex, or
- * imaginary.
- */
+deprecated("Use ocean.meta.traits.Basic.isFloatingPointType")
 template isFloatingPointType( T )
 {
     static immutable bool isFloatingPointType = isRealType!(T)    ||
@@ -1639,130 +617,19 @@ template isFloatingPointType( T )
                                      isImaginaryType!(T);
 }
 
-/**
- * complex type for the given type
- */
-template ComplexTypeOf(T){
-    static if(is(T==float)||is(T==ifloat)||is(T==cfloat)){
-        alias cfloat ComplexTypeOf;
-    } else static if(is(T==double)|| is(T==idouble)|| is(T==cdouble)){
-        alias cdouble ComplexTypeOf;
-    } else static if(is(T==real)|| is(T==ireal)|| is(T==creal)){
-        alias creal ComplexTypeOf;
-    } else static assert(0,"unsupported type in ComplexTypeOf "~T.stringof);
-}
-
-unittest
-{
-    static assert (is(ComplexTypeOf!(float) == cfloat));
-    static assert (is(ComplexTypeOf!(idouble) == cdouble));
-    static assert (is(ComplexTypeOf!(creal) == creal));
-}
-
-/**
- * real type for the given type
- */
-template RealTypeOf(T){
-    static if(is(T==float)|| is(T==ifloat)|| is(T==cfloat)){
-        alias float RealTypeOf;
-    } else static if(is(T==double)|| is(T==idouble)|| is(T==cdouble)){
-        alias double RealTypeOf;
-    } else static if(is(T==real)|| is(T==ireal)|| is(T==creal)){
-        alias real RealTypeOf;
-    } else static assert(0,"unsupported type in RealTypeOf "~T.stringof);
-}
-
-unittest
-{
-    static assert (is(RealTypeOf!(float) == float));
-    static assert (is(RealTypeOf!(idouble) == double));
-    static assert (is(RealTypeOf!(creal) == real));
-}
-
-/**
- * imaginary type for the given type
- */
-template ImaginaryTypeOf(T){
-    static if(is(T==float)|| is(T==ifloat)|| is(T==cfloat)){
-        alias ifloat ImaginaryTypeOf;
-    } else static if(is(T==double)|| is(T==idouble)|| is(T==cdouble)){
-        alias idouble ImaginaryTypeOf;
-    } else static if(is(T==real)|| is(T==ireal)|| is(T==creal)){
-        alias ireal ImaginaryTypeOf;
-    } else static assert(0,"unsupported type in ImaginaryTypeOf "~T.stringof);
-}
-
-unittest
-{
-    static assert (is(ImaginaryTypeOf!(float) == ifloat));
-    static assert (is(ImaginaryTypeOf!(idouble) == idouble));
-    static assert (is(ImaginaryTypeOf!(creal) == ireal));
-}
-
-/// type with maximum precision
-template MaxPrecTypeOf(T){
-    static if (isComplexType!(T)){
-        alias creal MaxPrecTypeOf;
-    } else static if (isImaginaryType!(T)){
-        alias ireal MaxPrecTypeOf;
-    } else {
-        alias real MaxPrecTypeOf;
-    }
-}
-
-unittest
-{
-    static assert (is(MaxPrecTypeOf!(cfloat) == creal));
-    static assert (is(MaxPrecTypeOf!(idouble) == ireal));
-    static assert (is(MaxPrecTypeOf!(real) == real));
-}
-
-/**
- * Evaluates to true if T is a pointer type.
- */
+deprecated("Use ocean.meta.traits.Basic.isPointerType")
 template isPointerType(T)
 {
         static immutable isPointerType = false;
 }
 
+deprecated("Use ocean.meta.traits.Basic.isPointerType")
 template isPointerType(T : T*)
 {
         static immutable isPointerType = true;
 }
 
-unittest
-{
-    static assert( isPointerType!(void*) );
-    static assert( !isPointerType!(char[]) );
-    static assert( isPointerType!(char[]*) );
-    static assert( !isPointerType!(char*[]) );
-    static assert( isPointerType!(real*) );
-    static assert( !isPointerType!(uint) );
-
-    class Ham
-    {
-        void* a;
-    }
-
-    static assert( !isPointerType!(Ham) );
-
-    union Eggs
-    {
-        void* a;
-        uint  b;
-    }
-
-    static assert( !isPointerType!(Eggs) );
-    static assert( isPointerType!(Eggs*) );
-
-    struct Bacon {}
-
-    static assert( !isPointerType!(Bacon) );
-}
-
-/**
- * Evaluates to true if T is a a pointer, class, interface, or delegate.
- */
+deprecated("Use ocean.meta.traits.Basic.isReferenceType")
 template isReferenceType( T )
 {
 
@@ -1772,59 +639,25 @@ template isReferenceType( T )
                                is( T == delegate );
 }
 
-unittest
-{
-    class Test1 { }
-    static assert (isReferenceType!(Test1));
-
-    interface Test2 { }
-    static assert (isReferenceType!(Test2));
-
-    alias void delegate() Test3;
-    static assert (isReferenceType!(Test3));
-}
-
-
-/**
- * Evaulates to true if T is a dynamic array type.
- */
+deprecated("Use ocean.meta.traits.Basic.isArrayType")
 template isDynamicArrayType( T )
 {
     static immutable bool isDynamicArrayType = is( typeof(T.init[0])[] == T );
 }
 
-unittest
-{
-    static assert ( isDynamicArrayType!(int[]));
-    static assert (!isDynamicArrayType!(int[2]));
-    static assert (!isDynamicArrayType!(int));
-
-    static assert (!isDynamicArrayType!(char[5][2]));
-}
-
-/**
- * Evaluates to true if T is a static array type.
- */
+deprecated("Use ocean.meta.traits.Basic.isArrayType")
 template isStaticArrayType( T : T[U], size_t U )
 {
     static immutable bool isStaticArrayType = true;
 }
 
+deprecated("Use ocean.meta.traits.Basic.isArrayType")
 template isStaticArrayType( T )
 {
     static immutable bool isStaticArrayType = false;
 }
 
-unittest
-{
-    static assert (!isStaticArrayType!(int[]));
-    static assert ( isStaticArrayType!(int[2]));
-    static assert (!isStaticArrayType!(int));
-
-    static assert ( isStaticArrayType!(char[5][2]));
-}
-
-/// true for array types
+deprecated("Use ocean.meta.traits.Basic.isArrayType")
 template isArrayType(T)
 {
     static if (is( T U : U[] ))
@@ -1833,32 +666,13 @@ template isArrayType(T)
         static immutable bool isArrayType=false;
 }
 
-unittest
-{
-    static assert ( isArrayType!(char[5][2]));
-    static assert ( isArrayType!(char[15]));
-    static assert ( isArrayType!(char[]));
-    static assert (!isArrayType!(char));
-}
-
-/**
- * Evaluates to true if T is an associative array type.
- */
+deprecated("Use ocean.meta.traits.Basic.isArrayType")
 template isAssocArrayType( T )
 {
     static immutable bool isAssocArrayType = is( typeof(T.init.values[0])[typeof(T.init.keys[0])] == T );
 }
 
-unittest
-{
-    static assert ( isAssocArrayType!(char[][int[]]));
-    static assert (!isAssocArrayType!(char[]));
-}
-
-/**
- * Evaluates to true if T is a function, function pointer, delegate, or
- * callable object.
- */
+deprecated("Use ocean.meta.traits.Basic.isCallableType")
 template isCallableType( T )
 {
     static immutable bool isCallableType = is( T == function )             ||
@@ -1867,24 +681,7 @@ template isCallableType( T )
                                 is( typeof(T.opCall) == function );
 }
 
-unittest
-{
-    void foo1() { }
-    auto foo2 = () { };
-    class Test
-    {
-        void foo3() {}
-    }
-
-    static assert (isCallableType!(typeof(&foo1)));
-    static assert (isCallableType!(typeof(foo2)));
-    static assert (isCallableType!(typeof(&Test.foo3)));
-}
-
-
-/**
- * Evaluates to the return type of Fn.  Fn is required to be a callable type.
- */
+deprecated("Use ocean.meta.types.Function.ReturnTypeOf")
 template ReturnTypeOf( Fn )
 {
     static if (is(Fn Fptr : Fptr*) && is(Fptr == function))
@@ -1899,33 +696,13 @@ template ReturnTypeOf( Fn )
         static assert( false, "Argument has no return type." );
 }
 
-/**
- * Evaluates to the return type of fn.  fn is required to be callable.
- */
+deprecated("Use ocean.meta.types.Function.ReturnTypeOf")
 template ReturnTypeOf( alias fn )
 {
     alias ReturnTypeOf!(typeof(fn)) ReturnTypeOf;
 }
 
-unittest
-{
-    int foo1() { return 0; }
-    static assert (is(ReturnTypeOf!(foo1) == int));
-
-    mixin (Typedef!(int, "MyType"));
-    MyType foo2() { return MyType.init; }
-    static assert (is(ReturnTypeOf!(foo2) == MyType));
-
-    mixin (Typedef!(double function(), "MyFuncType"));
-    MyFuncType foo3;
-    static assert (is(ReturnTypeOf!(foo3) == double));
-}
-
-/**
- * Evaluates to a tuple representing the parameters of Fn.  Fn is required to
- * be a callable type.
- */
-
+deprecated("Use ocean.meta.types.Function.ParametersOf")
 template ParameterTupleOf( Fn )
 {
     static if( is( Fn Params == function ) )
@@ -1938,65 +715,13 @@ template ParameterTupleOf( Fn )
         static assert( false, "Argument has no parameters." );
 }
 
-/**
- * Evaluates to a tuple representing the parameters of fn.  n is required to
- * be callable.
- */
+deprecated("Use ocean.meta.types.Function.ParametersOf")
 template ParameterTupleOf( alias fn )
 {
     alias ParameterTupleOf!(typeof(fn)) ParameterTupleOf;
 }
 
-unittest
-{
-    void foo(int x, ref double y, char[] z) {}
-    alias ParameterTupleOf!(foo) Params;
-
-    static assert (Params.length == 3);
-    static assert (is(Params[0] == int));
-    static assert (is(Params[1] == double));
-    static assert (is(Params[2] == char[]));
-}
-
-unittest
-{
-    mixin (Typedef!(void function(int, char[]), "MyType"));
-    MyType foo;
-    alias ParameterTupleOf!(foo) Params;
-
-    static assert (Params.length == 2);
-    static assert (is(Params[0] == int));
-    static assert (is(Params[1] == char[]));
-}
-
-/**
- * Evaluates to a tuple representing the ancestors of T.  T is required to be
- * a class or interface type.
- */
-template BaseTypeTupleOf( T )
-{
-    static if( is( T Base == super ) )
-        alias Base BaseTypeTupleOf;
-    else
-        static assert( false, "Argument is not a class or interface." );
-}
-
-unittest
-{
-    interface A { }
-    interface B { }
-    class C : A, B { }
-
-    alias BaseTypeTupleOf!(C) Bases;
-    static assert (Bases.length == 3);
-    static assert (is(Bases[0] == Object));
-    static assert (is(Bases[1] == A));
-    static assert (is(Bases[2] == B));
-}
-
-/**
- * Strips the []'s off of a type.
- */
+deprecated("Use ocean.meta.types.Arrays.StripAllArrays")
 template BaseTypeOfArrays(T)
 {
     static if( is( T S : S[]) ) {
@@ -2007,31 +732,13 @@ template BaseTypeOfArrays(T)
     }
 }
 
-unittest
-{
-    static assert( is(BaseTypeOfArrays!(real[][])==real) );
-    static assert( is(BaseTypeOfArrays!(real[2][3])==real) );
-}
-
-/**
- * strips one [] off a type
- */
+deprecated("Use ocean.meta.types.Arrays.ElementTypeOf")
 template ElementTypeOfArray(T:T[])
 {
     alias T ElementTypeOfArray;
 }
 
-unittest
-{
-    static assert( is(ElementTypeOfArray!(real[])==real) );
-    static assert( is(ElementTypeOfArray!(real[][])==real[]) );
-    static assert( is(ElementTypeOfArray!(real[2][])==real[2]) );
-    static assert( is(ElementTypeOfArray!(real[2][2])==real[2]) );
-}
-
-/**
- * Count the []'s on an array type
- */
+deprecated("Use ocean.meta.traits.Arrays.rankOfArray")
 template rankOfArray(T) {
     static if(is(T S : S[])) {
         static immutable uint rankOfArray = 1 + rankOfArray!(S);
@@ -2040,50 +747,7 @@ template rankOfArray(T) {
     }
 }
 
-unittest
-{
-    static assert (rankOfArray!(real[][]) == 2);
-    static assert (rankOfArray!(real[2][]) == 2);
-}
-
-/// type of the keys of an AA
-template KeyTypeOfAA(T){
-    alias typeof(T.init.keys[0]) KeyTypeOfAA;
-}
-
-unittest
-{
-    static assert (is(KeyTypeOfAA!(char[int])==int));
-    static assert(is(KeyTypeOfAA!(char[][int[]])==const(int)[]));
-}
-
-/// type of the values of an AA
-template ValTypeOfAA(T){
-    alias typeof(T.init.values[0]) ValTypeOfAA;
-}
-
-unittest
-{
-    static assert (is(ValTypeOfAA!(char[int])==char));
-    static assert (is(ValTypeOfAA!(char[][int])==char[]));
-}
-
-/// returns the size of a static array
-template staticArraySize(T)
-{
-    static assert (isStaticArrayType!(T),"staticArraySize needs a static array as type");
-    static assert (rankOfArray!(T)==1,"implemented only for 1d arrays...");
-    static immutable size_t staticArraySize=(T).sizeof / typeof(T.init[0]).sizeof;
-}
-
-unittest
-{
-    static assert (staticArraySize!(char[2]) == 2);
-}
-
-// ------- CTFE -------
-
-/// compile time integer to string
+deprecated("Use ocean.meta.codegen.CTFE.toString")
 istring ctfe_i2a(int i){
     istring digit="0123456789";
     istring res;
@@ -2105,12 +769,7 @@ istring ctfe_i2a(int i){
         return res;
 }
 
-unittest
-{
-    static assert (ctfe_i2a(42) == "42");
-}
-
-/// ditto
+deprecated("Use ocean.meta.codegen.CTFE.toString")
 istring ctfe_i2a(long i){
     istring digit="0123456789";
     istring res;
@@ -2132,12 +791,7 @@ istring ctfe_i2a(long i){
         return res;
 }
 
-unittest
-{
-    static assert (ctfe_i2a(-42L) == "-42");
-}
-
-/// ditto
+deprecated("Use ocean.meta.codegen.CTFE.toString")
 istring ctfe_i2a(uint i){
     istring digit="0123456789";
     istring res="";
@@ -2152,12 +806,7 @@ istring ctfe_i2a(uint i){
     return res;
 }
 
-unittest
-{
-    static assert (ctfe_i2a(42UL) == "42");
-}
-
-/// ditto
+deprecated("Use ocean.meta.codegen.CTFE.toString")
 istring ctfe_i2a(ulong i){
     istring digit="0123456789";
     istring res="";
@@ -2172,28 +821,7 @@ istring ctfe_i2a(ulong i){
     return res;
 }
 
-unittest
-{
-    static assert( ctfe_i2a(31)=="31" );
-    static assert( ctfe_i2a(-31)=="-31" );
-    static assert( ctfe_i2a(14u)=="14" );
-    static assert( ctfe_i2a(14L)=="14" );
-    static assert( ctfe_i2a(14UL)=="14" );
-}
-
-/*******************************************************************************
-
-    Checks for presence of method/field with specified name in aggregate.
-
-    In D1 most common idiom is to simply check for `is(typeof(T.something))` but
-    in D2 it can backfire because of UFCS as global names are checked too
-
-    Params:
-        T = aggregate type to check
-        name = method/field name to look for
-
-*******************************************************************************/
-
+deprecated("Use ocean.meta.traits.Aggregates.hasMember")
 public template hasMember(T, istring name)
 {
     static assert (
@@ -2203,12 +831,4 @@ public template hasMember(T, istring name)
     );
 
     enum hasMember = __traits(hasMember, T, name);
-}
-
-unittest
-{
-    struct S { void foo() {}; }
-
-    static assert ( hasMember!(S, "foo"));
-    static assert (!hasMember!(S, "bar"));
 }

--- a/src/ocean/meta/codegen/Identifier.d
+++ b/src/ocean/meta/codegen/Identifier.d
@@ -43,10 +43,7 @@ version (UnitTest)
 
 public template identifier ( alias Sym )
 {
-    static if (is(typeof(Sym) == function))
-        static immutable identifier = funcIdentifierHack!(Sym)();
-    else
-        static immutable identifier = Sym.stringof;
+    enum identifier = __traits(identifier, Sym);
 }
 
 ///
@@ -73,26 +70,6 @@ unittest
 
 /*******************************************************************************
 
-    Because of interaction with optional parens syntax, one can't simply do
-    `foo.stringof` if `foo` is a function symbol and fake argument list needs
-    to be constructed.
-
-*******************************************************************************/
-
-private istring funcIdentifierHack(alias Sym)()
-{
-    // Sym.stringof is treated as Sym().stringof
-    // ugly workaround:
-    ParametersOf!(typeof(Sym)) args;
-    auto name = Sym(args).stringof[];
-    size_t bracketIndex = 0;
-    while (name[bracketIndex] != '(' && bracketIndex < name.length)
-        ++bracketIndex;
-    return name[0 .. bracketIndex];
-}
-
-/*******************************************************************************
-
     Template to get the name of the ith member of a struct / class.
 
     Used over plain `identifier` when iterating over aggregate fields with
@@ -108,12 +85,13 @@ private istring funcIdentifierHack(alias Sym)()
 
 *******************************************************************************/
 
+deprecated("Use ocean.meta.codegen.identifier!(T.tupleof[i])")
 public template fieldIdentifier ( T, size_t i )
 {
-    static immutable istring fieldIdentifier = stripQualifiedPrefix(T.tupleof[i].stringof);
+    enum fieldIdentifier = identifier!(T.tupleof[i]);
 }
 
-unittest
+deprecated unittest
 {
     static struct TestStruct
     {

--- a/src/ocean/meta/traits/Aggregates.d
+++ b/src/ocean/meta/traits/Aggregates.d
@@ -99,3 +99,34 @@ unittest
     static assert ( hasMethod!(S, "foo2", int function(double)));
     static assert (!hasMethod!(S, "foo3", int delegate(double)));
 }
+
+/*******************************************************************************
+
+    Non-recursive aggregate field size calculation
+
+    Returns:
+        sum of individual sizes of all aggregate fields, identical to S.sizeof
+        if `align(1)` is used.
+
+*******************************************************************************/
+
+public template totalMemberSize ( S )
+{
+    static assert (isAggregateType!S);
+
+    private size_t calculate ( )
+    {
+        size_t size;
+        foreach (field; S.init.tupleof)
+            size += typeof(field).sizeof;
+        return size;
+    }
+
+    enum totalMemberSize = calculate();
+}
+
+unittest
+{
+    struct S { int x; byte[2] y; }
+    static assert (totalMemberSize!S == 6);
+}

--- a/src/ocean/meta/traits/Arrays.d
+++ b/src/ocean/meta/traits/Arrays.d
@@ -46,3 +46,28 @@ unittest
     static assert (isUTF8StringType!(Immut!(char)[]));
     static assert (!isUTF8StringType!(wchar[]));
 }
+
+/*******************************************************************************
+
+    Params:
+        T = any type
+
+    Returns:
+        Depth of array nesting (1 for plain array) if T is an array, 0 otherwise
+
+*******************************************************************************/
+
+template rankOfArray ( T )
+{
+    static if (is(T S : S[]))
+        enum rankOfArray = 1 + rankOfArray!S;
+    else
+        enum rankOfArray = 0;
+}
+
+///
+unittest
+{
+    static assert (rankOfArray!(real[][]) == 2);
+    static assert (rankOfArray!(real[2][]) == 2);
+}

--- a/src/ocean/meta/types/Enum.d
+++ b/src/ocean/meta/types/Enum.d
@@ -1,0 +1,50 @@
+/*******************************************************************************
+
+    Copyright:
+        Copyright (C) 2017 dunnhumby Germany GmbH. All rights reserved.
+
+    NB: because this module is often used as purely compile-time dependency it
+        used built-in asserts instead of `ocean.core.Test` to reduce amount of
+        cyclic imports. `ocean.meta` modules in general are not supposed to
+        import anything outside of `ocean.meta`.
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+        Alternatively, this file may be distributed under the terms of the Tango
+        3-Clause BSD License (see LICENSE_BSD.txt for details).
+
+*******************************************************************************/
+
+module ocean.meta.types.Enum;
+
+/*******************************************************************************
+
+    If T is enum, aliases to its base type. Otherwise aliases to T.
+
+    Params:
+        T = any type
+
+*******************************************************************************/
+
+public template EnumBaseType ( T )
+{
+    static if (is(T U == enum))
+    {
+        alias EnumBaseType = U;
+    }
+    else
+    {
+        alias EnumBaseType = T;
+    }
+}
+
+unittest
+{
+    enum Test : int
+    {
+        field = 42
+    }
+
+    static assert (is(EnumBaseType!(typeof(Test.field)) == int));
+    static assert (is(EnumBaseType!double == double));
+}

--- a/src/ocean/meta/types/package_.d
+++ b/src/ocean/meta/types/package_.d
@@ -23,5 +23,10 @@
 
 module ocean.meta.types.package_;
 
+public import ocean.meta.types.Arrays;
+public import ocean.meta.types.Enum;
+public import ocean.meta.types.Function;
 public import ocean.meta.types.Qualifiers;
 public import ocean.meta.types.ReduceType;
+public import ocean.meta.types.Templates;
+public import ocean.meta.types.Typedef;


### PR DESCRIPTION
One of bigger v5.0.0 changes (apart from full D2 :)). Stuff that proved to be unused based on internal search got immediately removed as there was plenty of useless baggage from Tango times.