### PR TITLE
[v5.x.x] Remove static if conditions that can never trigger

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -40,3 +40,7 @@ $O/test-unixsockext: override LDFLAGS += -lglib-2.0
 $O/%unittests: override LDFLAGS += -lglib-2.0 -lpcre -lxml2 -lxslt -lebtree \
 		-lreadline -lhistory -llzo2 -lbz2 -lz -ldl -lgcrypt -lgpg-error -lrt \
 		-lssl -lcrypto
+
+# Remove deprecated modules from testing:
+TEST_FILTER_OUT += \
+	$C/src/ocean/stdc/posix/netinet/in_.d

--- a/relnotes/netinet_in.deprecation.md
+++ b/relnotes/netinet_in.deprecation.md
@@ -1,0 +1,6 @@
+### Module `ocean.stdc.posix.netinet.in_` is deprecated
+
+`ocean.stdc.posix.netinet.in_`
+
+This module was just a thin wrapper around `core.sys.posix.netinet.in_`,
+which should now be imported directly.

--- a/src/ocean/io/select/protocol/fiber/FiberSelectWriter.d
+++ b/src/ocean/io/select/protocol/fiber/FiberSelectWriter.d
@@ -31,10 +31,10 @@ import ocean.io.select.protocol.fiber.model.IFiberSelectProtocol;
 import ocean.io.select.client.model.ISelectClient;
 import ocean.io.device.IODevice: IOutputDevice;
 import ocean.stdc.posix.sys.socket: setsockopt;
-import ocean.stdc.posix.netinet.in_: IPPROTO_TCP;
 import core.stdc.errno: errno, EAGAIN, EWOULDBLOCK, EINTR;
+import core.sys.posix.netinet.in_: IPPROTO_TCP;
 
-static if (__VERSION__ >= 2000 && __VERSION__ < 2073)
+static if (__VERSION__ < 2073)
     enum { TCP_CORK = 3 }
 else static if (__VERSION__ >= 2077)
     import core.sys.linux.netinet.tcp: TCP_CORK;

--- a/src/ocean/io/select/protocol/fiber/FiberSelectWriter.d
+++ b/src/ocean/io/select/protocol/fiber/FiberSelectWriter.d
@@ -26,20 +26,13 @@
 module ocean.io.select.protocol.fiber.FiberSelectWriter;
 
 import ocean.transition;
-
 import ocean.core.Verify;
-
 import ocean.io.select.protocol.fiber.model.IFiberSelectProtocol;
-
 import ocean.io.select.client.model.ISelectClient;
-
 import ocean.io.device.IODevice: IOutputDevice;
-
-import core.stdc.errno: errno, EAGAIN, EWOULDBLOCK, EINTR;
-
 import ocean.stdc.posix.sys.socket: setsockopt;
-
 import ocean.stdc.posix.netinet.in_: IPPROTO_TCP;
+import core.stdc.errno: errno, EAGAIN, EWOULDBLOCK, EINTR;
 
 static if (__VERSION__ >= 2000 && __VERSION__ < 2073)
     enum { TCP_CORK = 3 }

--- a/src/ocean/io/select/protocol/task/TaskSelectTransceiver.d
+++ b/src/ocean/io/select/protocol/task/TaskSelectTransceiver.d
@@ -35,9 +35,9 @@ class TaskSelectTransceiver
     import core.stdc.errno: errno, EAGAIN, EWOULDBLOCK, EINTR;
     import ocean.stdc.posix.sys.uio: iovec, readv;
     import ocean.stdc.posix.sys.socket: setsockopt;
-    import ocean.stdc.posix.netinet.in_: IPPROTO_TCP;
+    import core.sys.posix.netinet.in_: IPPROTO_TCP;
 
-    static if (__VERSION__ >= 2000 && __VERSION__ < 2073)
+    static if (__VERSION__ < 2073)
         enum { TCP_CORK = 3 }
     else static if (__VERSION__ >= 2077)
         import core.sys.linux.netinet.tcp: TCP_CORK;

--- a/src/ocean/meta/types/Qualifiers.d
+++ b/src/ocean/meta/types/Qualifiers.d
@@ -61,7 +61,7 @@ alias char[]         mstring;
 
 template Const(T)
 {
-    alias const(T) Const;;
+    alias const(T) Const;
 }
 
 unittest

