### PR TITLE
DMD 2.081 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,9 @@ jobs:
           env: DMD=2.078.3.s* F=devel DFLAGS=-debug=ISelectClient
           script: 2>/dev/null beaver dlang make
         - <<: *test-matrix-d2
-          env: DMD=2.078.* F=production
+          env: DMD=2.081.* F=production
         - <<: *test-matrix-d2
-          env: DMD=2.078.* F=devel
+          env: DMD=2.081.* F=devel
 
         # Additional stages
 

--- a/src/ocean/io/FilePath.d
+++ b/src/ocean/io/FilePath.d
@@ -780,7 +780,11 @@ class FilePath : PathView
                     if (filter is null || filter (p, info.folder))
                         paths ~= p;
                     else
-                       delete p;
+                    {
+                       import core.memory;
+                       destroy(p);
+                       GC.free(cast(void*) p);
+                    }
                     }
             return paths;
     }

--- a/src/ocean/io/Path.d
+++ b/src/ocean/io/Path.d
@@ -517,12 +517,13 @@ package struct FS
 
         scope (exit)
         {
+            import core.memory;
             core.sys.posix.dirent.closedir (dir);
-            delete sfnbuf;
+            GC.free(sfnbuf.ptr);
 
             // only delete when we dupped it
             if (folder[$-2] != '/')
-                delete prefix;
+                GC.free(prefix.ptr);
         }
 
         // ensure a trailing '/' is present

--- a/src/ocean/io/device/MemoryDevice.d
+++ b/src/ocean/io/device/MemoryDevice.d
@@ -335,7 +335,8 @@ class MemoryDevice : IConduit
 
     override void close ( )
     {
-        delete this.data;
+        import core.memory;
+        GC.free(this.data.ptr);
         this.data = null;
         this.position = 0;
     }

