### PR TITLE
 Add a client for sending stats to prometheus

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -35,6 +35,12 @@ $O/test-%: override LDFLAGS += -lebtree
 $O/test-filesystemevent: override LDFLAGS += -lrt
 
 $O/test-httpserver: override LDFLAGS += -lglib-2.0
+$O/test-asyncio: override LDFLAGS += -lglib-2.0
+$O/test-signalext: override LDFLAGS += -lglib-2.0
+$O/test-reopenfiles: override LDFLAGS += -lglib-2.0
+$O/test-sysstats: override LDFLAGS += -lglib-2.0
+$O/test-taskext_daemon: override LDFLAGS += -lglib-2.0
+$O/test-unixsockext: override LDFLAGS += -lglib-2.0
 
 # Link unittests to all used libraries
 $O/%unittests: override LDFLAGS += -lglib-2.0 -lpcre -lxml2 -lxslt -lebtree \

--- a/Build.mak
+++ b/Build.mak
@@ -37,6 +37,7 @@ $O/test-filesystemevent: override LDFLAGS += -lrt
 $O/test-httpserver: override LDFLAGS += -lglib-2.0
 $O/test-asyncio: override LDFLAGS += -lglib-2.0
 $O/test-signalext: override LDFLAGS += -lglib-2.0
+$O/test-prometheusstats: override LDFLAGS += -lglib-2.0
 $O/test-reopenfiles: override LDFLAGS += -lglib-2.0
 $O/test-sysstats: override LDFLAGS += -lglib-2.0
 $O/test-taskext_daemon: override LDFLAGS += -lglib-2.0

