### PR TITLE
Support extended arguments to task pool deserialization.

### DIFF
--- a/relnotes/taskdeserialization.feature.md
+++ b/relnotes/taskdeserialization.feature.md
@@ -1,0 +1,9 @@
+### Support extra arguments when deserialization tasks.
+
+`ocean.task.util.TaskPoolSerializer`,
+`ocean.task.TaskPool`
+
+The 'TaskPoolSerialiazer' now support passing additional
+arguments to the load method. These additional arguments
+will then be passed to the deserialize method alongside
+the serialized data buffer.

--- a/src/ocean/task/TaskPool.d
+++ b/src/ocean/task/TaskPool.d
@@ -180,17 +180,17 @@ class TaskPool ( TaskT : Task ) : ObjectPool!(Task)
             current_task.suspend();
     }
 
-    static if (hasMethod!(TaskT, "deserialize", void delegate(void[])))
+    static if (__traits(hasMember, TaskT, "deserialize"))
     {
         /***********************************************************************
 
             Starts a task in the same manner as `start` but instead calls the
-            `deserialize()` method on the derived task with a serialized buffer
-            of the state. This is to support dumping and loading tasks from disk.
+            `deserialize()` method on the derived task with arguments supported.
+            This is to support dumping and loading tasks from disk.
 
             Params:
-                serialized = Buffer containing serialized data for restoring
-                             the internal state of a task.
+                args = Arguments matching the function arguments of the
+                       'deserialize()' function of the task type.
 
             Returns:
                 'false' if new task can't be started because pool limit is reached
@@ -198,7 +198,7 @@ class TaskPool ( TaskT : Task ) : ObjectPool!(Task)
 
         ***********************************************************************/
 
-        public bool restore ( void[] serialized )
+        public bool restore  ( ParametersOf!(TaskT.deserialize) args )
         {
             if (this.num_busy() >= this.limit())
                 return false;
@@ -206,7 +206,7 @@ class TaskPool ( TaskT : Task ) : ObjectPool!(Task)
             auto task = cast(TaskT) this.get(new TaskT);
             assert (task !is null);
 
-            task.deserialize(serialized);
+            task.deserialize(args);
             this.startImpl(task);
 
             return true;

--- a/src/ocean/task/util/TaskPoolSerializer.d
+++ b/src/ocean/task/util/TaskPoolSerializer.d
@@ -137,6 +137,8 @@ public class TaskPoolSerializer
         Params:
             task_pool = The task pool that the tasks will be loaded in to.
             load_file_path = The file path of the file to load.
+            args = Parameters matching the task's 'deserialize()' excluding
+                   the deserialized buffer itself.
 
         Returns:
             The number of items loaded from the file.
@@ -147,7 +149,8 @@ public class TaskPoolSerializer
 
     ***************************************************************************/
 
-    public size_t load ( TaskPoolT ) ( TaskPoolT task_pool, cstring load_file_path )
+    public size_t load ( TaskPoolT, Args ... ) ( TaskPoolT task_pool,
+        cstring load_file_path, Args args )
     {
         if ( !FilePath(load_file_path).exists ) return 0;
 
@@ -155,7 +158,7 @@ public class TaskPoolSerializer
         scope ( success )
             FilePath(load_file_path).remove();
 
-        return this.load(task_pool, file);
+        return this.load(task_pool, file, args);
     }
 
     /***************************************************************************
@@ -165,6 +168,8 @@ public class TaskPoolSerializer
         Params:
             task_pool = The task pool that the tasks will be loaded in to.
             stream = InputStream containing the serialized tasks.
+            args = Parameters matching the task's 'deserialize()' excluding
+                   the deserialized buffer itself.
 
         Returns:
             The number of tasks loaded from the stream.
@@ -175,7 +180,8 @@ public class TaskPoolSerializer
 
     ***************************************************************************/
 
-    public size_t load ( TaskPoolT ) ( TaskPoolT task_pool, InputStream stream )
+    public size_t load ( TaskPoolT, Args ... ) ( TaskPoolT task_pool,
+        InputStream stream, Args args)
     {
         static assert(is(typeof(TaskPoolT.TaskType.deserialize)),
             "Must contain `deserialize` method for restoring");
@@ -189,12 +195,11 @@ public class TaskPoolSerializer
         while ( tasks_loaded < total_items )
         {
             SimpleStreamSerializerArrays.read(stream, this.serialize_buffer);
-            task_pool.restore(this.serialize_buffer);
+            task_pool.restore(this.serialize_buffer, args);
             ++tasks_loaded;
         }
 
         enforce!("==")(tasks_loaded, total_items);
         return tasks_loaded;
     }
-
 }


### PR DESCRIPTION
The main driver behind this change is to support passing runtime-dependant information
(such as DHT, DMQ instances) into the deserialized tasks as previously the only way this
could be done was to create static member variables which isn't ideal.

I've also included a small refactoring of the ThrottledTaskPool to simplify the code as the overriden
start/restore are no longer needed and can be done in an overriden startImpl

release notes coming _soon_.