### PR TITLE
Logger: Remove static variable beginTime

### DIFF
--- a/relnotes/logger.feature.md
+++ b/relnotes/logger.feature.md
@@ -1,0 +1,9 @@
+### `Logger.runtime()` now uses `Clock.startTime()`
+
+* `ocean.util.log.Logger`
+
+The `Logger` now uses `Clock.startTime()` instead of the hierarchy instantiation time.
+This means that all hierarchy will have the same `runtime`.
+In practice, programs only ever had one hierarchy,
+and since the common usage is to instantiate `Logger`s from the module constructor,
+the `runtime()` was almost always that of the program, save for a few milliseconds.

--- a/src/ocean/util/log/Logger.d
+++ b/src/ocean/util/log/Logger.d
@@ -200,9 +200,6 @@ public struct Log
     /// Stores all the existing `Logger` in a hierarchical manner
     private static HierarchyT!(Logger) hierarchy_;
 
-    /// Time elapsed since the first logger instantiation
-    private static Time beginTime;
-
     /// Logger stats
     private static Stats logger_stats;
 
@@ -294,7 +291,6 @@ public struct Log
     {
         if (This.hierarchy_ is null)
         {
-            This.beginTime = Clock.now;
             This.hierarchy_ = new HierarchyT!(Logger)("ocean");
         }
         return This.hierarchy_;
@@ -758,13 +754,13 @@ public final class Logger : ILogger
     /***************************************************************************
 
         Returns:
-            Time since the first logger instantiation
+            Time since the program start
 
     ***************************************************************************/
 
     public TimeSpan runtime ()
     {
-        return Clock.now - Log.beginTime;
+        return Clock.now - Clock.startTime();
     }
 
     /***************************************************************************
@@ -1044,4 +1040,10 @@ unittest
     test!("==")(appender.buffers[4].message,
                 "This is some arg fmt - 42 - object.Object - 1337.00");
     test!("==")(appender.buffers[5].message, "Just some more allocation tests");
+}
+
+unittest
+{
+    Logger log = (new Logger(Log.hierarchy(), "dummy")).additive(false);
+    test!(">=")(log.runtime(), TimeSpan.fromNanos(0));
 }


### PR DESCRIPTION
Users care more about time since program start than time since Hierarchy instantiation.
And since Logger is almost exclusively used combined with a static module constructor,
those two are essentially the same.