--- a/src/ocean/net/server/SelectListener.d
+++ b/src/ocean/net/server/SelectListener.d
@@ -62,7 +62,7 @@ abstract class ISelectListener : ISelectClient
 {
     import ocean.stdc.posix.sys.socket: accept, SOL_SOCKET, SO_ERROR,
                                         SO_REUSEADDR, sockaddr;
-    import ocean.stdc.posix.netinet.in_: SOCK_STREAM;
+    import core.sys.posix.netinet.in_: SOCK_STREAM;
     import core.sys.posix.unistd:     close;
 
     /**************************************************************************

--- a/src/ocean/net/server/SelectListener.d
+++ b/src/ocean/net/server/SelectListener.d
@@ -26,24 +26,16 @@ module ocean.net.server.SelectListener;
 
 import ocean.transition;
 import ocean.core.Verify;
-
 import ocean.io.select.client.model.ISelectClient;
 import ocean.net.server.connection.IConnectionHandler;
 import ocean.net.server.connpool.SelectListenerPool;
 import ocean.net.server.connpool.ISelectListenerPoolInfo;
-
 import ocean.util.container.pool.model.IPoolInfo;
-
 import ocean.text.convert.Formatter;
-
-import core.stdc.errno:            errno;
-
 import ocean.sys.socket.model.ISocket;
-
 import ocean.io.select.protocol.generic.ErrnoIOException: SocketError;
-
-
 import ocean.util.log.Logger;
+import core.stdc.errno: errno;
 
 /*******************************************************************************
 
@@ -51,7 +43,7 @@ import ocean.util.log.Logger;
 
 *******************************************************************************/
 
-static private Logger log;
+private Logger log;
 static this ( )
 {
     log = Log.lookup("ocean.net.server.SelectListener");

--- a/src/ocean/net/util/GetSocketAddress.d
+++ b/src/ocean/net/util/GetSocketAddress.d
@@ -30,11 +30,11 @@ import ocean.transition;
 import ocean.io.model.IConduit: ISelectable;
 import ocean.stdc.posix.sys.socket: getsockname, getpeername, socklen_t, sockaddr;
 import ocean.stdc.posix.arpa.inet: ntohs, inet_ntop, INET_ADDRSTRLEN, INET6_ADDRSTRLEN;
-import ocean.stdc.posix.netinet.in_: sa_family_t, in_port_t, sockaddr_in, sockaddr_in6, in_addr, in6_addr;
 import ocean.sys.ErrnoException;
 
 import core.stdc.errno;
 import core.stdc.string: strlen, strerror_r;
+import core.sys.posix.netinet.in_: sa_family_t, in_port_t, sockaddr_in, sockaddr_in6, in_addr, in6_addr;
 import consts = core.sys.posix.sys.socket;
 
 

--- a/src/ocean/net/util/GetSocketAddress.d
+++ b/src/ocean/net/util/GetSocketAddress.d
@@ -26,26 +26,17 @@
 
 module ocean.net.util.GetSocketAddress;
 
-
 import ocean.transition;
-
 import ocean.io.model.IConduit: ISelectable;
-
 import ocean.stdc.posix.sys.socket: getsockname, getpeername, socklen_t, sockaddr;
-
 import ocean.stdc.posix.arpa.inet: ntohs, inet_ntop, INET_ADDRSTRLEN, INET6_ADDRSTRLEN;
-
 import ocean.stdc.posix.netinet.in_: sa_family_t, in_port_t, sockaddr_in, sockaddr_in6, in_addr, in6_addr;
-
-import core.stdc.errno;
-
-import consts = core.sys.posix.sys.socket;
-
-import ocean.stdc.string: strlen;
-
 import ocean.sys.ErrnoException;
 
-extern (C) private char* strerror_r(int n, char* dst, size_t dst_length);
+import core.stdc.errno;
+import core.stdc.string: strlen, strerror_r;
+import consts = core.sys.posix.sys.socket;
+
 
 /******************************************************************************/
 

--- a/src/ocean/stdc/gnu/string.d
+++ b/src/ocean/stdc/gnu/string.d
@@ -34,8 +34,3 @@ Inout!(char)* strchrnul(Inout!(char)* str, int c);
 Inout!(wchar_t)* wcschrnul(Inout!(wchar_t)* wstr, wchar_t wc);
 Inout!(void)* memmem(Inout!(void)* haystack, size_t hlen,
                     in void *needle, size_t nlen);
-
-static if (__VERSION__ < 2070)
-{
-    char*    strerror_r(int errnum, char *buf, size_t buflen);
-}

--- a/src/ocean/stdc/posix/netinet/in_.d
+++ b/src/ocean/stdc/posix/netinet/in_.d
@@ -11,17 +11,7 @@
 
 *******************************************************************************/
 
-
+deprecated("Import `core.sys.posix.netinet.in_` directly")
 module ocean.stdc.posix.netinet.in_;
 
 public import core.sys.posix.netinet.in_;
-
-static if (__VERSION__ < 2067)
-{
-    enum
-    {
-        IPPROTO_PUP = 12, /* PUP protocol.  */
-        IPPROTO_IGMP = 2, /* Internet Group Management Protocol. */
-        IPPROTO_IDP = 22, /* XNS IDP protocol.  */
-    }
-}

--- a/src/ocean/stdc/posix/sys/socket.d
+++ b/src/ocean/stdc/posix/sys/socket.d
@@ -39,12 +39,3 @@ enum
     SOCK_CLOEXEC  = 0x8_0000, /* Atomically set close-on-exec flag for the
                                  new descriptor(s).  */
 }
-
-static if (__VERSION__ < 2067)
-{
-    enum
-    {
-        AF_IPX = 4,
-        AF_APPLETALK = 5,
-    }
-}

--- a/src/ocean/sys/GetIfAddrs.d
+++ b/src/ocean/sys/GetIfAddrs.d
@@ -21,10 +21,10 @@ import ocean.transition;
 import core.stdc.errno;
 import core.stdc.string;
 import ocean.stdc.posix.arpa.inet;
-import ocean.stdc.posix.netinet.in_: sockaddr_in, sockaddr_in6;
 import ocean.stdc.posix.sys.socket;
+import core.sys.posix.netinet.in_: sockaddr_in, sockaddr_in6;
 
-static if (__VERSION__ >= 2000 && __VERSION__ < 2073)
+static if (__VERSION__ < 2073)
 {
     extern (C)
     {

--- a/src/ocean/sys/socket/AddrInfo.d
+++ b/src/ocean/sys/socket/AddrInfo.d
@@ -15,25 +15,19 @@
 
 module ocean.sys.socket.AddrInfo;
 
-
-import ocean.transition;
-
+import ocean.core.Array: concat;
+import ocean.core.TypeConvert;
+import ocean.core.Verify;
 import ocean.stdc.posix.netinet.in_: sockaddr, socklen_t,
                                      sockaddr_in,  AF_INET,  INET_ADDRSTRLEN,
                                      sockaddr_in6, AF_INET6, INET6_ADDRSTRLEN,
                                      SOCK_STREAM, IPPROTO_TCP;
-
 import ocean.stdc.posix.arpa.inet: inet_ntop, inet_pton, ntohs, htons, htonl;
+import ocean.transition;
 
 import core.stdc.errno: errno, EAFNOSUPPORT;
-
 import core.stdc.string: strlen;
 
-import ocean.core.Array: concat;
-
-import ocean.core.TypeConvert;
-
-import ocean.core.Verify;
 
 /*******************************************************************************
 

--- a/src/ocean/sys/socket/AddrInfo.d
+++ b/src/ocean/sys/socket/AddrInfo.d
@@ -18,15 +18,15 @@ module ocean.sys.socket.AddrInfo;
 import ocean.core.Array: concat;
 import ocean.core.TypeConvert;
 import ocean.core.Verify;
-import ocean.stdc.posix.netinet.in_: sockaddr, socklen_t,
-                                     sockaddr_in,  AF_INET,  INET_ADDRSTRLEN,
-                                     sockaddr_in6, AF_INET6, INET6_ADDRSTRLEN,
-                                     SOCK_STREAM, IPPROTO_TCP;
 import ocean.stdc.posix.arpa.inet: inet_ntop, inet_pton, ntohs, htons, htonl;
 import ocean.transition;
 
 import core.stdc.errno: errno, EAFNOSUPPORT;
 import core.stdc.string: strlen;
+import core.sys.posix.netinet.in_: sockaddr, socklen_t,
+                                   sockaddr_in,  AF_INET,  INET_ADDRSTRLEN,
+                                   sockaddr_in6, AF_INET6, INET6_ADDRSTRLEN,
+                                   SOCK_STREAM, IPPROTO_TCP;
 
 
 /*******************************************************************************

--- a/src/ocean/sys/socket/IPSocket.d
+++ b/src/ocean/sys/socket/IPSocket.d
@@ -18,7 +18,6 @@ module ocean.sys.socket.IPSocket;
 import ocean.core.TypeConvert;
 import ocean.io.device.Conduit: ISelectable;
 import ocean.io.device.IODevice: InputDevice, IOutputDevice;
-import ocean.stdc.posix.netinet.in_: AF_INET, AF_INET6;
 import ocean.stdc.posix.sys.socket;
 import ocean.stdc.posix.sys.types: ssize_t;
 import ocean.sys.socket.InetAddress;
@@ -26,6 +25,7 @@ import ocean.sys.socket.model.ISocket;
 import ocean.text.convert.Formatter;
 import ocean.transition;
 
+import core.sys.posix.netinet.in_: AF_INET, AF_INET6;
 import core.sys.posix.unistd: close;
 
 /******************************************************************************

--- a/src/ocean/sys/socket/IPSocket.d
+++ b/src/ocean/sys/socket/IPSocket.d
@@ -15,28 +15,18 @@
 
 module ocean.sys.socket.IPSocket;
 
-
+import ocean.core.TypeConvert;
+import ocean.io.device.Conduit: ISelectable;
+import ocean.io.device.IODevice: InputDevice, IOutputDevice;
+import ocean.stdc.posix.netinet.in_: AF_INET, AF_INET6;
+import ocean.stdc.posix.sys.socket;
+import ocean.stdc.posix.sys.types: ssize_t;
+import ocean.sys.socket.InetAddress;
+import ocean.sys.socket.model.ISocket;
+import ocean.text.convert.Formatter;
 import ocean.transition;
 
-import ocean.stdc.posix.sys.socket;
-
-import ocean.stdc.posix.netinet.in_: AF_INET, AF_INET6;
-
 import core.sys.posix.unistd: close;
-
-import ocean.stdc.posix.sys.types: ssize_t;
-
-import ocean.io.device.Conduit: ISelectable;
-
-import ocean.io.device.IODevice: InputDevice, IOutputDevice;
-
-import ocean.sys.socket.InetAddress;
-
-import ocean.core.TypeConvert;
-
-import ocean.sys.socket.model.ISocket;
-
-import ocean.text.convert.Formatter;
 
 /******************************************************************************
 

--- a/src/ocean/sys/socket/model/ISocket.d
+++ b/src/ocean/sys/socket/model/ISocket.d
@@ -15,22 +15,14 @@
 
 module ocean.sys.socket.model.ISocket;
 
-
 import ocean.transition;
-
 import ocean.stdc.posix.sys.socket;
-
 import ocean.stdc.posix.netinet.in_: AF_INET, AF_INET6, IPPROTO_TCP;
-
-import core.sys.posix.unistd: close;
-
 import ocean.stdc.posix.sys.types: ssize_t;
-
 import ocean.io.device.Conduit: ISelectable;
-
 import ocean.io.device.IODevice: IODevice;
-
 import ocean.sys.socket.InetAddress;
+import core.sys.posix.unistd: close;
 
 // FIXME: somehow the import above doesn't result in this symbol being
 // identifiable in this module. Re-defining it locally.

--- a/src/ocean/sys/socket/model/ISocket.d
+++ b/src/ocean/sys/socket/model/ISocket.d
@@ -17,11 +17,11 @@ module ocean.sys.socket.model.ISocket;
 
 import ocean.transition;
 import ocean.stdc.posix.sys.socket;
-import ocean.stdc.posix.netinet.in_: AF_INET, AF_INET6, IPPROTO_TCP;
 import ocean.stdc.posix.sys.types: ssize_t;
 import ocean.io.device.Conduit: ISelectable;
 import ocean.io.device.IODevice: IODevice;
 import ocean.sys.socket.InetAddress;
+import core.sys.posix.netinet.in_: AF_INET, AF_INET6, IPPROTO_TCP;
 import core.sys.posix.unistd: close;
 
 // FIXME: somehow the import above doesn't result in this symbol being

--- a/src/ocean/text/util/StringEncode.d
+++ b/src/ocean/text/util/StringEncode.d
@@ -47,7 +47,7 @@ import ocean.transition;
 
 version(UnitTest) import ocean.core.Test;
 
-static if (__VERSION__ >= 2000 && __VERSION__ < 2073)
+static if (__VERSION__ < 2073)
 {
     extern (C)
     {

--- a/src/ocean/time/StopWatch.d
+++ b/src/ocean/time/StopWatch.d
@@ -17,23 +17,11 @@
 
 module ocean.time.StopWatch;
 
-// CLOCK_MONOTONIC and clock_gettime will be added to core.sys.posix.time in
-// tangort v1.7.0, see tangort issue #6.
-import core.sys.posix.time; // clockid_t, timespec
+import core.sys.posix.time;
 
 version (UnitTest)
 {
     import ocean.core.Test;
-}
-
-extern (C) private
-{
-    enum: clockid_t
-    {
-        CLOCK_MONOTONIC = 1
-    }
-
-    int clock_gettime(clockid_t clk_id, timespec* t);
 }
 
 /*******************************************************************************
@@ -74,9 +62,6 @@ extern (C) private
 
 public struct StopWatch
 {
-         // TODO: From tangort v1.7.0 import clock_gettime and CLOCK_MONOTONIC.
-        import core.sys.posix.time: timespec;
-
         import ocean.core.ExceptionDefinitions : PlatformException;
 
 


### PR DESCRIPTION
```
Since Ocean v5.x.x does not support DMD < 2.072.x,
those can be safely removed.
As a consequence, an empty module has been deprecated.
```