### PR TITLE
Make getIeeeFlags() naked

### DIFF
--- a/src/ocean/math/IEEE.d
+++ b/src/ocean/math/IEEE.d
@@ -281,22 +281,26 @@ private:
         {
             asm
             {
+                 naked;
                  fstsw AX;
                  // NOTE: If compiler supports SSE2, need to OR the result with
                  // the SSE2 status register.
                  // Clear all irrelevant bits
                  and EAX, 0x03D;
+                 ret;
             }
         }
         else version(D_InlineAsm_X86_64)
         {
             asm
             {
+                 naked;
                  fstsw AX;
                  // NOTE: If compiler supports SSE2, need to OR the result with
                  // the SSE2 status register.
                  // Clear all irrelevant bits
                  and RAX, 0x03D;
+                 ret;
             }
         } else {
            /*   SPARC:


### PR DESCRIPTION
Change the return type from a struct with one `int` member to plain `int`.

This function is implemented in assembly language. The function body doesn’t have a return statement so the compiler needs to know how to return the result implicitly. DMD seems to know what to do to implicitly return a struct with one `int` member while LDC doesn’t. LDC can be helped by returning `int` instead.

Fixes #496. That issue has been closed as “wontfix”, but IMHO this is not so much to support LDC but rather to correct sloppy code which DMD accepts and LDC doesn’t. This seems to be the only remaining obstacle for compiling ocean with LDC.