### PR TITLE
Add message when the gc monitor is not available

### DIFF
--- a/src/ocean/application/components/GCStats.d
+++ b/src/ocean/application/components/GCStats.d
@@ -39,6 +39,9 @@ public class GCStats
     }
     else
     {
+        pragma(msg, "There will be no gc stats! You need to use dmd transitional:");
+        pragma(msg, "https://github.com/sociomantic-tsunami/dmd-transitional");
+
         /// Default type for integers used by monitor
         private alias long MonitorInt;
     }


### PR DESCRIPTION
Right now there is no way to check if your binary can use this feature. With this feature, you will be notified if the feature is available or not.