### PR TITLE
Workaround a compiler bug

### DIFF
--- a/src/ocean/util/container/cache/ExpiringCache.d
+++ b/src/ocean/util/container/cache/ExpiringCache.d
@@ -336,7 +336,16 @@ class ExpiringCache ( size_t ValueSize = 0 ) : Cache!(ValueSize, true),
             time_t access_time;
 
             cache_item = this.access(**node, access_time);
-            assert(cache_item !is null);
+            // XXX: This was previously an assert() but it was changed to
+            // verify() due to a compiler bug when using -release -inline -O.
+            // In that case the null check is removed by -release and it seems
+            // that due to compiler optimizations and inlining, the compiler
+            // ends up thinking that cache_item is null when used afterwards
+            // (in the following if statement for example). By using verify()
+            // instead of assert() we make sure the compiler can see there is a
+            // null check even when -release is used.
+            verify(cache_item !is null,
+                    "cache item existed, so it shouldn't be null");
             bool empty = cache_item.value_ref.length == 0;
 
             time_t used_lifetime = empty ? this.empty_lifetime : this.lifetime;


### PR DESCRIPTION
We had reports of this code issuing a compile error with dmd 1.081.2 and 1.082.1 when -release -O -inline is used. The errors being:

```
./submodules/ocean/src/ocean/util/container/cache/ExpiringCache.d(346): Error: null dereference in function _D5ocean4util9container5cache13ExpiringCache22__T13ExpiringCacheVm8Z13ExpiringCache19getExpiringOrCreateMFmJbbZAv
./submodules/ocean/src/ocean/util/container/cache/ExpiringCache.d(355): Error: null dereference in function _D5ocean4util9container5cache13ExpiringCache22__T13ExpiringCacheVm8Z13ExpiringCache19getExpiringOrCreateMFmJbbZAv
./submodules/ocean/src/ocean/util/container/cache/ExpiringCache.d(362): Error: null dereference in function _D5ocean4util9container5cache13ExpiringCache22__T13ExpiringCacheVm8Z13ExpiringCache19getExpiringOrCreateMFmJbbZAv
```

Looking at those lines of code (in v4.4.0+breaking) is quite clear that cache_item can't really be `null`, there is even an `assert()` checking for that, and it would be impossible for the compile it to determine it at compile time, so this really looks like a compiler bug.

For now we just convert the assert() to verify() to make sure the check is not removed by -release, and the optimizer doesn't get confused.