### PR TITLE
Reset all fields in the gc stats

### DIFF
--- a/src/ocean/application/components/GCStats.d
+++ b/src/ocean/application/components/GCStats.d
@@ -95,7 +95,7 @@ public class GCStats
     private void reset ( )
     {
         this.last_collected_timestamp = MicrosecondsClock.now_us();
-        this.stats.gc_run_duration = 0;
+        this.stats = Stats.init;
     }
 
     /**********************************************************************


### PR DESCRIPTION
@scott-gibson-sociomantic noticed that not all fields are updated after a reset. This is a fix for that.