### PR TITLE
Rewrite outdated usage documentation to compilable example

### DIFF
--- a/src/ocean/text/json/Json.d
+++ b/src/ocean/text/json/Json.d
@@ -980,7 +980,7 @@ class Json(T) : JsonParser!(T)
                     if (type is typeid(Composite))
                         v.set (va_arg!(Composite)(args));
                     else
-                    if (type is typeid(T[]))
+                    if (type is typeid(istring))
                         v.set (va_arg!(T[])(args));
                     else
                     if (type is typeid(void*))

--- a/src/ocean/text/json/Json.d
+++ b/src/ocean/text/json/Json.d
@@ -31,60 +31,61 @@ import ocean.text.json.JsonParser;
 
 import Float = ocean.text.convert.Float;
 
-version(UnitTest) import ocean.core.Test;
+version (UnitTest)
+{
+    import ocean.core.Test;
+    import ocean.io.Stdout;
+}
+
+///
+unittest
+{
+
+    // Typical usage is as follows:
+
+    auto json = new Json!(char);
+    json.parse(`{"t": true, "n":null, "array":["world", [4, 5]]}`);
+
+
+    // Convert back to text format:
+
+    Stdout.formatln("{}", json.value.print());
+
+
+    // Constructing json within your code leverages a handful of factories
+    // within a document instance. This example creates a document from an
+    // array of values:
+
+    with (json)
+        value = array (true, false, null, "text");
+    test!("==")(json.value.print(), `[true, false, null, "text"]`);
+
+
+    // Setting the document to contain a simple object instead:
+
+    with (json)
+        value = object (pair("a", value(10)));
+    test!("==")(json.value.print(), `{"a":10}`);
+
+
+    // Objects may be constructed with multiple attribute pairs like so:
+
+    with (json)
+        value = object (pair("a", value(10)), pair("b", value(true)));
+    test!("==")(json.value.print(), `{"a":10,"b":true}`);
+
+
+    // Substitute arrays, or other objects as values where appropriate:
+
+    with (json)
+        value = object (pair("a", array(10, true, object(pair("b")))));
+    test!("==")(json.value.print(), `{"a":[10, true, {"b":null}]}`);
+}
+
 
 /*******************************************************************************
 
-    Parse json text into a set of inter-related structures. Typical
-    usage is as follows:
-    ---
-    auto json = new Json!(char);
-    json.parse (`{"t": true, "n":null, "array":["world", [4, 5]]}`);
-    ---
-
-    Converting back to text format employs a delegate. This one emits
-    document content to the console:
-    ---
-    json.print ((char[] s) {Stdout(s);});
-    ---
-
-    Constructing json within your code leverages a handful of factories
-    within a document instance. This example creates a document from an
-    array of values:
-    ---
-    auto json = new Json!(char);
-
-    // [true, false, null, "text"]
-    with (json)
-    value = array (true, false, null, "text");
-    ---
-
-    Setting the document to contain a simple object instead:
-    ---
-    // {"a" : 10}
-    with (json)
-    value = object (pair("a", value(10)));
-    ---
-
-    Objects may be constructed with multiple attribute pairs like so:
-    ---
-    // {"a" : 10, "b" : true}
-    with (json)
-    value = object (pair("a", value(10)), pair("b", value(true)));
-    ---
-
-    Substitute arrays, or other objects as values where appropriate:
-    ---
-    // {"a" : [10, true, {"b" : null}]}
-    with (json)
-    value = object (pair("a", array(10, true, object(pair("b")))));
-    ---
-
-    TODO: document how to extract content
-
-    Big thanks to dhasenan for suggesting the construction notation. We
-    can't make effective use of operator-overloading, due to the use of
-    struct pointers, so this syntax turned out to be the next best thing.
+    Parse json text into a set of inter-related structures.
 
  *******************************************************************************/
 


### PR DESCRIPTION
The example usage in the documentation did not give correct results,
because json.print() now returns a string and takes different
parameters. Using compilable examples makes sure that usage examples can
still compile.