### PR TITLE
Replace hex string literal in Tiger.d with ordinary string literal

### DIFF
--- a/src/ocean/util/digest/Tiger.d
+++ b/src/ocean/util/digest/Tiger.d
@@ -870,7 +870,7 @@ unittest
         "Tiger - A Fast New Hash Function, by Ross Anderson and Eli Biham",
         "Tiger - A Fast New Hash Function, by Ross Anderson and Eli Biham, proceedings of Fast Software Encryption 3, Cambridge.",
         "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq",
-        x"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000",
+        "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x08\0\0\0",
     ];
 
     static istring[] results = [


### PR DESCRIPTION
Hex string literals are deprecated in D.  We are trying to remove them from the language (https://github.com/dlang/dmd/pull/9549).  Since Ocean is part of D's test suite, we need this hex string remedied.