### PR TITLE
Improve POSIX portability & work around #716

### DIFF
--- a/src/ocean/core/UnitTestRunner.d
+++ b/src/ocean/core/UnitTestRunner.d
@@ -13,7 +13,8 @@
     for example:
 
     ---
-    module tester;
+    // Workaround: https://github.com/dlang/dub/issues/1761
+    module_ tester;
     import ocean.core.UnitTestRunner;
     import mymodule;
     ---

--- a/src/ocean/time/Clock.d
+++ b/src/ocean/time/Clock.d
@@ -17,11 +17,10 @@
 
 module ocean.time.Clock;
 
-public  import ocean.time.Time;
-
-import ocean.sys.Common;
-
+import core.sys.posix.sys.time;
+import core.sys.posix.time;
 import ocean.core.ExceptionDefinitions;
+public import ocean.time.Time;
 
 version (unittest) import ocean.core.Test;
 

--- a/src/ocean/time/WallClock.d
+++ b/src/ocean/time/WallClock.d
@@ -17,11 +17,11 @@
 
 module ocean.time.WallClock;
 
-public  import ocean.time.Time;
-
+import core.sys.posix.sys.time;
+import core.sys.posix.time;
 import ocean.time.Clock;
+public import ocean.time.Time;
 
-import ocean.sys.Common;
 
 /******************************************************************************
 

--- a/src/ocean/util/container/queue/NotifyingQueue.d
+++ b/src/ocean/util/container/queue/NotifyingQueue.d
@@ -41,36 +41,36 @@
 
     Usage example for a hypothetical client who writes numbers to a socket
     ---
-        module NotifyingQueueExample;
+    module NotifyingQueueExample;
 
-        import ocean.util.container.queue.NotifyingQueue;
+    import ocean.util.container.queue.NotifyingQueue;
 
-        void main ( )
+    void main ( )
+    {
+        auto notifying_queue = new NotifyingByteQueue(1024 * 40);
+
+        void notee ( )
         {
-            auto notifying_queue = new NotifyingByteQueue(1024 * 40);
-
-            void notee ( )
+            while (true)
             {
-                while (true)
+                auto popped = cast(char[]) notifying_queue.pop()
+
+                if ( popped !is null )
                 {
-                    auto popped = cast(char[]) notifying_queue.pop()
-
-                    if ( popped !is null )
-                    {
-                        Stdout.formatln("Popped from the queue: {}", popped);
-                    }
-                    else break;
+                    Stdout.formatln("Popped from the queue: {}", popped);
                 }
-
-                notifying_queue.ready(&notee);
+                else break;
             }
 
             notifying_queue.ready(&notee);
-
-            numbers.sendNumber(23);
-            numbers.sendNumber(85);
-            numbers.sendNumber(42);
         }
+
+        notifying_queue.ready(&notee);
+
+        numbers.sendNumber(23);
+        numbers.sendNumber(85);
+        numbers.sendNumber(42);
+    }
     ---
 
     Copyright:
@@ -743,4 +743,3 @@ unittest
 {
     auto q = new NotifyingQueue!(char)(256);
 }
-

--- a/src/ocean/util/container/queue/NotifyingQueue.d
+++ b/src/ocean/util/container/queue/NotifyingQueue.d
@@ -41,7 +41,8 @@
 
     Usage example for a hypothetical client who writes numbers to a socket
     ---
-    module NotifyingQueueExample;
+    // Workaround: https://github.com/dlang/dub/issues/1761
+    module_ NotifyingQueueExample;
 
     import ocean.util.container.queue.NotifyingQueue;
 

--- a/src/ocean/util/log/Logger.d
+++ b/src/ocean/util/log/Logger.d
@@ -10,7 +10,8 @@
     object and initialize it on construction:
 
     ---
-    module superapp.main;
+    // Workaround: https://github.com/dlang/dub/issues/1761
+    module_ superapp.main;
 
     import ocean.transition;
     import ocean.util.log.Logger;

--- a/src/ocean/util/log/Logger.d
+++ b/src/ocean/util/log/Logger.d
@@ -61,15 +61,12 @@ import ocean.transition;
 import ocean.core.Verify;
 import ocean.core.ExceptionDefinitions;
 import ocean.io.model.IConduit;
-import ocean.sys.Common;
 import ocean.text.convert.Formatter;
 import ocean.time.Clock;
 import ocean.util.log.Appender;
 import ocean.util.log.Event;
 import ocean.util.log.model.ILogger;
-
 import ocean.util.log.Hierarchy;
-
 
 version (unittest)
 {


### PR DESCRIPTION
I needed `WallClock` and `Clock` to compile on OSX, hence switching to POSIX imports.
Also we're using `dub` to compile our code and a little `_` is all it takes to make it usable.