### PR TITLE
"yesterday" and single value support improvements for TimeIntervalArgs.

### DIFF
--- a/src/ocean/text/arguments/TimeIntervalArgs.d
+++ b/src/ocean/text/arguments/TimeIntervalArgs.d
@@ -2,6 +2,42 @@
 
     Handler for time interval CLI arguments
 
+    One Argument
+    ------------
+
+    Date:
+        Gives the range for that day.
+        "-t 2019-04-01" (start: 2019-04-01 00:00:00, end: 2019-04-01 23:59:59 )
+
+    TimeStamp
+        Gives a range from the provided timestamp plus one day.
+        "-t 1554132392" (start: 1554132392, end: 1554218791)
+
+    Timerange
+        Gives X amount in the past NOT including the current second.
+        "-t 1m" with now:1000 (start:940, end:999)
+
+    Two Arguments
+    -------------
+
+    Dates:
+        Start is parsed inclusively, end is parsed exclusively
+        eg. -t "2019-04-01 2019-04-02"
+            (start: 2019-04-01 00:00:00)
+            (  end: 2019-04-02 23:59:59)
+
+    TimeStamp
+        Start is treated as is, end is NOT included in final range.
+        eg. -t 100 200 = (begin: 100, end: 199)
+
+    Timerange
+        End range includes the starting second.
+        eg. -t 100 1m = (begin: 100, end: 159)
+        eg. -t 1m 100 = (begin: 60, end: 99)
+
+    Intended Range Usage
+        for ( long i = range.begin; i <= range.end; ++i )
+
     copyright: Copyright (c) 2018 dunnhumby Germany GmbH. All rights reserved
 
 *******************************************************************************/
@@ -56,6 +92,10 @@ public void setupTimeIntervalArgs ( Arguments args, bool required )
             "an integer for unix timestamps\n\t" ~
             "a time duration `{int}m`. Supported units are [m]inutes, [h]ours and [d]ays\n\t" ~
             "an iso1806 date (YYYY-MM-DD)");