--- a/integrationtest/prometheusstats/main.d
+++ b/integrationtest/prometheusstats/main.d
@@ -1,0 +1,185 @@
+/*******************************************************************************
+
+    Test-suite for stat collection using prometheus.
+
+    This test uses a TCP socket connection to `localhost:8080`.
+
+    Copyright: Copyright (c) 2019 dunnhumby Germany GmbH. All rights reserved
+
+    License:
+        Boost Software License Version 1.0. See LICENSE_BOOST.txt for details.
+        Alternatively, this file may be distributed under the terms of the Tango
+        3-Clause BSD License (see LICENSE_BSD.txt for details).
+
+*******************************************************************************/
+
+module integrationtest.prometheusstats.main;
+
+import ocean.transition;
+
+import ocean.io.select.EpollSelectDispatcher;
+import ocean.task.Task;
+import ocean.task.Scheduler;
+import ocean.text.convert.Formatter;
+import ocean.sys.socket.IPSocket;
+import ocean.sys.ErrnoException;
+import core.stdc.errno;
+import core.stdc.stdlib;
+
+import ocean.util.prometheus.collector.Collector;
+import ocean.util.prometheus.collector.CollectorRegistry;
+import ocean.util.prometheus.server.PrometheusListener;
+
+import ocean.io.Stdout;
+
+/// A class containing structs representing stats and their labels, a method
+/// that can be added to the CollectorRegistry, followed by a textual
+/// representation of the stats mock-collected here.
+class PrometheusStats
+{
+    ///
+    struct Statistics
+    {
+        ulong up_time_s;
+        size_t count;
+        float ratio;
+        double fraction;
+        real very_real;
+    }
+
+    ///
+    struct Labels
+    {
+        hash_t id;
+        cstring job;
+        float perf;
+    }
+
+    ///
+    void collect ( Collector collector )
+    {
+        collector.collect(
+            Statistics(3600, 347, 3.14, 6.023, 0.43),
+            Labels(1_235_813, "ocean", 3.14159));
+    }
+
+    ///
+    static istring collection_text =
+        "up_time_s {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 3600\n" ~
+        "count {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 347\n" ~
+        "ratio {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 3.14\n" ~
+        "fraction {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 6.023\n" ~
+        "very_real {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 0.43\n";
+}
+
+/// HTTP client task. It sends one HTTP GET request to the prometheus endpoint
+/// and receives a respone that should contain the expected stats, as provided
+/// in `PrometheusStats.collection_text`.
+class ClientTask: Task
+{
+    import Finder = ocean.core.array.Search;
+    import ocean.core.Test: test;
+    import ocean.io.select.protocol.task.TaskSelectTransceiver;
+    import ocean.io.select.protocol.generic.ErrnoIOException: SocketError;
+
+    public Exception to_report;
+
+    private TaskSelectTransceiver tst;
+
+    private IPSocket!() socket;
+    private SocketError socket_err;
+    private IPSocket!().InetAddress srv_address;
+
+    private mstring response_msg;
+
+    ///
+    this ( IPSocket!().InetAddress srv_address )
+    {
+        this.socket = new IPSocket!();
+        this.socket_err = new SocketError(socket);
+
+        this.tst = new TaskSelectTransceiver(socket, socket_err, socket_err);
+
+        this.srv_address = srv_address;
+    }
+
+    ///
+    override void run ( )
+    {
+        try
+        {
+            this.socket_err.enforce(
+                this.socket.tcpSocket(true) >= 0, "", "socket");
+
+            connect(this.tst, delegate (IPSocket!() socket) {
+                return !socket.connect(this.srv_address.addr);
+            });
+
+            this.tst.write(
+                "GET /metrics HTTP/1.1\r\nHost: oceantest.net\r\n\r\n");
+
+            this.tst.readConsume(&this.consume);
+            test!("==")(this.response_msg, PrometheusStats.collection_text);
+        }
+        catch (Exception ex)
+        {
+            this.to_report = ex;
+        }
+    }
+
+    ///
+    size_t consume ( void[] data )
+    {
+        cstring header_end = "\r\n\r\n";
+        auto header_end_idx = Finder.find(cast(char[])data, header_end);
+
+        if (header_end_idx == data.length)
+        {
+            return data.length + 1;
+        }
+
+        sformat(this.response_msg, "{}",
+            cast(char[])data[header_end_idx + 4 .. $]);
+        return 0;
+    }
+}
+
+/*******************************************************************************
+
+    Runs the server, which listens to one request on the prometheus endpoint,
+    and exits.
+
+    Returns:
+        `EXIT_SUCCESS`
+
+*******************************************************************************/
+
+version(UnitTest) {} else
+int main ( )
+{
+    initScheduler(SchedulerConfiguration.init);
+
+    auto stats = new PrometheusStats();
+    auto registry = new CollectorRegistry([&stats.collect]);
+
+    IPSocket!().InetAddress srv_address;
+
+    auto listener = new PrometheusListener(srv_address("127.0.0.1", 8080),
+        new IPSocket!(), registry, theScheduler.epoll);
+
+    auto client = new ClientTask(srv_address);
+    client.terminationHook = delegate {
+        theScheduler.epoll.unregister(listener);
+    };
+
+    listener.registerEventHandling(theScheduler.epoll);
+    theScheduler.schedule(client);
+    theScheduler.eventLoop();
+
+    if (client.to_report !is null)
+    {
+        throw client.to_report;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/relnotes/prometheus.feature.md
+++ b/relnotes/prometheus.feature.md
@@ -1,0 +1,39 @@
+### Add a client for sending stats to prometheus
+
+`integrationtest.prometheusstats.main`,
+`ocean.util.app.DaemonApp`,
+`ocean.util.prometheus.collector.Collector`,
+`ocean.util.prometheus.collector.CollectorRegistry`,
+`ocean.util.prometheus.collector.StatFormatter`,
+`ocean.util.prometheus.server.PrometheusHandler`,
+`ocean.util.prometheus.server.PrometheusListener`
+
+Prometheus sends HTTP GET requests to an application at `/metrics` endpoint to
+pull stats from it. This feature adds a listener for these requests, and a
+handler to response with stats to prometheus.
+
+Also introduced here are classes that interface between the handler and a
+client application, such that the handler is able to invoke callbacks that
+collect stats from the client application upon receiving requests from
+prometheus.
+
+The `DaemonApp` class now has two functions, namely, `collectSystemStats` and
+`collectGCStats`, to allow existing implementations to initially incorporate
+system and GC stats into Prometheus' stat collection with ease.
+
+In general, the steps to start stat collection using Prometheus would be:
+
+    a. Create a `CollectorRegistry` instance with all the delegates, fetching
+       your desired stats.
+    b. Create a `PrometheusListener` instance with your desired socket address
+       and the `CollectorRegistry` instance (created in step a).
+    c. Register the `PrometheusListener` instance (created in step b) with your
+       epoll dispatcher, using the `PrometheusListener.registerEventHandling`
+       method.
+
+To stop the listener, the method `PrometheusListener.shutdown` should suffice
+(along with de-registering from epoll, if needed).
+
+For a detailed and functional example, please refer to the system test module,
+`integrationtest.prometheusstats.main` and the unittest in module
+`ocean.util.prometheus.server.PrometheusListener`.

--- a/src/ocean/util/app/DaemonApp.d
+++ b/src/ocean/util/app/DaemonApp.d
@@ -82,6 +82,7 @@ public abstract class DaemonApp : Application,
     import ocean.util.app.ExitException;
     import ocean.util.log.Logger;
     import ocean.util.log.Stats;
+    import ocean.util.prometheus.collector.Collector;
 
     static import core.sys.posix.signal;
 
@@ -668,6 +669,19 @@ public abstract class DaemonApp : Application,
 
     /***************************************************************************
 
+        Collects CPU and memory stats for incoming prometheus' requests. Should
+        be sent, as a callback, to the CollectorRegistry instance used in
+        prometheus request listener.
+
+    ***************************************************************************/
+
+    public void collectSystemStats ( Collector prometheus_collector )
+    {
+        prometheus_collector.collect(this.system_stats.collect());
+    }
+
+    /***************************************************************************
+
         Collects GC stats and reports them to stats log. Should be
         called periodically (inside onStatsTimer).
 
@@ -676,6 +690,19 @@ public abstract class DaemonApp : Application,
     protected void reportGCStats ( )
     {
         this.stats_ext.stats_log.add(this.gc_stats.collect());
+    }
+
+    /***************************************************************************
+
+        Collects GC stats for incoming prometheus' requests. Should be sent,
+        as a callback, to the CollectorRegistry instance used in prometheus
+        request listener.
+
+    ***************************************************************************/
+
+    public void collectGCStats ( Collector prometheus_collector )
+    {
+        prometheus_collector.collect(this.gc_stats.collect());
     }
 
     /***************************************************************************

--- a/src/ocean/util/prometheus/collector/Collector.d
+++ b/src/ocean/util/prometheus/collector/Collector.d
@@ -1,0 +1,327 @@
+/*******************************************************************************
+
+    Contains methods that collect stats from primitive data members of structs
+    or classes to respond to Prometheus queries with.
+
+    The metric designs specified by Prometheus
+    (`https://prometheus.io/docs/concepts/metric_types/`) have not been
+    implemented yet. So, as of now, this collector can process only primitive
+    data-type members from a struct or a class. However, the current Prometheus
+    stat collection framework could be enhanced to support metrics with a very
+    little effort.
+
+    In Prometheus' data model, the stats that are measured are called Metrics,
+    and the dimensions along which stats are measured are called Labels.
+
+    Metrics can be any measurable value, e.g., CPU or memory consumption.
+
+    Labels resemble key-value pairs, where the key is referred to as a label's
+    name, and the value as a label's value. A label name would refer to the name
+    of a dimension across which we want to measure stats. Correspondingly, a
+    label value would refer to a point along the said dimension. A stat can have
+    more than one label, if it is intended to be measured across multiple
+    dimensions.
+
+    Stats with labels look like the following example
+    `
+    promhttp_metric_handler_requests_total{code="200"} 3
+    promhttp_metric_handler_requests_total{code="500"} 0
+    promhttp_metric_handler_requests_total{code="503"} 0
+    `
+    Here `promhttp_metric_handler_requests_total` is the metric, `code` is
+    the label name, `"200"`, `"500"` and `"503"` are the label values, and `3`,
+    `0` and `0` are the respective metric values.
+
+    On the data visualization side of Prometheus, fetching stats using queries
+    is analogous to calling functions. A metric name is analogous to a function
+    name, and a label is analogous to a function parameter. Continuing with the
+    above example, the following query will return `3`:
+    `
+    promhttp_metric_handler_requests_total {code="200"}
+    `
+
+    (For detailed information about Prometheus-specific terminology, e.g.,
+    Metrics and Labels, please refer to
+    `https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels`.)
+
+    This module contains a class which can be used to collect metrics as well as
+    labels from composite-type values, and format them in a way acceptable for
+    Prometheus.
+
+    Copyright:
+        Copyright (c) 2019 dunnhumby Germany GmbH.
+        All rights reserved
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+*******************************************************************************/
+
+module ocean.util.prometheus.collector.Collector;
+
+/*******************************************************************************
+
+    This class provides methods to collect metrics with no label, one label, or
+    multiple labels, using overloaded definitions of the `collect` method.
+
+    Once the desired stats have been collected, the accumulated response
+    string can be collected using the `getCollection` method.
+
+    Additionally, the `reset` method can be used to reset stat
+    collection, when the desired stats have been collected from a Collector
+    instance.
+
+*******************************************************************************/
+
+public class Collector
+{
+    import core.stdc.time;
+    import Traits = ocean.core.Traits;
+    import ocean.math.IEEE;
+    import ocean.text.convert.Formatter;
+    import ocean.transition;
+    import StatFormatter = ocean.util.prometheus.collector.StatFormatter;
+
+    /// A buffer used for storing collected stats. Is cleared when the `reset`
+    /// method is called.
+    private mstring collect_buf;
+
+    /***************************************************************************
+
+        Returns:
+            The stats collected since the last call to the `reset` method, in a
+            textual respresentation that can be readily added to a response
+            message body.
+            The specifications of the format of the collected stats can be found
+            at `https://prometheus.io/docs/instrumenting/exposition_formats/`.
+
+    ***************************************************************************/
+
+    public cstring getCollection ( )
+    {
+        return this.collect_buf;
+    }
+
+    /// Reset the length of the stat collection buffer to 0.
+    public void reset ( )
+    {
+        this.collect_buf.length = 0;
+        enableStomping(this.collect_buf);
+    }
+
+    /***************************************************************************
+
+        Collect stats from the data members of a struct or a class and prepare
+        them to be fetched upon the next call to `getCollection`. The
+        specifications of the format of the collected stats can be found at
+        `https://prometheus.io/docs/instrumenting/exposition_formats/`.
+
+        Params:
+            ValuesT = The struct or class type to fetch the stat names from.
+            values  = The struct or class to fetch stat values from.
+
+    ***************************************************************************/
+
+    public void collect ( ValuesT ) ( ValuesT values )
+    {
+        static assert (is(ValuesT == struct) || is(ValuesT == class),
+            "'values' parameter must be a struct or a class.");
+
+        StatFormatter.formatStats(values, this.collect_buf);
+    }
+
+    /***************************************************************************
+
+        Collect stats from the data members of a struct or a class, annotate
+        them with a given label name and value, and prepare them to be fetched
+        upon the next call to `getCollection`.
+        The specifications of the format of the collected stats can be found
+        at `https://prometheus.io/docs/instrumenting/exposition_formats/`.
+
+        Params:
+            LabelName = The name of the label to annotate the stats with.
+            ValuesT   = The struct or class type to fetch the stat names from.
+            LabelT    = The type of the label's value.
+            values    = The struct or class to fetch stat values from.
+            label_val = The label value to annotate the stats with.
+
+    ***************************************************************************/
+
+    public void collect ( istring LabelName, ValuesT, LabelT ) (
+        ValuesT values, LabelT label_val )
+    {
+        static assert (is(ValuesT == struct) || is(ValuesT == class),
+            "'values' parameter must be a struct or a class.");
+
+        StatFormatter.formatStats!(LabelName)(values, label_val,
+            this.collect_buf);
+    }
+
+    /***************************************************************************
+
+        Collect stats from the data members of a struct or a class, annotate
+        them with labels from the data members of another struct or class, and
+        prepare them to be fetched upon the next call to `getCollection`.
+        The specifications of the format of the collected stats can be found
+        at `https://prometheus.io/docs/instrumenting/exposition_formats/`.
+
+        Params:
+            ValuesT = The struct or class type to fetch the stat names from.
+            LabelsT = The struct or class type to fetch the label names from.
+            values  = The struct or class to fetch stat values from.
+            labels  = The struct or class holding the label values to annotate
+                      the stats with.
+
+    ***************************************************************************/
+
+    public void collect ( ValuesT, LabelsT ) ( ValuesT values, LabelsT labels )
+    {
+        static assert (is(ValuesT == struct) || is(ValuesT == class),
+            "'values' parameter must be a struct or a class.");
+        static assert (is(LabelsT == struct) || is(LabelsT == class),
+            "'labels' parameter must be a struct or a class.");
+
+        StatFormatter.formatStats(values, labels, this.collect_buf);
+    }
+}
+
+version (UnitTest)
+{
+    import ocean.core.Test;
+    import ocean.transition;
+
+    struct Statistics
+    {
+        ulong up_time_s;
+        size_t count;
+        float ratio;
+        double fraction;
+        real very_real;
+
+        // The following should not be collected as stats
+        int delegate ( int ) a_delegate;
+        void function ( ) a_function;
+    }
+
+    struct Labels
+    {
+        hash_t id;
+        cstring job;
+        float perf;
+    }
+}
+
+/// Test collecting populated stats, but without any label.
+unittest
+{
+    auto test_collector = new Collector();
+    test_collector.collect(Statistics(3600, 347, 3.14, 6.023, 0.43));
+
+    test!("==")(test_collector.getCollection(),
+        "up_time_s 3600\ncount 347\nratio 3.14\nfraction 6.023\n" ~
+        "very_real 0.43\n");
+}
+
+/// Test collecting populated stats with one label
+unittest
+{
+    auto test_collector = new Collector();
+    test_collector.collect!("id")(
+        Statistics(3600, 347, 3.14, 6.023, 0.43), 123.034);
+
+    test!("==")(test_collector.getCollection(),
+        "up_time_s {id=\"123.034\"} 3600\ncount {id=\"123.034\"} 347\n" ~
+        "ratio {id=\"123.034\"} 3.14\nfraction {id=\"123.034\"} 6.023\n" ~
+        "very_real {id=\"123.034\"} 0.43\n");
+}
+
+/// Test collecting stats having initial values with multiple labels
+unittest
+{
+    auto test_collector = new Collector();
+    test_collector.collect(Statistics(3600, 347, 3.14, 6.023, 0.43),
+        Labels(1_235_813, "ocean", 3.14159));
+
+    test!("==")(test_collector.getCollection(),
+        "up_time_s {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 3600\n" ~
+        "count {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 347\n" ~
+        "ratio {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 3.14\n" ~
+        "fraction {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 6.023\n" ~
+        "very_real {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 0.43\n");
+}
+
+/// Test resetting collected stats
+unittest
+{
+    auto test_collector = new Collector();
+    test_collector.collect!("id")(Statistics.init, 123);
+
+    test!("==")(test_collector.getCollection(),
+        "up_time_s {id=\"123\"} 0\ncount {id=\"123\"} 0\n" ~
+        "ratio {id=\"123\"} 0\nfraction {id=\"123\"} 0\n" ~
+        "very_real {id=\"123\"} 0\n");
+
+    test_collector.reset();
+
+    test!("==")(test_collector.getCollection(), "");
+}
+
+// Test collecting stats having initial values, but without any label.
+unittest
+{
+    auto test_collector = new Collector();
+    test_collector.collect(Statistics.init);
+
+    test!("==")(test_collector.getCollection(),
+        "up_time_s 0\ncount 0\nratio 0\nfraction 0\nvery_real 0\n");
+}
+
+// Test collecting stats having initial values with one label
+unittest
+{
+    auto test_collector = new Collector();
+    test_collector.collect!("id")(Statistics.init, 123);
+
+    test!("==")(test_collector.getCollection(),
+        "up_time_s {id=\"123\"} 0\ncount {id=\"123\"} 0\n" ~
+        "ratio {id=\"123\"} 0\nfraction {id=\"123\"} 0\n" ~
+        "very_real {id=\"123\"} 0\n");
+}
+
+// Test collecting stats having initial values with multiple labels
+unittest
+{
+    auto test_collector = new Collector();
+    test_collector.collect(Statistics.init, Labels.init);
+
+    test!("==")(test_collector.getCollection(),
+        "up_time_s {id=\"0\",job=\"\",perf=\"0\"} 0\n" ~
+        "count {id=\"0\",job=\"\",perf=\"0\"} 0\n" ~
+        "ratio {id=\"0\",job=\"\",perf=\"0\"} 0\n" ~
+        "fraction {id=\"0\",job=\"\",perf=\"0\"} 0\n" ~
+        "very_real {id=\"0\",job=\"\",perf=\"0\"} 0\n");
+}
+
+// Test accumulation of collected stats
+unittest
+{
+    auto test_collector = new Collector();
+    test_collector.collect!("id")(Statistics.init, 123);
+
+    test!("==")(test_collector.getCollection(),
+        "up_time_s {id=\"123\"} 0\ncount {id=\"123\"} 0\n" ~
+        "ratio {id=\"123\"} 0\nfraction {id=\"123\"} 0\n" ~
+        "very_real {id=\"123\"} 0\n");
+
+    test_collector.collect!("id")(
+        Statistics(3600, 347, 3.14, 6.023, 0.43), 123.034);
+
+    test!("==")(test_collector.getCollection(),
+        "up_time_s {id=\"123\"} 0\ncount {id=\"123\"} 0\n" ~
+        "ratio {id=\"123\"} 0\nfraction {id=\"123\"} 0\n" ~
+        "very_real {id=\"123\"} 0\n" ~
+
+        "up_time_s {id=\"123.034\"} 3600\ncount {id=\"123.034\"} 347\n" ~
+        "ratio {id=\"123.034\"} 3.14\nfraction {id=\"123.034\"} 6.023\n" ~
+        "very_real {id=\"123.034\"} 0.43\n");
+}

--- a/src/ocean/util/prometheus/collector/CollectorRegistry.d
+++ b/src/ocean/util/prometheus/collector/CollectorRegistry.d
@@ -1,0 +1,213 @@
+/*******************************************************************************
+
+    Contains a collection of prometheus stat collectors that acts as an
+    interface between the response handler, and stat collectors from every
+    individual metric and label set.
+
+    Copyright:
+        Copyright (c) 2019 dunnhumby Germany GmbH.
+        All rights reserved
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+*******************************************************************************/
+
+module ocean.util.prometheus.collector.CollectorRegistry;
+
+/// ditto
+public class CollectorRegistry
+{
+    import ocean.transition;
+    import ocean.util.prometheus.collector.Collector : Collector;
+
+    /// An alias for the type of delegates that are called for stat collection
+    public alias void delegate ( Collector ) CollectionDg;
+
+    /// An array of delegates that are called for stat collection
+    private CollectionDg[] collector_callbacks;
+
+    /// The collector to use for stat collection. This acts as the actual
+    /// parameter for the delegates in `collector_callbacks`.
+    private Collector collector;
+
+    /***************************************************************************
+
+        Constructor, that accepts an array of stat collection callbacks.
+
+        Params:
+            callbacks = An array of delegates to be called for stat collection.
+
+    ***************************************************************************/
+
+    public this ( CollectionDg[] callbacks )
+    {
+        this.collector = new Collector();
+        this.collector_callbacks = callbacks;
+    }
+
+    /***************************************************************************
+
+        Appends a stat collector callback to the list of existing ones.
+        May result in a re-allocation of the entire buffer storing the
+        callbacks.
+
+        Params:
+            collector = The stat collector to append.
+
+    ***************************************************************************/
+
+    public void addCollector ( CollectionDg collector )
+    {
+        this.collector_callbacks ~= collector;
+    }
+
+    /***************************************************************************
+
+        Collects stats by calling all delegates specified for stat collection,
+        formats them using `ocean.util.prometheus.collector.StatFormatter`
+        eventually, and finally returns the accumulated result. The
+        specifications of the format can be found at
+        `https://prometheus.io/docs/instrumenting/exposition_formats/`.
+
+        Returns:
+            The stats accumulated since last time this method was called.
+
+    ***************************************************************************/
+
+    public cstring collect ( )
+    {
+        this.collector.reset();
+
+        try
+        {
+            foreach (ref callback; this.collector_callbacks)
+            {
+                callback(this.collector);
+            }
+        }
+        catch (Exception ex)
+        {
+            throw ex;
+        }
+
+        return this.collector.getCollection();
+    }
+}
+
+version (UnitTest)
+{
+    import ocean.core.Test;
+    import Traits = ocean.core.Traits;
+    import ocean.transition;
+    import ocean.util.prometheus.collector.Collector;
+
+    ///
+    public struct Statistics
+    {
+        ulong up_time_s;
+        size_t count;
+        float ratio;
+        double fraction;
+        real very_real;
+    }
+
+    ///
+    public struct Labels
+    {
+        hash_t id;
+        cstring job;
+        float perf;
+    }
+
+    private class ExampleStats
+    {
+        Statistics test_stats;
+        Labels test_labels;
+
+        ///
+        public void setTestStats ( Statistics stats )
+        {
+            test_stats = stats;
+        }
+
+        ///
+        public void setTestLabels ( Labels labels )
+        {
+            test_labels = labels;
+        }
+
+        ///
+        public void collectDg1 ( Collector collector )
+        {
+            collector.collect!("id")(test_stats, 123.034);
+        }
+
+        ///
+        public void collectDg2 ( Collector collector )
+        {
+            collector.collect(test_stats, test_labels);
+        }
+    }
+}
+
+/// Test collection from a single delegate
+unittest
+{
+    auto stats = new ExampleStats();
+    auto registry = new CollectorRegistry([&stats.collectDg1]);
+
+    stats.setTestStats(Statistics(3600, 347, 3.14, 6.023, 0.43));
+
+    test!("==")(registry.collect(),
+        "up_time_s {id=\"123.034\"} 3600\ncount {id=\"123.034\"} 347\n" ~
+        "ratio {id=\"123.034\"} 3.14\nfraction {id=\"123.034\"} 6.023\n" ~
+        "very_real {id=\"123.034\"} 0.43\n");
+}
+
+/// Test collection from more than one delegates
+unittest
+{
+    auto stats = new ExampleStats();
+    auto registry = new CollectorRegistry([&stats.collectDg1]);
+    registry.addCollector(&stats.collectDg2);
+
+    stats.setTestStats(Statistics(3600, 347, 3.14, 6.023, 0.43));
+    stats.setTestLabels(Labels(1_235_813, "ocean", 3.14159));
+
+    test!("==")(registry.collect(),
+        "up_time_s {id=\"123.034\"} 3600\ncount {id=\"123.034\"} 347\n" ~
+        "ratio {id=\"123.034\"} 3.14\nfraction {id=\"123.034\"} 6.023\n" ~
+        "very_real {id=\"123.034\"} 0.43\n" ~
+
+        "up_time_s {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 3600\n" ~
+        "count {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 347\n" ~
+        "ratio {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 3.14\n" ~
+        "fraction {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 6.023\n" ~
+        "very_real {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 0.43\n");
+}
+
+/// Test that the collections are not accumulated upon more than one call to
+/// the `collect` method.
+unittest
+{
+    auto stats = new ExampleStats();
+    auto registry = new CollectorRegistry([&stats.collectDg2]);
+
+    stats.setTestStats(Statistics(3600, 347, 3.14, 6.023, 0.43));
+    stats.setTestLabels(Labels(1_235_813, "ocean", 3.14159));
+
+    auto collected = registry.collect();
+
+    // Update the stats
+    stats.setTestStats(Statistics(4200, 257, 2.345, 1.098, 0.56));
+
+    // A 2nd call to `collect` should return the updated stats, without the
+    // previous values anywhere in it.
+    test!("==")(registry.collect(),
+        "up_time_s {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 4200\n" ~
+        "count {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 257\n" ~
+        "ratio {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 2.345\n" ~
+        "fraction {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 1.098\n" ~
+        "very_real {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 0.56\n");
+}

--- a/src/ocean/util/prometheus/collector/StatFormatter.d
+++ b/src/ocean/util/prometheus/collector/StatFormatter.d
@@ -1,0 +1,369 @@
+/*******************************************************************************
+
+    Contains methods that format primitive data members from structs or classes
+    into strings that can be exported as responses to prometheus queries.
+
+    Copyright:
+        Copyright (c) 2019 dunnhumby Germany GmbH.
+        All rights reserved
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+*******************************************************************************/
+
+module ocean.util.prometheus.collector.StatFormatter;
+
+import ocean.net.http.TaskHttpConnectionHandler;
+
+import core.stdc.time;
+import Traits = ocean.core.Traits;
+import ocean.math.IEEE;
+import ocean.text.convert.Formatter;
+import ocean.transition;
+
+/*******************************************************************************
+
+    Format data members from a struct or a class into a string that can be
+    added to a stat collection buffer for exporting to prometheus.
+
+    The names and values of the members of the given struct are formatted as
+    stat names and values, respectively.
+
+    Params:
+        ValuesT = The struct or class type to fetch the stat names from.
+        values  = The struct or class to fetch stat values from.
+        buffer  = The buffer to add the formatted stats to.
+
+*******************************************************************************/
+
+public static void formatStats ( ValuesT ) (
+    ValuesT values, ref mstring buffer )
+{
+    static assert (is(ValuesT == struct) || is(ValuesT == class),
+        "'values' parameter must be a struct or a class.");
+
+    foreach (i, ValMemberT; typeof(ValuesT.tupleof))
+    {
+        static if (Traits.isPrimitiveType!(ValMemberT))
+        {
+            sformat(buffer, "{}", Traits.FieldName!(i, ValuesT));
+            appendValue(*Traits.GetField!(i, ValMemberT, ValuesT)(&values),
+                buffer);
+        }
+    }
+}
+
+/*******************************************************************************
+
+    Format data members from a struct or a class, with a additional label name
+    and value, into a string that can be added to a stat collection buffer for
+    exporting to prometheus.
+
+    Params:
+        LabelName = The name of the label to annotate the stats with.
+        ValuesT   = The struct or class type to fetch the stat names from.
+        LabelT    = The type of the label's value.
+        values    = The struct or class to fetch stat values from.
+        label_val = The label value to annotate the stats with.
+        buffer    = The buffer to add the formatted stats to.
+
+*******************************************************************************/
+
+public static void formatStats ( istring LabelName, ValuesT, LabelT ) (
+    ValuesT values, LabelT label_val, ref mstring buffer )
+{
+    static assert (is(ValuesT == struct) || is(ValuesT == class),
+        "'values' parameter must be a struct or a class.");
+
+    foreach (i, ValMemberT; typeof(ValuesT.tupleof))
+    {
+        static if (Traits.isPrimitiveType!(ValMemberT))
+        {
+            sformat(buffer, "{} {{", Traits.FieldName!(i, ValuesT));
+
+            appendLabel!(LabelName)(label_val, buffer);
+
+            sformat(buffer, "}");
+            appendValue(*Traits.GetField!(i, ValMemberT, ValuesT)(&values),
+                buffer);
+        }
+    }
+}
+
+/*******************************************************************************
+
+    Format data members from a struct or a class, with an additional struct or
+    class to fetch label names and values from, into a string that can be added
+    to a stat collection buffer for exporting to prometheus.
+
+    Params:
+        ValuesT = The struct or class type to fetch the stat names from.
+        LabelsT = The struct or class type to fetch the label names from.
+        values  = The struct or class to fetch stat values from.
+        labels  = The struct or class holding the label values to annotate
+                    the stats with.
+        buffer  = The buffer to add the formatted stats to.
+
+*******************************************************************************/
+
+public static void formatStats ( ValuesT, LabelsT ) ( ValuesT values,
+    LabelsT labels, ref mstring buffer )
+{
+    static assert (is(ValuesT == struct) || is(ValuesT == class),
+        "'values' parameter must be a struct or a class.");
+    static assert (is(LabelsT == struct) || is(LabelsT == class),
+        "'labels' parameter must be a struct or a class.");
+
+    foreach (i, ValMemberT; typeof(ValuesT.tupleof))
+    {
+        static if (Traits.isPrimitiveType!(ValMemberT))
+        {
+            sformat(buffer, "{} {{", Traits.FieldName!(i, ValuesT));
+
+            bool first_label = true;
+
+            foreach (j, LabelMemberT; typeof(LabelsT.tupleof))
+            {
+                if (first_label)
+                {
+                    first_label = false;
+                }
+                else
+                {
+                    sformat(buffer, ",");
+                }
+
+                appendLabel!(Traits.FieldName!(j, LabelsT))(
+                    *Traits.GetField!(j, LabelMemberT, LabelsT)(&labels),
+                    buffer);
+            }
+
+            sformat(buffer, "}");
+            appendValue(*Traits.GetField!(i, ValMemberT, ValuesT)(&values),
+                buffer);
+        }
+    }
+}
+
+/*******************************************************************************
+
+    Appends a label name and value to a given buffer. If the value is of a
+    floating-point type, then appends it with a precision upto 6 decimal places.
+
+    Params:
+        LabelName = The name of the label to annotate the stats with.
+        LabelT    = The type of the label's value.
+        label_val = The label value to annotate the stats with.
+        buffer    = The buffer to append the label to.
+
+*******************************************************************************/
+
+private static void appendLabel ( istring LabelName, LabelT ) (
+    LabelT label_val, ref mstring buffer )
+{
+    static if (Traits.isFloatingPointType!(LabelT))
+    {
+        sformat(buffer, "{}=\"{:6.}\"", LabelName,
+            getSanitized(label_val));
+    }
+    else
+    {
+        sformat(buffer, "{}=\"{}\"", LabelName, label_val);
+    }
+}
+
+// Test appending a label with a value of type string
+unittest
+{
+    mstring buffer;
+    appendLabel!("labelname")("labelval", buffer);
+    test!("==")(buffer, "labelname=\"labelval\"");
+}
+
+// Test appending a label with an integer type value
+unittest
+{
+    mstring buffer;
+    appendLabel!("labelname")(2345678UL, buffer);
+    test!("==")(buffer, "labelname=\"2345678\"");
+}
+
+// Test appending a label with a floting point type value
+unittest
+{
+    mstring buffer;
+    appendLabel!("labelname")(3.1415926, buffer);
+    test!("==")(buffer, "labelname=\"3.141593\"");
+}
+
+/*******************************************************************************
+
+    Appends a stat value to a given buffer. If the value is of a floating-point
+    type, then appends it with a precision of upto 6 decimal places.
+
+    Params:
+        T      = The datatype of the value.
+        value  = The value to append to the buffer.
+        buffer = The buffer to which the stat value will be appended.
+
+*******************************************************************************/
+
+private static void appendValue ( T ) ( T value, ref mstring buffer )
+{
+    static if (Traits.isFloatingPointType!(T))
+    {
+        sformat(buffer, " {:6.}\n", getSanitized(value));
+    }
+    else
+    {
+        sformat(buffer, " {}\n", value);
+    }
+}
+
+// Test appending a non-floating-point values
+unittest
+{
+    mstring buffer;
+    appendValue(32768UL, buffer);
+    test!("==")(buffer, " 32768\n");
+}
+
+// Test appending a floating-point value having less than 6 decimal places
+unittest
+{
+    mstring buffer;
+    appendValue(3.14159, buffer);
+    test!("==")(buffer, " 3.14159\n");
+}
+
+// Test appending a floating-point value having more than 6 decimal places
+unittest
+{
+    mstring buffer;
+    appendValue(3.1415926, buffer);
+    test!("==")(buffer, " 3.141593\n");
+}
+
+/*******************************************************************************
+
+    Sanitizes floating-point type values.
+
+    If the datatype of the value is a floating-point type, then returns 0.0
+    for NaN and the datatype's maximum value for +/-Inf.
+    If the datatype of the value is not a floating-point type, then returns
+    the given value without any modification.
+
+    Params:
+        T      = The datatype of the value.
+        value  = The value to append to sanitize.
+
+    Returns:
+        The sanitized value, if the input is of a floating-point type,
+        otherwise the given value itself.
+
+*******************************************************************************/
+
+private static T getSanitized ( T ) ( T val )
+{
+    static if (Traits.isFloatingPointType!(T))
+    {
+        if (isNaN(val))
+        {
+            return 0.0;
+        }
+        else if (isInfinity(val))
+        {
+            return T.max;
+        }
+    }
+
+    return val;
+}
+
+// Test sanitization of a floating type value as NaN
+unittest
+{
+    test!("==")(getSanitized(double.init), 0.0);
+}
+
+// Test sanitization of a floating point value as infinity
+unittest
+{
+    test!("==")(getSanitized(double.infinity), double.max);
+}
+
+// Test that sanitization does not alter any floating point value that is
+// not NaN or Inf.
+unittest
+{
+    double pi = 3.141592;
+    test!("==")(getSanitized(pi), 3.141592);
+}
+
+
+version (UnitTest)
+{
+    import ocean.core.Test;
+    import ocean.transition;
+
+    struct Statistics
+    {
+        ulong up_time_s;
+        size_t count;
+        float ratio;
+        double fraction;
+        real very_real;
+    }
+
+    struct Labels
+    {
+        hash_t id;
+        cstring job;
+        float perf;
+    }
+}
+
+/// Test collecting populated stats, but without any label.
+unittest
+{
+    auto expected = "up_time_s 3600\ncount 347\nratio 3.14\nfraction 6.023\n" ~
+        "very_real 0.43\n";
+
+    mstring actual;
+    formatStats(Statistics(3600, 347, 3.14, 6.023, 0.43), actual);
+
+    test!("==")(actual, expected);
+}
+
+/// Test collecting populated stats with one label
+unittest
+{
+    auto expected =
+        "up_time_s {id=\"123.034\"} 3600\ncount {id=\"123.034\"} 347\n" ~
+        "ratio {id=\"123.034\"} 3.14\nfraction {id=\"123.034\"} 6.023\n" ~
+        "very_real {id=\"123.034\"} 0.43\n";
+
+    mstring actual;
+    formatStats!("id")(
+        Statistics(3600, 347, 3.14, 6.023, 0.43), 123.034, actual);
+
+    test!("==")(actual, expected);
+}
+
+/// Test collecting stats having initial values with multiple labels
+unittest
+{
+    auto expected =
+        "up_time_s {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 3600\n" ~
+        "count {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 347\n" ~
+        "ratio {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 3.14\n" ~
+        "fraction {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 6.023\n" ~
+        "very_real {id=\"1235813\",job=\"ocean\",perf=\"3.14159\"} 0.43\n";
+
+    mstring actual;
+    formatStats(Statistics(3600, 347, 3.14, 6.023, 0.43),
+        Labels(1_235_813, "ocean", 3.14159), actual);
+
+    test!("==")(actual, expected);
+}

--- a/src/ocean/util/prometheus/server/PrometheusHandler.d
+++ b/src/ocean/util/prometheus/server/PrometheusHandler.d
@@ -1,0 +1,150 @@
+/*******************************************************************************
+
+    An HTTP response handler for Prometheus' requests, used in
+    `PrometheusListener`.
+
+    Responds to GET requests only.
+
+    Copyright:
+        Copyright (c) 2019 dunnhumby Germany GmbH.
+        All rights reserved
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+*******************************************************************************/
+
+module ocean.util.prometheus.server.PrometheusHandler;
+
+import ocean.net.http.HttpConnectionHandler;
+
+/// ditto
+public class PrometheusHandler : HttpConnectionHandler
+{
+    import ocean.io.select.EpollSelectDispatcher : EpollSelectDispatcher;
+    import ocean.net.http.HttpRequest : HttpRequest;
+    import ocean.net.http.HttpConst: HttpResponseCode;
+    import ocean.net.http.consts.HttpMethod: HttpMethod;
+    import ocean.text.convert.Formatter : sformat;
+    import ocean.transition;
+    import ocean.util.log.Logger : Logger, Log;
+    import ocean.util.prometheus.collector.CollectorRegistry :
+        CollectorRegistry;
+
+    /// A static logger for logging information about connections.
+    private static Logger log;
+    static this ( )
+    {
+        this.log = Log.lookup("ocean.util.prometheus.server.PrometheusHandler");
+    }
+
+    /// A CollectorRegistry instance that refers to the callbacks that need to
+    /// be called for stat collection.
+    private CollectorRegistry collector_registry;
+
+    /// A buffer to hold error messages, if any exception while stat collection
+    /// is encountered.
+    private mstring err_buf;
+
+    /***************************************************************************
+
+        Constructor.
+
+        Initializes an HTTP request handler instance for GET requests at the
+        `/metrics` endpoint.
+
+        Params:
+            finalizer          = Finalizer callback of the select listener.
+            collector_registry = The CollectorRegistry instance, containing
+                                 references to the collection callbacks.
+            epoll              = The EpollSelectDispatcher instance used here.
+            stack_size         = The fiber stack size to use. Defaults to
+                                 `HttpConnectionHandler.default_stack_size`.
+
+    ***************************************************************************/
+
+    public this ( FinalizeDg finalizer, CollectorRegistry collector_registry,
+        EpollSelectDispatcher epoll,
+        size_t stack_size = HttpConnectionHandler.default_stack_size )
+    {
+        super(epoll, finalizer, stack_size, [HttpMethod.Get]);
+        this.collector_registry = collector_registry;
+    }
+
+    /***************************************************************************
+
+        Handles responses for incoming HTTP requests. Responds with stats when
+        the request endpoint is `/metrics`.
+        For all other endpoints, returns `HttpResponseCode.NotImplemented`.
+        If stat collection throws an error, responds with
+        `HttpResponseCode.InternalServerError`, with the exception message as
+        the response message body;
+
+        Params:
+            response_msg_body = Body of the response body.
+
+        Returns:
+            HTTP status code
+
+    ***************************************************************************/
+
+    override protected HttpResponseCode handleRequest (
+        out cstring response_msg_body )
+    {
+        if (this.request.uri_string() != "/metrics")
+        {
+            PrometheusHandler.log.info(
+                "Received request at an unhandled endpoint: {}",
+                this.request.uri_string());
+            return HttpResponseCode.NotImplemented;
+        }
+
+        try
+        {
+            response_msg_body = this.collector_registry.collect();
+            return HttpResponseCode.OK;
+        }
+        catch (Exception ex)
+        {
+            err_buf.length = 0;
+            enableStomping(err_buf);
+
+            sformat(err_buf, "{}({}):{}", ex.file, ex.line, ex.message());
+
+            PrometheusHandler.log.error(err_buf);
+            response_msg_body = err_buf;
+
+            return HttpResponseCode.InternalServerError;
+        }
+    }
+
+    /***************************************************************************
+
+        Logs an warning or error message when an IOWarning or IOError,
+        respectively, is caught.
+
+        An IOWarning is thrown when a socket read/write operation results in an
+        end-of-flow or hung-up condition, an IOError when an error event is
+        triggered for a socket.
+
+        Params:
+            e        = caught IOWarning or IOError
+            is_error = true: e was an IOError, false: e was an IOWarning
+
+     **************************************************************************/
+
+    override protected void notifyIOException (
+        ErrnoException e, bool is_error )
+    {
+        if (is_error)
+        {
+            PrometheusHandler.log.error("IOError encountered : {}({}):{}",
+                e.file, e.line, e.message());
+        }
+        else
+        {
+            PrometheusHandler.log.warn("IOWarning encountered : {}({}):{}",
+                e.file, e.line, e.message());
+        }
+    }
+}

--- a/src/ocean/util/prometheus/server/PrometheusListener.d
+++ b/src/ocean/util/prometheus/server/PrometheusListener.d
@@ -1,0 +1,182 @@
+/*******************************************************************************
+
+    Contains a listener for scrape requests by Prometheus.
+
+    Please refer to the unittest in this module for an example. A more elaborate
+    example can be found in `integrationtest.prometheusstats.main`.
+
+    Copyright:
+        Copyright (c) 2019 dunnhumby Germany GmbH.
+        All rights reserved
+
+    License:
+        Boost Software License Version 1.0. See LICENSE.txt for details.
+
+*******************************************************************************/
+
+module ocean.util.prometheus.server.PrometheusListener;
+
+import ocean.io.select.EpollSelectDispatcher;
+import ocean.net.server.SelectListener;
+import ocean.util.prometheus.collector.CollectorRegistry;
+import ocean.util.prometheus.server.PrometheusHandler;
+
+/*******************************************************************************
+
+    A listener for Prometheus' stat scrape.
+
+    Once instantiated with the set of callbacks that collect stats for given
+    stats and labels, the callbacks will be called for every incoming prometheus
+    request, and the accumulated stats will be appended to the response message.
+
+    Derives from `SelectListener` with four generic parameters, the last three
+    of which are used to instantiate the handler used by this listener.
+
+*******************************************************************************/
+
+public class PrometheusListener :
+    SelectListener!(PrometheusHandler, CollectorRegistry, EpollSelectDispatcher,
+        size_t)
+{
+    import core.sys.posix.sys.socket : sockaddr, time_t;
+    import ocean.io.select.client.TimerEvent : TimerEvent;
+    import ocean.net.http.HttpConnectionHandler : HttpConnectionHandler;
+    import ocean.sys.socket.model.ISocket : ISocket;
+    import ocean.text.convert.Formatter : sformat;
+    import ocean.util.log.Logger : Logger, Log;
+
+    import ocean.transition;
+
+    /// A static logger for logging information about connections.
+    private static Logger log;
+    static this ( )
+    {
+        PrometheusListener.log =
+            Log.lookup("ocean.util.prometheus.server.PrometheusListener");
+    }
+
+    /// A buffer used for logging information about connections.
+    private mstring connection_log_buf;
+
+    /***************************************************************************
+
+        Constructor
+
+        Creates the server socket and registers it for incoming connections.
+
+        Params:
+            address            = The address of the socket.
+            socket             = The server socket.
+            collector_registry = The CollectorRegistry instance, containing
+                                 references to the collection callbacks.
+            epoll              = The EpollSelectDispatcher instance to use in
+                                 response handler(s).
+            stack_size         = The fiber stack size to use. Defaults to
+                                 `HttpConnectionHandler.default_stack_size`.
+
+    ***************************************************************************/
+
+    public this ( sockaddr* address, ISocket socket,
+        CollectorRegistry collector_registry, EpollSelectDispatcher epoll,
+        size_t stack_size = HttpConnectionHandler.default_stack_size )
+    {
+        super(address, socket, collector_registry, epoll, stack_size);
+    }
+
+    /***************************************************************************
+
+        Registers the listener with a given epoll, so that it can be activated
+        in the latter's event loop.
+
+        Params:
+            epoll = The epoll to register the server with.
+
+    ***************************************************************************/
+
+    public void registerEventHandling ( EpollSelectDispatcher epoll )
+    {
+        epoll.register(this);
+    }
+
+    /***************************************************************************
+
+        Logs the information about connections to the log file.
+
+        Overriden from the base instance to specify the logger's name to be
+        this module's fully-qualified name.
+
+    ***************************************************************************/
+
+    override public void connectionLog ( )
+    {
+        auto conns = this.poolInfo;
+
+        PrometheusListener.log.info("Connection pool: {} busy, {} idle",
+            conns.num_busy, conns.num_idle);
+
+        foreach ( i, conn; conns )
+        {
+            this.connection_log_buf.length = 0;
+            sformat(this.connection_log_buf, "{}: ", i);
+
+            conn.formatInfo(this.connection_log_buf);
+
+            PrometheusListener.log.info(this.connection_log_buf);
+        }
+    }
+}
+
+version (UnitTest)
+{
+    import ocean.stdc.posix.sys.socket;
+    import ocean.sys.socket.IPSocket;
+    import ocean.util.prometheus.collector.Collector;
+}
+
+/// Test and demonstrate instantiation of a `PrometheusListener` object
+unittest
+{
+    class ExampleStats
+    {
+        import core.sys.posix.unistd;
+        import ocean.sys.Stats : CpuMemoryStats;
+
+        CpuMemoryStats system_stats;
+
+        struct Labels
+        {
+            pid_t pid;
+        }
+
+        this ( ) { this.system_stats = new CpuMemoryStats(); }
+
+        void collect ( Collector collector )
+        {
+            // CpuMemoryStats.collect() returns a struct whose fields we want
+            // to collect via Prometheus.
+            collector.collect(this.system_stats.collect(), Labels( getpid() ));
+        }
+
+        void collectp ( Collector collector )
+        {
+            collector.collect(this.system_stats.collect(), Labels( getppid() ));
+        }
+    }
+
+    auto epoll = new EpollSelectDispatcher();
+
+    auto example = new ExampleStats();
+    auto registry = new CollectorRegistry(
+        [&example.collect, &example.collectp]);
+
+    IPSocket!().InetAddress srv_address;
+    sockaddr* socket_addrress = srv_address("127.0.0.1", 8080);
+    auto listener = new PrometheusListener(socket_addrress, new IPSocket!(),
+        registry, epoll);
+
+    // The following line registers the server with the dispatcher, which in
+    // effect makes it operational, subject to the latter's scheduling.
+    // (Commented out here to not start a server instance in a unit test.)
+
+    // listener.registerEventHandling(epoll);
+}


### PR DESCRIPTION
Prometheus sends HTTP GET requests to an application at `/metrics` endpoint to pull stats from it. This PR adds a listener for these requests, and a handler to response with stats to prometheus.

Also accompanying here are classes that interface between the handler and a client application, such that the handler is able to invoke callbacks that collect stats from the client application upon receiving requests from prometheus.