### PR TITLE
Update deprecation message for `isStringType` 

### DIFF
--- a/src/ocean/core/Traits.d
+++ b/src/ocean/core/Traits.d
@@ -535,7 +535,7 @@ public template TemplateInstanceArgs (alias Template, Type : Template!(TA), TA..
     public alias TA TemplateInstanceArgs;
 }
 
-deprecated("Use ocean.meta.traits.Basic.isStringType")
+deprecated("Use ocean.meta.traits.Arrays.isUTF8StringType")
 template isStringType( T )
 {
     static immutable bool isStringType = is( T : char[] )  ||


### PR DESCRIPTION
~This template has been deprecated in `ocean.core.Traits`, and the
[deprecation message](https://github.com/sociomantic-tsunami/ocean/blob/v5.x.x/src/ocean/core/Traits.d#L538) points to the template added here, which was missing
until now.~


 The deprecation message should redirect to `ocean.meta.traits.Arrays.isUTF8StringType` instead of `ocean.meta.traits.Basic.isStringType`