+    args("time-interval-exclude")
+        .help("If not set, then a range of '-t 2019-04-01 2019-04-02' will \n" ~
+              "include the end date's data. eg. (end: 2019-04-02 23:59:59) \n" ~
+              "If set, end date data will not be included, eg.(end: 2019-04-01 23:59:59)");
 
     if ( required )
     {
@@ -78,8 +118,8 @@ public void setupTimeIntervalArgs ( Arguments args, bool required )
 
 public istring validateTimeIntervalArgs ( Arguments args )
 {
-    if ( args["time-interval"].assigned.length < 1 ||
-        args["time-interval"].assigned.length > 2 )
+    auto num_args = args["time-interval"].assigned.length;
+    if ( num_args < 1 || num_args > 2 )
     {
         return "The 'time-interval' argument must have 1 or 2 values";
     }
@@ -100,68 +140,71 @@ public TimestampInterval processTimeIntervalArgs ( Arguments args )
 {
     auto num_args = args["time-interval"].assigned.length;
     enforce(num_args >= 1 && num_args <= 2, "Not enough arguments provided");
+    bool include_end_date = !args["time-interval-exclude"].set;
 
-    TimestampInterval interval;
+    long begin, end;
 
     if ( num_args == 1 )
     {
         auto arg = args["time-interval"].assigned[0];
         if ( isTimeInterval(arg) )
         {
-            interval.end = time(null);
-            interval.begin = interval.end - parseTimeInterval(arg);
+            end = time(null);
+            begin = end - parseTimeInterval(arg);
         }
         else
         {
-            interval.begin = parseDateString(arg, 0);
-            interval.end = interval.begin + SECONDS_IN_DAY -1;
+            begin = parseDateString(arg);
+            end = begin + SECONDS_IN_DAY;
         }
     }
     else if ( num_args == 2 )
     {
-        cstring begin = args["time-interval"].assigned[0];
-        cstring end = args["time-interval"].assigned[1];
+        cstring begin_arg = args["time-interval"].assigned[0];
+        cstring end_arg = args["time-interval"].assigned[1];
 
-        if ( isTimeInterval(begin) && isTimeInterval(end) )
+        if ( isTimeInterval(begin_arg) && isTimeInterval(end_arg) )
         {
-            interval.begin = time(null) - parseTimeInterval(begin);
-            interval.end = time(null) + parseTimeInterval(end);
+            begin = time(null) - parseTimeInterval(begin_arg);
+            end = time(null) + parseTimeInterval(end_arg);
         }
-        else if ( isTimeInterval(begin) )
+        else if ( isTimeInterval(begin_arg) )
         {
-            interval.end = parseDateString(end, SECONDS_IN_DAY - 1);
-            interval.begin = interval.end - parseTimeInterval(begin);
+            end = parseDateString(end_arg, include_end_date);
+            begin = end - parseTimeInterval(begin_arg);
         }
-        else if ( isTimeInterval(end) )
+        else if ( isTimeInterval(end_arg) )
         {
-            interval.begin = parseDateString(begin, 0);
-            interval.end = interval.begin + parseTimeInterval(end);
+            begin = parseDateString(begin_arg);
+            end = begin + parseTimeInterval(end_arg);
         }
         else
         {
-            interval.begin = parseDateString(begin, 0);
-            interval.end = parseDateString(end, SECONDS_IN_DAY - 1);
+            begin = parseDateString(begin_arg);
+            end = parseDateString(end_arg, include_end_date);
         }
     }
-
-    return interval;
+    //Don't include the last second in the range.
+    return TimestampInterval(begin, end-1);
 }
 
 /**************************************************************************
 
     Converts a string interval to a unix timestamp. If the value is an
-    ISO 8601 date then the date_time will be added to the converted value.
+    ISO 8601 date. If the value is a stirng date and from the end of the range
+    then we say the value is actually the next day
 
     Params:
         value = `now`, "yesterday", a string timestamp or iso8601 date
-        date_time = seconds added to the converted iso8601 timestamp
+        include_end_date = For string dates, actually parse the next day to
+                           include the dates data.
 
     Returns:
         an unix timestamp
 
 **************************************************************************/
 
-private long parseDateString ( cstring value, long date_time )
+private long parseDateString ( cstring value, bool include_end_date = false )
 {
     if ( value == "now" )
     {
@@ -184,8 +227,7 @@ private long parseDateString ( cstring value, long date_time )
     DateConversion dummy_conv;
     if ( timeToUnixTime(value, result, dummy_conv) )
     {
-        result += date_time;
-        return result;
+        return result + (include_end_date ? SECONDS_IN_DAY : 0);
     }
 
     enforce(isTimeInterval(value), cast(istring) ("`" ~ value ~ "` is an invalid time interval argument. " ~
@@ -197,7 +239,7 @@ private long parseDateString ( cstring value, long date_time )
 /// Timestamp to use in unit tests;
 version ( UnitTest )
 {
-    // 04/01/2019 @ 3:26pm (UTC)
+    // 2019-04-01 15:26:32
     const TEST_TIME_NOW = 1554132392;
 
     /***************************************************************************
@@ -239,15 +281,26 @@ unittest
     timeToUnixTime("2014-03-09 00:00:00", dummy_time, dummy_conv);
 
     Test.test!("==")(interval.begin, dummy_time);
-    Test.test!("==")(interval.end, time(null));
+    Test.test!("==")(interval.end, TEST_TIME_NOW - 1);
 
     /// When the end date is provided
     args = new Arguments;
 
     setupTimeIntervalArgs(args, false);
-    args.parse("--time-interval now 2014-03-09");
+    args.parse("--time-interval now 2014-04-09");
     interval = processTimeIntervalArgs(args);
-    timeToUnixTime("2014-03-09 23:59:59", dummy_time, dummy_conv);
+    timeToUnixTime("2014-04-09 23:59:59", dummy_time, dummy_conv);
+
+    Test.test!("==")(interval.begin, time(null));
+    Test.test!("==")(interval.end, dummy_time);
+
+    /// When the end date is provided with exclusion arg
+    args = new Arguments;
+
+    setupTimeIntervalArgs(args, false);
+    args.parse("--time-interval now 2014-04-09 --time-interval-exclude");
+    interval = processTimeIntervalArgs(args);
+    timeToUnixTime("2014-04-08 23:59:59", dummy_time, dummy_conv);
 
     Test.test!("==")(interval.begin, time(null));
     Test.test!("==")(interval.end, dummy_time);
@@ -273,7 +326,7 @@ unittest
     interval = processTimeIntervalArgs(args);
 
     Test.test!("==")(interval.begin, 1000);
-    Test.test!("==")(interval.end, 1200);
+    Test.test!("==")(interval.end, 1199);
 
     /// Using interval starting with time duration
     args = new Arguments;
@@ -283,7 +336,7 @@ unittest
     interval = processTimeIntervalArgs(args);
 
     Test.test!("==")(interval.begin, 940);
-    Test.test!("==")(interval.end, 1000);
+    Test.test!("==")(interval.end, 999);
 
     /// Using interval ending with time duration
     args = new Arguments;
@@ -293,7 +346,7 @@ unittest
     interval = processTimeIntervalArgs(args);
 
     Test.test!("==")(interval.begin, 1000);
-    Test.test!("==")(interval.end, 1060);
+    Test.test!("==")(interval.end, 1059);
 
     /// Using two time durations
     args = new Arguments;
@@ -303,7 +356,7 @@ unittest
     interval = processTimeIntervalArgs(args);
 
     Test.test!("==")(interval.begin, TEST_TIME_NOW - 60);
-    Test.test!("==")(interval.end, TEST_TIME_NOW + 60);
+    Test.test!("==")(interval.end, TEST_TIME_NOW + 59);
 
     /// Using an invalid argument
     args = new Arguments;
@@ -323,6 +376,18 @@ unittest
     Test.test!("==")(interval.begin, 1553990400);
     /// 03/31/2019 @ 11:59pm (UTC)
     Test.test!("==")(interval.end, 1554076799);
+
+    /// Test last 2 hours of data receiving the last 2 hours of data.
+    args = new Arguments;
+
+    setupTimeIntervalArgs(args, false);
+    args.parse("--time-interval 2h");
+    interval = processTimeIntervalArgs(args);
+
+    /// 2019-04-01 13:26:32
+    Test.test!("==")(interval.begin, 1554125192);
+    /// 2019-04-01 15:26:31
+    Test.test!("==")(interval.end, 1554132391);
 }
 
 /******************************************************************************

--- a/src/ocean/text/arguments/TimeIntervalArgs.d
+++ b/src/ocean/text/arguments/TimeIntervalArgs.d
@@ -31,7 +31,8 @@ struct TimestampInterval
     long end;
 }
 
-
+/// Number of seconds in the day for creating day ranges.
+const SECONDS_IN_DAY = 86_400;
 
 /***************************************************************************
 
@@ -48,8 +49,8 @@ public void setupTimeIntervalArgs ( Arguments args, bool required )
 {
     auto interval = args("time-interval")
         .aliased('t')
-        .params(2)
-        .help("Specify a time interval. It get 2 values, where they can be:\n\t" ~
+        .params(1, 2)
+        .help("Specify a time interval. It 1 or 2 values, where they can be:\n\t" ~
             "'now' an alias for the current timestamp\n\t" ~
             "an integer for unix timestamps\n\t" ~
             "a time duration `{int}m`. Supported units are [m]inutes, [h]ours and [d]ays\n\t" ~
@@ -76,10 +77,10 @@ public void setupTimeIntervalArgs ( Arguments args, bool required )
 
 public istring validateTimeIntervalArgs ( Arguments args )
 {
-    if ( args["time-interval"].assigned.length != 2 &&
-        args["time-interval"].assigned.length != 0 )
+    if ( args["time-interval"].assigned.length < 1 ||
+        args["time-interval"].assigned.length > 2 )
     {
-        return "The 'time-interval' argument must have 2 values";
+        return "The 'time-interval' argument must have 1 or 2 values";
     }
 
     return null;
@@ -91,54 +92,55 @@ public istring validateTimeIntervalArgs ( Arguments args )
 
     Params:
         args = The arguments to process
-        default_interval = The interval in seconds that should be used when
-            dates are not set by the user
 
 ***************************************************************************/
 
-public TimestampInterval processTimeIntervalArgs ( Arguments args,
-    long default_interval = 60 )
+public TimestampInterval processTimeIntervalArgs ( Arguments args )
 {
+    auto num_args = args["time-interval"].assigned.length;
+    enforce(num_args >= 1 && num_args <= 2, "Not enough arguments provided");
+
     TimestampInterval interval;
 
-    if ( args("time-interval").set && args["time-interval"].assigned.length == 2 )
+    if ( num_args == 1 )
+    {
+        auto arg = args["time-interval"].assigned[0];
+        if ( isTimeInterval(arg) )
+        {
+            interval.end = time(null);
+            interval.begin = interval.end - parseTimeInterval(arg);
+        }
+        else
+        {
+            interval.begin = parseDateString(arg, 0);
+            interval.end = interval.begin + SECONDS_IN_DAY -1;
+        }
+    }
+    else if ( num_args == 2 )
     {
         cstring begin = args["time-interval"].assigned[0];
         cstring end = args["time-interval"].assigned[1];
-
-        interval.begin = parseDateString(begin, 0);
-        interval.end = parseDateString(end, 24 * 3600 - 1);
 
         if ( isTimeInterval(begin) && isTimeInterval(end) )
         {
             interval.begin = time(null) - parseTimeInterval(begin);
             interval.end = time(null) + parseTimeInterval(end);
         }
-
-        if ( isTimeInterval(begin) && interval.begin == 0 )
+        else if ( isTimeInterval(begin) )
         {
+            interval.end = parseDateString(end, SECONDS_IN_DAY - 1);
             interval.begin = interval.end - parseTimeInterval(begin);
         }
-
-        if ( isTimeInterval(end) && interval.end == 0 )
+        else if ( isTimeInterval(end) )
         {
+            interval.begin = parseDateString(begin, 0);
             interval.end = interval.begin + parseTimeInterval(end);
         }
-    }
-
-    if ( interval.begin == 0 && interval.end == 0 )
-    {
-        interval.begin = time(null) - default_interval;
-    }
-
-    if ( interval.begin == 0 )
-    {
-        interval.begin = time(null);
-    }
-
-    if ( interval.end == 0 )
-    {
-        interval.end = time(null);
+        else
+        {
+            interval.begin = parseDateString(begin, 0);
+            interval.end = parseDateString(end, SECONDS_IN_DAY - 1);
+        }
     }
 
     return interval;
@@ -212,16 +214,14 @@ unittest
 {
     long dummy_time;
     DateConversion dummy_conv;
-    long default_interval = 60;
+    TimestampInterval interval;
 
     auto args = new Arguments;
 
     /// When there is no begin and end date set
     setupTimeIntervalArgs(args, false);
     args.parse("");
-    auto interval = processTimeIntervalArgs(args, default_interval);
-    Test.test!("<=")(interval.begin, time(null) - default_interval);
-    Test.test!("==")(interval.end, time(null));
+    Test.testThrown!(Exception)(processTimeIntervalArgs(args));
 
     /// When the begin date is provided
     args = new Arguments;

--- a/src/ocean/text/arguments/TimeIntervalArgs.d
+++ b/src/ocean/text/arguments/TimeIntervalArgs.d
@@ -405,37 +405,29 @@ unittest
 
 public long parseTimeInterval ( cstring value )
 {
-    if ( value == "" )
-    {
-        return 0;
-    }
-
     long result;
-    long tempValue;
 
-    char unit = value[value.length - 1];
-
-    if ( !toLong(value[0..$-1], tempValue) )
+    if ( value.length < 2 || !toLong(value[0..$-1], result) || result == 0 )
     {
         throw new Exception("The provided time interval has an invalid value.");
     }
 
+    char unit = value[value.length - 1];
     switch ( unit )
     {
         case 's':
-            result = tempValue;
             break;
 
         case 'm':
-            result = tempValue * 60;
+            result *= 60;
             break;
 
         case 'h':
-            result = tempValue * 3600;
+            result *= 3600;
             break;
 
         case 'd':
-            result = tempValue * 3600 * 24;
+            result *= 3600 * 24;
             break;
 
         default:
@@ -448,7 +440,6 @@ public long parseTimeInterval ( cstring value )
 ///
 unittest
 {
-    Test.test!("==")(parseTimeInterval(""), 0);
     Test.test!("==")(parseTimeInterval("1s"), 1);
     Test.test!("==")(parseTimeInterval("1m"), 60);
     Test.test!("==")(parseTimeInterval("2m"), 120);
@@ -457,6 +448,8 @@ unittest
     Test.test!("==")(parseTimeInterval("1d"), 3600 * 24);
     Test.test!("==")(parseTimeInterval("2d"), 3600 * 48);
 
+    Test.testThrown!(Exception)(parseTimeInterval(""), false);
+    Test.testThrown!(Exception)(parseTimeInterval("0s"), false);
     Test.testThrown!(Exception)(parseTimeInterval("2x"), false);
     Test.testThrown!(Exception)(parseTimeInterval("1xm"), false);
 }

--- a/src/ocean/text/arguments/TimeIntervalArgs.d
+++ b/src/ocean/text/arguments/TimeIntervalArgs.d
@@ -185,6 +185,27 @@ private long parseDateString ( cstring value, long date_time )
     return 0;
 }
 
+/// Timestamp to use in unit tests;
+version ( UnitTest )
+{
+    // 04/01/2019 @ 3:26pm (UTC)
+    const TEST_TIME_NOW = 1554132392;
+
+    /***************************************************************************
+
+        Params
+            _unused = Unused.
+
+        Returns:
+            Fake "now" time to use within the unit tests.
+
+    ***************************************************************************/
+
+    private time_t time ( tm* _unused )
+    {
+        return TEST_TIME_NOW;
+    }
+}
 
 /// Check the date arguments setup
 unittest
@@ -274,8 +295,8 @@ unittest
     args.parse("--time-interval 1m 1m");
     interval = processTimeIntervalArgs(args);
 
-    Test.test!("==")(interval.begin, time(null) - 60);
-    Test.test!("==")(interval.end, time(null) + 60);
+    Test.test!("==")(interval.begin, TEST_TIME_NOW - 60);
+    Test.test!("==")(interval.end, TEST_TIME_NOW + 60);
 
     /// Using an invalid argument
     args = new Arguments;


### PR DESCRIPTION
This PR adds the following features
1. specifying "yesterday" will use the unix timestamp of the previous day
2. specifying a single parameter now supported
    - With timestamp (including 'yesterday' it will be 24 hours range after given time.
    - With a duration provided it will be a range of X in the past to the current time.

it also adds an overload for the 'time' method to unsure the unit tests are using a stable value.

---

I've added a second commit to standardize how the interval is defined. It is to never include the final
parsed second. For example, `"-t 1h" with now:1000 (start:940, end:999)`. This was done after an internal poll and discussion.