### PR TITLE
[v5.x.x] Remove scope as type qualifier on classes

### DIFF
--- a/src/ocean/core/UnitTestRunner.d
+++ b/src/ocean/core/UnitTestRunner.d
@@ -95,7 +95,7 @@ import core.runtime: Runtime;
 
 ******************************************************************************/
 
-private scope class UnitTestRunner
+private class UnitTestRunner
 {
 
     /**************************************************************************

--- a/src/ocean/io/Stdout.d
+++ b/src/ocean/io/Stdout.d
@@ -279,7 +279,7 @@ public class TerminalOutput : FormatOutput
 
     ***************************************************************************/
 
-    public scope class TextColour
+    public class TextColour
     {
         /***********************************************************************
 
@@ -361,12 +361,12 @@ public class TerminalOutput : FormatOutput
 
     /***************************************************************************
 
-        Background colour scope class. Resets the default background colour, if
+        Background colour class. Resets the default background colour, if
         it has been changed, when scope exits.
 
     ***************************************************************************/
 
-    public scope class BackgroundColour
+    public class BackgroundColour
     {
         /***********************************************************************
 

--- a/src/ocean/io/model/SuspendableThrottlerCount.d
+++ b/src/ocean/io/model/SuspendableThrottlerCount.d
@@ -89,7 +89,7 @@ public class SuspendableThrottlerCount : ISuspendableThrottlerCount
         this.count++;
         super.throttledSuspend();
     }
-    
+
     // WORKAROUND: DMD 2.068 had difficulties  resolving multiple overloads of
     // `add` when one came from alias and other was "native" method. Creating
     // distinct name (`inc`) allowed to disambugate it manually
@@ -185,7 +185,7 @@ public class SuspendableThrottlerCount : ISuspendableThrottlerCount
 
 unittest
 {
-    scope class SuspendableThrottlerCount_Test : ISuspendableThrottlerCount_Test
+    static class SuspendableThrottlerCount_Test : ISuspendableThrottlerCount_Test
     {
         private SuspendableThrottlerCount count;
 
@@ -328,7 +328,7 @@ version ( UnitTest )
 {
     private import ocean.core.Test;
 
-    abstract scope class ISuspendableThrottlerCount_Test
+    abstract class ISuspendableThrottlerCount_Test
     {
         static immutable suspend = 10;
         static immutable resume = 2;

--- a/src/ocean/io/select/protocol/task/TaskSelectTransceiver_test.d
+++ b/src/ocean/io/select/protocol/task/TaskSelectTransceiver_test.d
@@ -38,7 +38,7 @@ unittest
 
     // This TaskSelectTransceiver subclass uses a tiny 3-bytes buffer to test
     // the reading loop.
-    static scope class TestTaskSelectTransceiver: TaskSelectTransceiver
+    static class TestTaskSelectTransceiver: TaskSelectTransceiver
     {
         this ( IODevice iodev )
         {

--- a/src/ocean/net/http/HttpResponse.d
+++ b/src/ocean/net/http/HttpResponse.d
@@ -419,7 +419,7 @@ class HttpResponse : HttpHeader
 
          **********************************************************************/
 
-        scope class IncrementalValue
+        class IncrementalValue
         {
             /******************************************************************
 

--- a/src/ocean/net/http/message/HttpHeaderParser.d
+++ b/src/ocean/net/http/message/HttpHeaderParser.d
@@ -188,7 +188,7 @@ class HttpHeaderParser : IHttpHeaderParser
 
      **************************************************************************/
 
-    private static scope class SplitHeaderLines : ISplitIterator
+    private static class SplitHeaderLines : ISplitIterator
     {
         /**************************************************************************
 

--- a/src/ocean/util/container/map/model/BucketElementFreeList.d
+++ b/src/ocean/util/container/map/model/BucketElementFreeList.d
@@ -371,7 +371,7 @@ abstract class IBucketElementFreeList: IAllocator
 
      **************************************************************************/
 
-    scope class ParkingStack: IParkingStack
+    class ParkingStack: IParkingStack
     {
         /**********************************************************************
 

--- a/src/ocean/util/container/map/model/IBucketElementGCAllocator.d
+++ b/src/ocean/util/container/map/model/IBucketElementGCAllocator.d
@@ -61,7 +61,7 @@ class IBucketElementGCAllocator: IAllocator
 
     ***************************************************************************/
 
-    static scope class ParkingStack: IParkingStack
+    static class ParkingStack: IParkingStack
     {
         /***********************************************************************
 

--- a/src/ocean/util/container/pool/model/IAggregatePool.d
+++ b/src/ocean/util/container/pool/model/IAggregatePool.d
@@ -61,11 +61,9 @@
 
         foreach ( busy_item; pool.new BusyItemsIterator )
 
-    This is because the iterators are declared as scope classes, meaning that
-    the compiler should enforce that they can *only* be newed as scope (i.e. on
-    the stack). Unfortunately the compiler doesn't always enforce this
-    requirement, and will allow a scope class to be allocated on the heap in
-    certain situations, one of these being the foreach situation shown above.
+    This is because the iterators are designed as scope classes, meaning that
+    `new`ing them won't GC allocate (and thus can't trigger a collection).
+    In case like the above, the absence of `scope` means a GC allocation.
 
     Note about ref iteration over pools:
 
@@ -669,7 +667,7 @@ public abstract class IAggregatePool ( T ) : IPool, IFreeList!(ItemType_!(T))
 
     ***************************************************************************/
 
-    protected abstract scope class IItemsIterator
+    protected abstract class IItemsIterator
     {
         protected Item[] iteration_items;
 
@@ -764,7 +762,7 @@ public abstract class IAggregatePool ( T ) : IPool, IFreeList!(ItemType_!(T))
 
     ***************************************************************************/
 
-    protected abstract scope class SafeItemsIterator : IItemsIterator
+    protected abstract class SafeItemsIterator : IItemsIterator
     {
         /***********************************************************************
 
@@ -813,7 +811,7 @@ public abstract class IAggregatePool ( T ) : IPool, IFreeList!(ItemType_!(T))
 
     ***************************************************************************/
 
-    protected abstract scope class UnsafeItemsIterator : IItemsIterator
+    protected abstract class UnsafeItemsIterator : IItemsIterator
     {
         /***********************************************************************
 
@@ -862,7 +860,7 @@ public abstract class IAggregatePool ( T ) : IPool, IFreeList!(ItemType_!(T))
 
     ***************************************************************************/
 
-    public scope class AllItemsIterator : SafeItemsIterator
+    public class AllItemsIterator : SafeItemsIterator
     {
         this ( )
         {
@@ -876,7 +874,7 @@ public abstract class IAggregatePool ( T ) : IPool, IFreeList!(ItemType_!(T))
 
     ***************************************************************************/
 
-    public scope class ReadOnlyAllItemsIterator : UnsafeItemsIterator
+    public class ReadOnlyAllItemsIterator : UnsafeItemsIterator
     {
         this ( )
         {
@@ -890,7 +888,7 @@ public abstract class IAggregatePool ( T ) : IPool, IFreeList!(ItemType_!(T))
 
     ***************************************************************************/
 
-    public scope class BusyItemsIterator : SafeItemsIterator
+    public class BusyItemsIterator : SafeItemsIterator
     {
         this ( )
         {
@@ -904,7 +902,7 @@ public abstract class IAggregatePool ( T ) : IPool, IFreeList!(ItemType_!(T))
 
     ***************************************************************************/
 
-    public scope class ReadOnlyBusyItemsIterator : UnsafeItemsIterator
+    public class ReadOnlyBusyItemsIterator : UnsafeItemsIterator
     {
         this ( )
         {
@@ -918,7 +916,7 @@ public abstract class IAggregatePool ( T ) : IPool, IFreeList!(ItemType_!(T))
 
     ***************************************************************************/
 
-    public scope class IdleItemsIterator : SafeItemsIterator
+    public class IdleItemsIterator : SafeItemsIterator
     {
         this ( )
         {
@@ -932,7 +930,7 @@ public abstract class IAggregatePool ( T ) : IPool, IFreeList!(ItemType_!(T))
 
     ***************************************************************************/
 
-    public scope class ReadOnlyIdleItemsIterator : UnsafeItemsIterator
+    public class ReadOnlyIdleItemsIterator : UnsafeItemsIterator
     {
         this ( )
         {
@@ -1271,4 +1269,3 @@ version ( UnitTest )
         }
     }
 }
-


### PR DESCRIPTION
It is deprecated in recent D2 versions.