--- a/src/ocean/io/device/TempFile.d
+++ b/src/ocean/io/device/TempFile.d
@@ -275,8 +275,9 @@ class TempFile : File
             istring prefix=DEFAULT_PREFIX,
             istring suffix=DEFAULT_SUFFIX)
     {
+        import core.memory;
         auto junk = new char[length];
-        scope(exit) delete junk;
+        scope(exit) GC.free(junk.ptr);
 
         foreach( ref c ; junk )
         {

--- a/src/ocean/io/select/protocol/generic/ErrnoIOException.d
+++ b/src/ocean/io/select/protocol/generic/ErrnoIOException.d
@@ -132,7 +132,7 @@ class IOError : IOWarning
 
 class SocketError : IOError
 {
-    import ocean.sys.socket.model.ISocket : ISelectable;
+    import ocean.io.device.Conduit: ISelectable;
     import ocean.sys.socket.model.ISocket;
 
     /**************************************************************************

--- a/src/ocean/text/convert/UnicodeBom.d
+++ b/src/ocean/text/convert/UnicodeBom.d
@@ -20,7 +20,6 @@ module ocean.text.convert.UnicodeBom;
 import core.exception : onUnicodeError;
 
 import ocean.transition;
-
 import ocean.core.ByteSwap;
 
 import  Utf = ocean.text.convert.Utf;
@@ -381,13 +380,13 @@ class BomSniffer
     private static Const!(Info[]) lookup = [
         {Utf8,  Encoding.Unknown,  null,        true,  false, false, Encoding.UTF_8},
         {Utf8,  Encoding.UTF_8N,   null,        true,  false, false, Encoding.UTF_8},
-        {Utf8,  Encoding.UTF_8,    x"efbbbf",   false},
+        {Utf8,  Encoding.UTF_8,    "\xEF\xBB\xBF",   false},
         {Utf16, Encoding.UTF_16,   null,        true,  false, false, Encoding.UTF_16BE},
-        {Utf16, Encoding.UTF_16BE, x"feff",     false, true, true},
-        {Utf16, Encoding.UTF_16LE, x"fffe",     false, true},
+        {Utf16, Encoding.UTF_16BE, "\xFE\xFF", false, true, true},
+        {Utf16, Encoding.UTF_16LE, "\xFF\xFE", false, true},
         {Utf32, Encoding.UTF_32,   null,        true,  false, false, Encoding.UTF_32BE},
-        {Utf32, Encoding.UTF_32BE, x"0000feff", false, true, true},
-        {Utf32, Encoding.UTF_32LE, x"fffe0000", false, true},
+        {Utf32, Encoding.UTF_32BE, "\x00\x00\xFE\xFF", false, true, true},
+        {Utf32, Encoding.UTF_32LE, "\xFF\xFE\x00\x00", false, true},
     ];
 
     /***********************************************************************
@@ -469,7 +468,7 @@ class BomSniffer
 unittest
 {
     void[] INPUT2 = "abc\xE3\x81\x82\xE3\x81\x84\xE3\x81\x86".dup;
-    void[] INPUT = x"efbbbf" ~ INPUT2;
+    void[] INPUT = "\xEF\xBB\xBF" ~ INPUT2;
     auto bom = new UnicodeBom!(char)(Encoding.Unknown);
     size_t ate;
     char[256] buf;

--- a/src/ocean/util/Convert.d
+++ b/src/ocean/util/Convert.d
@@ -1018,7 +1018,6 @@ D toArrayFromArray(D,S)(S value)
     alias ElementTypeOf!(D) De;
 
     D result; result.length = value.length;
-    scope(failure) delete result;
 
     foreach( i,e ; value )
         result[i] = to!(De)(e);

--- a/src/ocean/util/container/map/model/BucketElementMallocAllocator.d
+++ b/src/ocean/util/container/map/model/BucketElementMallocAllocator.d
@@ -362,6 +362,5 @@ version (UnitTest)
         // Test if creating a map with a bucket compiles.
         auto allocator = new
             BucketElementMallocAllocator!(Bucket!(hash_t.sizeof, hash_t));
-        delete allocator;
     }
 }

--- a/src/ocean/util/container/map/model/IBucketElementGCAllocator.d
+++ b/src/ocean/util/container/map/model/IBucketElementGCAllocator.d
@@ -51,7 +51,8 @@ class IBucketElementGCAllocator: IAllocator
 
     protected override void deallocate ( void* element )
     {
-        delete element;
+        import core.memory;
+        GC.free(element);
     }
 
     /***************************************************************************

--- a/src/ocean/util/container/mem/MemManager.d
+++ b/src/ocean/util/container/mem/MemManager.d
@@ -185,7 +185,8 @@ private class GCMemManager ( bool gc_aware ) : IMemManager
 
     public override void destroy ( ubyte[] buffer )
     {
-        delete buffer;
+        import core.memory;
+        GC.free(buffer.ptr);
     }
 
     /***************************************************************************

--- a/src/ocean/util/container/pool/model/IAggregatePool.d
+++ b/src/ocean/util/container/pool/model/IAggregatePool.d
@@ -606,14 +606,18 @@ public abstract class IAggregatePool ( T ) : IPool, IFreeList!(ItemType_!(T))
     }
     body
     {
+        import core.memory;
+
         static if (is (ItemType == class))
         {
-            delete item.obj;
+            destroy(item.obj);
+            GC.free(cast(void*) item.obj);
             item.obj = null;
         }
         else
         {
-            delete item.ptr;
+            destroy(item.ptr);
+            GC.free(cast(void*) item.ptr);
             item.ptr = null;
         }
     }

--- a/src/ocean/util/digest/Crc32.d
+++ b/src/ocean/util/digest/Crc32.d
@@ -18,7 +18,6 @@
 module ocean.util.digest.Crc32;
 
 import ocean.transition;
-
 public import ocean.util.digest.Digest;
 
 version(UnitTest) import ocean.core.Test;
@@ -141,7 +140,7 @@ unittest
     scope c = new Crc32();
     static ubyte[] data = [1,2,3,4,5,6,7,8,9,10];
     c.update(data);
-    test(c.binaryDigest() == cast(ubyte[]) x"7b572025");
+    test(c.binaryDigest() == "\x7B\x57\x20\x25");
     c.update(data);
     test(c.crc32Digest == 0x2520577b);
     c.update(data);

--- a/src/ocean/util/digest/Tiger.d
+++ b/src/ocean/util/digest/Tiger.d
@@ -23,7 +23,7 @@ module ocean.util.digest.Tiger;
 import ocean.transition;
 
 import ocean.core.Verify;
-
+import ocean.core.TypeConvert;
 import ocean.core.ByteSwap;
 
 import ocean.util.digest.MerkleDamgard;
@@ -870,7 +870,10 @@ unittest
         "Tiger - A Fast New Hash Function, by Ross Anderson and Eli Biham",
         "Tiger - A Fast New Hash Function, by Ross Anderson and Eli Biham, proceedings of Fast Software Encryption 3, Cambridge.",
         "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq",
-        x"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000",
+        arrayOf!(char)(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8,
+                0, 0, 0)
     ];
 
     static istring[] results = [


### PR DESCRIPTION
Changes compared to https://github.com/sociomantic-tsunami/ocean/pull/502 :

- rebased
- tweaked hex literals based on @david-eckardt-sociomantic suggestion
- `delete` keyword is replaced with `destroy` + `GC.free` pair in most places to preserve old behavior as much as possible
- CI uses 2.081 instead of 2.080 (same changes needed)