### PR TITLE
Replace getIeeeFlags with version in phobos

### DIFF
--- a/src/ocean/math/IEEE.d
+++ b/src/ocean/math/IEEE.d
@@ -63,6 +63,16 @@ version (Naked_D_InlineAsm_X86) {
     // Needed for cos(), sin(), tan() on GNU.
     static import core.stdc.math;
 }
+
+version (D_InlineAsm_X86)
+{
+    version = InlineAsm_X86_Any;
+}
+else version (D_InlineAsm_X86_64)
+{
+    version = InlineAsm_X86_Any;
+}
+
 static import tsm = core.stdc.math;
 
 // Standard Tango NaN payloads.

--- a/src/ocean/math/IEEE.d
+++ b/src/ocean/math/IEEE.d
@@ -280,13 +280,13 @@ private:
         version (InlineAsm_X86_Any)
         {
             ushort sw;
-            asm pure nothrow @nogc { fstsw sw; }
+            asm { fstsw sw; }
 
             // OR the result with the SSE2 status register (MXCSR).
             if (haveSSE)
             {
                 uint mxcsr;
-                asm pure nothrow @nogc { stmxcsr mxcsr; }
+                asm { stmxcsr mxcsr; }
                 return (sw | mxcsr) & EXCEPTIONS_MASK;
             }
             else return sw & EXCEPTIONS_MASK;
@@ -295,7 +295,7 @@ private:
         {
            /*
                int retval;
-               asm pure nothrow @nogc { st %fsr, retval; }
+               asm { st %fsr, retval; }
                return retval;
             */
            assert(0, "Not yet supported");

--- a/src/ocean/math/IEEE.d
+++ b/src/ocean/math/IEEE.d
@@ -73,6 +73,19 @@ else version (D_InlineAsm_X86_64)
     version = InlineAsm_X86_Any;
 }
 
+version (X86_64) version = StaticallyHaveSSE;
+version (X86) version (OSX) version = StaticallyHaveSSE;
+
+version (StaticallyHaveSSE)
+{
+    private enum bool haveSSE = true;
+}
+else version (X86)
+{
+    static import core.cpuid;
+    private alias haveSSE = core.cpuid.sse;
+}
+
 static import tsm = core.stdc.math;
 
 // Standard Tango NaN payloads.


### PR DESCRIPTION
    ocean almost compiles with gdc, if it weren't for this function and
    a few other small things. Sadly I have no idea, what this function does,
    but a function with the same name exists in phobos, which in contrast to
    the ocean one compiles with both dmd and gdc, so it seems cool to me.