### PR TITLE
Deprecated empty ocean.stdc.posix.arpa.inet module

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -43,6 +43,7 @@ $O/%unittests: override LDFLAGS += -lglib-2.0 -lpcre -lxml2 -lxslt -lebtree \
 
 # Remove deprecated modules from testing:
 TEST_FILTER_OUT += \
+	$C/src/ocean/stdc/posix/arpa/inet.d \
 	$C/src/ocean/stdc/posix/net/if_.d \
 	$C/src/ocean/stdc/posix/netinet/in_.d \
 	$C/src/ocean/stdc/posix/stdlib.d \

--- a/relnotes/posix-arpa-inet.deprecation.md
+++ b/relnotes/posix-arpa-inet.deprecation.md
@@ -1,0 +1,6 @@
+### Module `ocean.stdc.posix.arpa.inet` has been deprecated
+
+`ocean.stdc.posix.arpa.inet`
+
+This module was just publicly importing `core.sys.posix.arpa.inet`.
+Prefer this import instead.

--- a/src/ocean/net/util/GetSocketAddress.d
+++ b/src/ocean/net/util/GetSocketAddress.d
@@ -29,11 +29,11 @@ module ocean.net.util.GetSocketAddress;
 import ocean.transition;
 import ocean.io.model.IConduit: ISelectable;
 import ocean.stdc.posix.sys.socket: getsockname, getpeername, socklen_t, sockaddr;
-import ocean.stdc.posix.arpa.inet: ntohs, inet_ntop, INET_ADDRSTRLEN, INET6_ADDRSTRLEN;
 import ocean.sys.ErrnoException;
 
 import core.stdc.errno;
 import core.stdc.string: strlen, strerror_r;
+import core.sys.posix.arpa.inet: ntohs, inet_ntop, INET_ADDRSTRLEN, INET6_ADDRSTRLEN;
 import core.sys.posix.netinet.in_: sa_family_t, in_port_t, sockaddr_in, sockaddr_in6, in_addr, in6_addr;
 import consts = core.sys.posix.sys.socket;
 

--- a/src/ocean/stdc/posix/arpa/inet.d
+++ b/src/ocean/stdc/posix/arpa/inet.d
@@ -11,7 +11,7 @@
 
 *******************************************************************************/
 
-
+deprecated("Import `core.sys.posix.arpa.inet` directly")
 module ocean.stdc.posix.arpa.inet;
 
 public import core.sys.posix.arpa.inet;

--- a/src/ocean/sys/GetIfAddrs.d
+++ b/src/ocean/sys/GetIfAddrs.d
@@ -20,8 +20,8 @@ import ocean.transition;
 
 import core.stdc.errno;
 import core.stdc.string;
-import ocean.stdc.posix.arpa.inet;
 import ocean.stdc.posix.sys.socket;
+import core.sys.posix.arpa.inet;
 import core.sys.posix.netinet.in_: sockaddr_in, sockaddr_in6;
 
 static if (__VERSION__ < 2073)

--- a/src/ocean/sys/socket/AddrInfo.d
+++ b/src/ocean/sys/socket/AddrInfo.d
@@ -18,11 +18,11 @@ module ocean.sys.socket.AddrInfo;
 import ocean.core.Array: concat;
 import ocean.core.TypeConvert;
 import ocean.core.Verify;
-import ocean.stdc.posix.arpa.inet: inet_ntop, inet_pton, ntohs, htons, htonl;
 import ocean.transition;
 
 import core.stdc.errno: errno, EAFNOSUPPORT;
 import core.stdc.string: strlen;
+import core.sys.posix.arpa.inet: inet_ntop, inet_pton, ntohs, htons, htonl;
 import core.sys.posix.netinet.in_: sockaddr, socklen_t,
                                    sockaddr_in,  AF_INET,  INET_ADDRSTRLEN,
                                    sockaddr_in6, AF_INET6, INET6_ADDRSTRLEN,


### PR DESCRIPTION
On the long run, I aim to remove `ocean.stdc`. At the moment druntime is still missing quite a lot of symbol, but this module can already go.