### PR TITLE
[v5.x.x] Test, format and simplify ocean.util.log.LayoutDate

### DIFF
--- a/src/ocean/util/log/LayoutDate.d
+++ b/src/ocean/util/log/LayoutDate.d
@@ -1,62 +1,58 @@
 /*******************************************************************************
 
-        Copyright:
-            Copyright (c) 2004 Kris Bell.
-            Some parts copyright (c) 2009-2016 dunnhumby Germany GmbH.
-            All rights reserved.
+    Copyright:
+        Copyright (c) 2004 Kris Bell.
+        Some parts copyright (c) 2009-2016 dunnhumby Germany GmbH.
+        All rights reserved.
 
-        License:
-            Tango Dual License: 3-Clause BSD License / Academic Free License v3.0.
-            See LICENSE_TANGO.txt for details.
+    License:
+        Tango Dual License: 3-Clause BSD License / Academic Free License v3.0.
+        See LICENSE_TANGO.txt for details.
 
-        Version: Initial release: May 2004
+    Version: Initial release: May 2004
 
-        Authors: Kris
+    Authors: Kris
 
 *******************************************************************************/
 
 module ocean.util.log.LayoutDate;
 
-import ocean.transition;
-
+import ocean.meta.types.Qualifiers;
+import Integer = ocean.text.convert.Integer_tango;
 import ocean.text.Util;
-
-import ocean.time.Clock,
-       ocean.time.WallClock;
-
+import ocean.time.Clock;
+import ocean.time.WallClock;
 import ocean.util.log.Appender;
 import ocean.util.log.Event;
 
-import Integer = ocean.text.convert.Integer_tango;
 
 /*******************************************************************************
 
-        A layout with ISO-8601 date information prefixed to each message
+    A layout with ISO-8601 date information prefixed to each message
 
 *******************************************************************************/
 
 public class LayoutDate : Appender.Layout
 {
-        private bool localTime;
+    private bool localTime;
 
-        /***********************************************************************
+    /***************************************************************************
 
-                Ctor with indicator for local vs UTC time. Default is
-                local time.
+        Ctor with indicator for local vs UTC time. Default is local time.
 
-        ***********************************************************************/
+    ***************************************************************************/
 
-        this (bool localTime = true)
-        {
-                this.localTime = localTime;
-        }
+    this (bool localTime = true)
+    {
+        this.localTime = localTime;
+    }
 
-        /***********************************************************************
+    /***************************************************************************
 
-                Subclasses should implement this method to perform the
-                formatting of the actual message content.
+        Subclasses should implement this method to perform the formatting
+        of the actual message content.
 
-        ***********************************************************************/
+    ***************************************************************************/
 
     public override void format (LogEvent event, scope void delegate(cstring) dg)
     {
@@ -83,14 +79,14 @@ public class LayoutDate : Appender.Layout
         dg(event.toString);
     }
 
-        /**********************************************************************
+    /**************************************************************************
 
-                Convert an integer to a zero prefixed text representation
+        Convert an integer to a zero prefixed text representation
 
-        **********************************************************************/
+    ***************************************************************************/
 
-        private cstring convert (char[] tmp, long i)
-        {
-                return Integer.formatter (tmp, i, 'u', '?', 8);
-        }
+    private cstring convert (char[] tmp, long i)
+    {
+        return Integer.formatter (tmp, i, 'u', '?', 8);
+    }
 }

--- a/src/ocean/util/log/LayoutDate.d
+++ b/src/ocean/util/log/LayoutDate.d
@@ -25,6 +25,12 @@ import ocean.time.WallClock;
 import ocean.util.log.Appender;
 import ocean.util.log.Event;
 
+version (UnitTest)
+{
+    import ocean.core.Test;
+    import ocean.transition : enableStomping;
+    import ocean.util.log.model.ILogger;
+}
 
 /*******************************************************************************
 
@@ -89,4 +95,24 @@ public class LayoutDate : Appender.Layout
     {
         return Integer.formatter (tmp, i, 'u', '?', 8);
     }
+}
+
+unittest
+{
+       mstring result = new mstring(2048);
+       result.length = 0;
+       enableStomping(result);
+
+       scope dg = (cstring v) { result ~= v; };
+       scope layout = new LayoutDate(false);
+       LogEvent event = {
+           msg_: "Have you met Ted?",
+               name_: "Barney",
+               time_: Time.fromUnixTime(1525048962) + TimeSpan.fromMillis(420),
+               level_: ILogger.Level.Warn,
+               host_: null,
+       };
+
+       testNoAlloc(layout.format(event, dg));
+       test!("==")(result, "2018-04-30 00:42:42,420 Warn [Barney] - Have you met Ted?");
 }

--- a/src/ocean/util/log/LayoutDate.d
+++ b/src/ocean/util/log/LayoutDate.d
@@ -18,8 +18,7 @@
 module ocean.util.log.LayoutDate;
 
 import ocean.meta.types.Qualifiers;
-import Integer = ocean.text.convert.Integer_tango;
-import ocean.text.Util;
+import ocean.text.convert.Formatter;
 import ocean.time.Clock;
 import ocean.time.WallClock;
 import ocean.util.log.Appender;
@@ -60,40 +59,17 @@ public class LayoutDate : Appender.Layout
 
     ***************************************************************************/
 
-    public override void format (LogEvent event, scope void delegate(cstring) dg)
+    public override void format (LogEvent event, scope FormatterSink dg)
     {
-        auto level = event.levelName;
-
         // convert time to field values
-        auto tm = event.time;
-        auto dt = (localTime) ? WallClock.toDate(tm) : Clock.toDate(tm);
+        const tm = event.time;
+        const dt = (localTime) ? WallClock.toDate(tm) : Clock.toDate(tm);
 
         // format date according to ISO-8601 (lightweight formatter)
-        char[20] tmp = void;
-        char[256] tmp2 = void;
-        dg(layout(tmp2, "%0-%1-%2 %3:%4:%5,%6 %7 [%8] - ",
-                  convert(tmp[0..4],   dt.date.year),
-                  convert(tmp[4..6],   dt.date.month),
-                  convert(tmp[6..8],   dt.date.day),
-                  convert(tmp[8..10],  dt.time.hours),
-                  convert(tmp[10..12], dt.time.minutes),
-                  convert(tmp[12..14], dt.time.seconds),
-                  convert(tmp[14..17], dt.time.millis),
-                  level,
-                  event.name
-               ));
-        dg(event.toString);
-    }
-
-    /**************************************************************************
-
-        Convert an integer to a zero prefixed text representation
-
-    ***************************************************************************/
-
-    private cstring convert (char[] tmp, long i)
-    {
-        return Integer.formatter (tmp, i, 'u', '?', 8);
+        sformat(dg, "{u4}-{u2}-{u2} {u2}:{u2}:{u2},{u2} {} [{}] - {}",
+            dt.date.year, dt.date.month, dt.date.day,
+            dt.time.hours, dt.time.minutes, dt.time.seconds, dt.time.millis,
+            event.levelName, event.name, event);
     }
 }
 


### PR DESCRIPTION
Not sure if this would be better to target v4.x.x, but all my development is done in D2 so that's why I base everything off this branch.