### PR TITLE
Deprecate IMicrosecondsClock

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -24,6 +24,7 @@ endif
 TEST_FILTER_OUT += \
 	$C/src/ocean/util/serialize/contiguous/model/LoadCopyMixin.d \
 	$C/src/ocean/util/serialize/model/VersionDecoratorMixins.d \
+	$C/src/ocean/time/model/IMicrosecondsClock.d \
 	$C/src/ocean/io/UnicodeFile.d
 
 # Remove coverage files

--- a/relnotes/microseconds.deprecation.md
+++ b/relnotes/microseconds.deprecation.md
@@ -1,0 +1,4 @@
+### Deprecation of `IMicrosecondsClock`
+
+This ocean module and containing interface family was not used anywhere in ocean
+and is now pending removal.

--- a/src/ocean/io/console/AppStatus.d
+++ b/src/ocean/io/console/AppStatus.d
@@ -67,7 +67,6 @@ import ocean.io.Stdout;
 import ocean.io.Terminal;
 import ocean.io.model.IConduit;
 import ocean.text.convert.Formatter;
-import ocean.time.model.IMicrosecondsClock;
 import ocean.time.MicrosecondsClock;
 import ocean.transition;
 import ocean.util.container.AppendBuffer;

--- a/src/ocean/time/model/IMicrosecondsClock.d
+++ b/src/ocean/time/model/IMicrosecondsClock.d
@@ -13,7 +13,7 @@
 
  ******************************************************************************/
 
-module ocean.time.model.IMicrosecondsClock;
+deprecated module ocean.time.model.IMicrosecondsClock;
 
 
 


### PR DESCRIPTION
Unused ocean module/interface. Fixes #576.