### PR TITLE
Prepare for dlang/dmd#10124 (field of init symbol no lvalue anymore)

### DIFF
--- a/src/ocean/util/container/ebtree/model/KeylessMethods.d
+++ b/src/ocean/util/container/ebtree/model/KeylessMethods.d
@@ -158,7 +158,7 @@ template KeylessMethods ( Node, alias eb_first, alias eb_last )
     private Node* ebCall ( alias eb_func, T ... ) ( T args )
     {
         static assert (is (typeof (eb_func(&this.root, args)) ==
-                           typeof (&Node.init.node_)));
+                           typeof (Node.node_)*));
 
         return cast (Node*) eb_func(&this.root, args);
     }


### PR DESCRIPTION
According to DMD's buildkite CI service ([log](https://buildkite.com/dlang/dmd/builds/8910#23dad51f-55b0-46da-ae79-97d66a792ea1)). I haven't set up a dev environment for ocean, so I have no idea whether there are more occurrences like this. No idea which branch to target either.