### PR TITLE
Backport "Make `getIeeeFlags()` `naked`" to ocean v4.x.x

### DIFF
--- a/src/ocean/math/IEEE.d
+++ b/src/ocean/math/IEEE.d
@@ -281,22 +281,26 @@ private:
         {
             asm
             {
+                 naked;
                  fstsw AX;
                  // NOTE: If compiler supports SSE2, need to OR the result with
                  // the SSE2 status register.
                  // Clear all irrelevant bits
                  and EAX, 0x03D;
+                 ret;
             }
         }
         else version(D_InlineAsm_X86_64)
         {
             asm
             {
+                 naked;
                  fstsw AX;
                  // NOTE: If compiler supports SSE2, need to OR the result with
                  // the SSE2 status register.
                  // Clear all irrelevant bits
                  and RAX, 0x03D;
+                 ret;
             }
         } else {
            /*   SPARC:


### PR DESCRIPTION
This was originally submitted against ocean v5.0.x on the assumption that only D2-only users would care about building with other compilers.  However, going by @johannes-riecken-dunnhumby's remarks in https://github.com/sociomantic-tsunami/ocean/pull/724 there is interest in having this available also for transitional projects.

I've successfully tested this with LDC.  @johannes-riecken-dunnhumby perhaps you could give it a go with GDC and see if it addresses your concerns too?