### PR TITLE
[v5.x.x][trivial] ocean.core.{Enforce,Exception}: Reduce import surface

### DIFF
--- a/src/ocean/core/Enforce.d
+++ b/src/ocean/core/Enforce.d
@@ -15,8 +15,7 @@
 
 module ocean.core.Enforce;
 
-
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.text.convert.Formatter;
 
 

--- a/src/ocean/core/Exception.d
+++ b/src/ocean/core/Exception.d
@@ -15,10 +15,8 @@
 
 module ocean.core.Exception;
 
-
-import ocean.transition;
-
 static import ocean.core.Enforce;
+import ocean.meta.types.Qualifiers;
 
 version (UnitTest)
 {


### PR DESCRIPTION
```
Only 'istring' is needed, which is in Qualifiers.
```