### PR TITLE
Remove ocean.util.cipher.gcrypt dependency on ocean.transition

### DIFF
--- a/src/ocean/util/cipher/gcrypt/AES.d
+++ b/src/ocean/util/cipher/gcrypt/AES.d
@@ -21,8 +21,8 @@
 
 module ocean.util.cipher.gcrypt.AES;
 
+import ocean.meta.types.Qualifiers;
 import ocean.util.cipher.gcrypt.core.Gcrypt;
-import ocean.transition;
 
 
 /*******************************************************************************
@@ -122,7 +122,7 @@ version (unittest)
 
     void testAES ( Cipher, istring str_key ) ( )
     {
-        auto key = cast(Immut!(ubyte)[])str_key;
+        auto key = cast(immutable(ubyte)[])str_key;
 
         // Test that only keys of the provided length are allowed
         Cipher.testFixedKeyLength(key);
@@ -154,8 +154,8 @@ version (unittest)
 
     void testAES_IV ( Cipher, istring str_key, istring str_iv ) ( )
     {
-        auto key = cast(Immut!(ubyte)[])str_key;
-        auto iv = cast(Immut!(ubyte)[])str_iv;
+        auto key = cast(immutable(ubyte)[])str_key;
+        auto iv = cast(immutable(ubyte)[])str_iv;
 
         // Test that only keys of the provided length are allowed
         Cipher.testFixedKeyLength(key);

--- a/src/ocean/util/cipher/gcrypt/HMAC.d
+++ b/src/ocean/util/cipher/gcrypt/HMAC.d
@@ -24,9 +24,7 @@
 
 module ocean.util.cipher.gcrypt.HMAC;
 
-
 import ocean.util.cipher.gcrypt.core.MessageDigestCore;
-import ocean.transition;
 import ocean.util.cipher.gcrypt.c.md;
 
 /******************************************************************************/
@@ -52,7 +50,7 @@ public class HMAC: MessageDigestCore
     ***************************************************************************/
 
     public this ( gcry_md_algos algorithm, gcry_md_flags flags = cast(gcry_md_flags)0,
-                     istring file = __FILE__, int line = __LINE__ )
+                  string file = __FILE__, int line = __LINE__ )
     {
         super(algorithm, flags | flags.GCRY_MD_FLAG_HMAC, file, line);
     }
@@ -86,7 +84,7 @@ public class HMAC: MessageDigestCore
 
     ***************************************************************************/
 
-    public ubyte[] calculate ( Const!(ubyte)[] key, Const!(ubyte)[][] input_data ... )
+    public ubyte[] calculate (const(ubyte)[] key, const(ubyte)[][] input_data ... )
     {
         gcry_md_reset(this.md);
 
@@ -111,21 +109,21 @@ version (unittest)
 unittest
 {
     // https://tools.ietf.org/html/rfc4231#section-4.2
-    static Immut!(ubyte)[] sha224_hmac = [
+    static immutable(ubyte)[] sha224_hmac = [
         0x89, 0x6f, 0xb1, 0x12, 0x8a, 0xbb, 0xdf,
         0x19, 0x68, 0x32, 0x10, 0x7c, 0xd4, 0x9d,
         0xf3, 0x3f, 0x47, 0xb4, 0xb1, 0x16, 0x99,
         0x12, 0xba, 0x4f, 0x53, 0x68, 0x4b, 0x22
     ];
 
-    Immut!(ubyte)[20] key = 0x0b;
+    immutable(ubyte)[20] key = 0x0b;
     scope hmacgen = new HMAC(gcry_md_algos.GCRY_MD_SHA224);
     test!("==")(
         hmacgen.calculate(
             key,
-            cast(Immut!(ubyte)[])"Hi",
-            cast(Immut!(ubyte)[])" ",
-            cast(Immut!(ubyte)[])"There"
+            cast(immutable(ubyte)[])"Hi",
+            cast(immutable(ubyte)[])" ",
+            cast(immutable(ubyte)[])"There"
         ),
         sha224_hmac
     );
@@ -134,9 +132,9 @@ unittest
         hmacgen.calculate(
             key,
             [
-                cast(Immut!(ubyte)[])"Hi",
-                cast(Immut!(ubyte)[])" ",
-                cast(Immut!(ubyte)[])"There"
+                cast(immutable(ubyte)[])"Hi",
+                cast(immutable(ubyte)[])" ",
+                cast(immutable(ubyte)[])"There"
             ]
         ),
         sha224_hmac

--- a/src/ocean/util/cipher/gcrypt/MessageDigest.d
+++ b/src/ocean/util/cipher/gcrypt/MessageDigest.d
@@ -29,7 +29,6 @@
 module ocean.util.cipher.gcrypt.MessageDigest;
 
 import ocean.util.cipher.gcrypt.core.MessageDigestCore;
-import ocean.transition;
 import ocean.util.cipher.gcrypt.c.md;
 
 /*******************************************************************************
@@ -57,7 +56,7 @@ public class MessageDigest: MessageDigestCore
     ***************************************************************************/
 
     public this ( gcry_md_algos algorithm, gcry_md_flags flags = cast(gcry_md_flags)0,
-                     istring file = __FILE__, int line = __LINE__ )
+                  string file = __FILE__, int line = __LINE__ )
     {
         super(algorithm, flags, file, line);
     }
@@ -81,7 +80,7 @@ public class MessageDigest: MessageDigestCore
 
     ***************************************************************************/
 
-    public ubyte[] calculate ( Const!(ubyte)[][] input_data ... )
+    public ubyte[] calculate ( const(ubyte)[][] input_data ... )
     {
         gcry_md_reset(this.md);
         return this.calculate_(input_data);
@@ -98,7 +97,7 @@ version (unittest)
 unittest
 {
     // http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/SHA224.pdf
-    static Immut!(ubyte)[] sha224_hash = [
+    static immutable(ubyte)[] sha224_hash = [
         0x75, 0x38, 0x8B, 0x16, 0x51, 0x27, 0x76,
         0xCC, 0x5D, 0xBA, 0x5D, 0xA1, 0xFD, 0x89,
         0x01, 0x50, 0xB0, 0xC6, 0x45, 0x5C, 0xB4,
@@ -109,22 +108,22 @@ unittest
 
     test!("==")(
         md.calculate(
-            cast(Immut!(ubyte)[])"abcdbcdec",
-            cast(Immut!(ubyte)[])"defdefgefghfghig",
-            cast(Immut!(ubyte)[])"hi",
-            cast(Immut!(ubyte)[])"jhijkijkljklmklmnlmnomno",
-            cast(Immut!(ubyte)[])"pnopq"
+            cast(immutable(ubyte)[])"abcdbcdec",
+            cast(immutable(ubyte)[])"defdefgefghfghig",
+            cast(immutable(ubyte)[])"hi",
+            cast(immutable(ubyte)[])"jhijkijkljklmklmnlmnomno",
+            cast(immutable(ubyte)[])"pnopq"
         ),
         sha224_hash
     );
 
     test!("==")(
         md.calculate([
-            cast(Immut!(ubyte)[])"abcdbcdec",
-            cast(Immut!(ubyte)[])"defdefgefghfghig",
-            cast(Immut!(ubyte)[])"hi",
-            cast(Immut!(ubyte)[])"jhijkijkljklmklmnlmnomno",
-            cast(Immut!(ubyte)[])"pnopq"
+            cast(immutable(ubyte)[])"abcdbcdec",
+            cast(immutable(ubyte)[])"defdefgefghfghig",
+            cast(immutable(ubyte)[])"hi",
+            cast(immutable(ubyte)[])"jhijkijkljklmklmnlmnomno",
+            cast(immutable(ubyte)[])"pnopq"
         ]),
         sha224_hash
     );

--- a/src/ocean/util/cipher/gcrypt/PBKDF2.d
+++ b/src/ocean/util/cipher/gcrypt/PBKDF2.d
@@ -33,7 +33,6 @@ public alias KeyDerivationCore!(KDF.GCRY_KDF_PBKDF2, Hasher.GCRY_MD_SHA256) PBKD
 
 version (unittest)
 {
-    import ocean.transition;
     import ocean.core.Test;
     import ocean.text.convert.Hex;
 }
@@ -42,8 +41,8 @@ version (unittest)
 unittest
 {
     // Set up the passphrase and salt
-    auto passphrase = cast(Immut!(ubyte)[])"passphrase";
-    auto salt = cast(Immut!(ubyte)[])"salt";
+    auto passphrase = cast(immutable(ubyte)[])"passphrase";
+    auto salt = cast(immutable(ubyte)[])"salt";
 
     // Create the key derivation instance
     auto pbkdf2 = new PBKDF2(passphrase, salt);

--- a/src/ocean/util/cipher/gcrypt/TripleDES.d
+++ b/src/ocean/util/cipher/gcrypt/TripleDES.d
@@ -27,8 +27,6 @@
 module ocean.util.cipher.gcrypt.TripleDES;
 
 import ocean.util.cipher.gcrypt.core.Gcrypt;
-import ocean.transition;
-
 
 /*******************************************************************************
 
@@ -43,15 +41,16 @@ public alias GcryptWithIV!(Algorithm.GCRY_CIPHER_3DES, Mode.GCRY_CIPHER_MODE_CFB
 version (unittest)
 {
     import ocean.core.Test;
+    import ocean.meta.types.Qualifiers;
 }
 
 /// Usage example
 unittest
 {
     // TripleDES requires a key of length 24 bytes
-    auto key = cast(Immut!(ubyte)[])"a key of 24 bytesa key o";
+    auto key = cast(immutable(ubyte)[])"a key of 24 bytesa key o";
     // TripleDES requires an initialisation vector of length 8 bytes.
-    auto iv = cast(Immut!(ubyte)[])"iv8bytes";
+    auto iv = cast(immutable(ubyte)[])"iv8bytes";
 
     istring text = "This is a text we are going to encrypt";
     mstring encrypted_text, decrypted_text;
@@ -81,6 +80,6 @@ unittest
 // Test that only 24-bytes keys are allowed
 unittest
 {
-    auto key = cast(Immut!(ubyte)[])"a key of 24 bytesa key o";
+    auto key = cast(immutable(ubyte)[])"a key of 24 bytesa key o";
     TripleDES.testFixedKeyLength(key);
 }

--- a/src/ocean/util/cipher/gcrypt/Twofish.d
+++ b/src/ocean/util/cipher/gcrypt/Twofish.d
@@ -27,8 +27,6 @@
 module ocean.util.cipher.gcrypt.Twofish;
 
 import ocean.util.cipher.gcrypt.core.Gcrypt;
-import ocean.transition;
-
 
 /*******************************************************************************
 
@@ -43,15 +41,16 @@ public alias GcryptWithIV!(Algorithm.GCRY_CIPHER_TWOFISH, Mode.GCRY_CIPHER_MODE_
 version (unittest)
 {
     import ocean.core.Test;
+    import ocean.meta.types.Qualifiers;
 }
 
 /// Usage example
 unittest
 {
     // Twofish requires a key of length 32 bytes
-    auto key = cast(Immut!(ubyte)[])"a key of 32 bytesa key of32bytes";
+    auto key = cast(immutable(ubyte)[])"a key of 32 bytesa key of32bytes";
     // Twofish requires an initialisation vector of length 16 bytes.
-    auto iv = cast(Immut!(ubyte)[])"a iv of 16 bytes";
+    auto iv = cast(immutable(ubyte)[])"a iv of 16 bytes";
 
     istring text = "This is a text we are going to encrypt";
     mstring encrypted_text, decrypted_text;
@@ -81,6 +80,6 @@ unittest
 // Test that only keys of the provided length are allowed
 unittest
 {
-    auto key = cast(Immut!(ubyte)[])"a key of 32 bytesa key of32bytes";
+    auto key = cast(immutable(ubyte)[])"a key of 32 bytesa key of32bytes";
     Twofish.testFixedKeyLength(key);
 }

--- a/src/ocean/util/cipher/gcrypt/c/gcrypt.d
+++ b/src/ocean/util/cipher/gcrypt/c/gcrypt.d
@@ -23,8 +23,6 @@
 
 module ocean.util.cipher.gcrypt.c.gcrypt;
 
-import ocean.transition;
-
 public import ocean.util.cipher.gcrypt.c.general;
 
 extern (C):
@@ -37,19 +35,19 @@ gcry_error_t gcry_cipher_open (gcry_cipher_hd_t* hd, gcry_cipher_algos algo,
 void gcry_cipher_close (gcry_cipher_hd_t h);
 
 /// See original's library documentation for details.
-gcry_error_t gcry_cipher_setkey (gcry_cipher_hd_t h, Const!(void)* k, size_t l);
+gcry_error_t gcry_cipher_setkey (gcry_cipher_hd_t h, const(void)* k, size_t l);
 
 /// See original's library documentation for details.
-gcry_error_t gcry_cipher_setiv (gcry_cipher_hd_t h, Const!(void)* k, size_t l);
+gcry_error_t gcry_cipher_setiv (gcry_cipher_hd_t h, const(void)* k, size_t l);
 
 
 /// See original's library documentation for details.
-gcry_error_t gcry_cipher_encrypt (gcry_cipher_hd_t h, Const!(void)* out_,
-    size_t outsize, Const!(void)* in_, size_t inlen);
+gcry_error_t gcry_cipher_encrypt (gcry_cipher_hd_t h, const(void)* out_,
+    size_t outsize, const(void)* in_, size_t inlen);
 
 /// See original's library documentation for details.
-gcry_error_t gcry_cipher_decrypt (gcry_cipher_hd_t h, Const!(void)* out_,
-    size_t outsize, Const!(void)* in_, size_t inlen);
+gcry_error_t gcry_cipher_decrypt (gcry_cipher_hd_t h, const(void)* out_,
+    size_t outsize, const(void)* in_, size_t inlen);
 
 
 /// See original's library documentation for details.
@@ -112,5 +110,3 @@ enum gcry_cipher_modes
     GCRY_CIPHER_MODE_POLY1305 = 10,  /* Poly1305 based AEAD mode. */
     GCRY_CIPHER_MODE_OCB      = 11   /* OCB3 mode.  */
 }
-
-

--- a/src/ocean/util/cipher/gcrypt/c/general.d
+++ b/src/ocean/util/cipher/gcrypt/c/general.d
@@ -25,8 +25,6 @@ module ocean.util.cipher.gcrypt.c.general;
 
 public import ocean.util.cipher.gcrypt.c.libversion;
 
-import ocean.transition;
-
 extern (C):
 
 /// See original's library documentation for details.
@@ -104,14 +102,14 @@ enum gcry_ctl_cmds
 }
 
 /// See original's library documentation for details.
-gcry_error_t gcry_control ( gcry_ctl_cmds CMD, ...);
+gcry_error_t gcry_control (gcry_ctl_cmds CMD, ...);
 
 // The function gcry_strerror returns a pointer to a statically allocated string
 // containing a description of the error code contained in the error value err.
 // This string can be used to output a diagnostic message to the user.
-Const!(char)* gcry_strerror (gcry_error_t err);
+const(char)* gcry_strerror (gcry_error_t err);
 
 // The function gcry_strsource returns a pointer to a statically allocated
 // string containing a description of the error source contained in the error
 // value err. This string can be used to output a diagnostic message to the user.
-Const!(char)* gcry_strsource (gcry_error_t err);
+const(char)* gcry_strsource (gcry_error_t err);

--- a/src/ocean/util/cipher/gcrypt/c/gpgerror.d
+++ b/src/ocean/util/cipher/gcrypt/c/gpgerror.d
@@ -26,10 +26,9 @@
 
 module ocean.util.cipher.gcrypt.c.gpgerror;
 
-public import ocean.util.cipher.gcrypt.c.libversion;
-
-import ocean.transition;
 import ocean.core.Verify;
+public import ocean.util.cipher.gcrypt.c.libversion;
+import core.stdc.string;
 
 extern (C):
 
@@ -650,12 +649,10 @@ GPG_ERR_SOURCE gpg_err_source (gpg_error_t err)
 }
 
 /// See original's library documentation for details.
-Const!(char)* gpg_strerror(gpg_error_t err);
+const(char)* gpg_strerror(gpg_error_t err);
 
 /// See original's library documentation for details.
 int gpg_strerror_r(gpg_error_t err, char* buf, size_t buflen);
-
-import ocean.stdc.string;
 
 extern (D) int gpg_strerror_r(uint err, ref char[] msg)
 {
@@ -668,7 +665,7 @@ extern (D) int gpg_strerror_r(uint err, ref char[] msg)
 }
 
 /// See original's library documentation for details.
-Const!(char)* gpg_strsource (uint err);
+const(char)* gpg_strsource (uint err);
 
 /// See original's library documentation for details.
 GPG_ERR_CODE gpg_err_code_from_errno(int err);
@@ -686,5 +683,5 @@ GPG_ERR_CODE gpg_err_code_from_syserror();
 void gpg_err_set_errno(int err);
 
 /// See original's library documentation for details.
-Const!(char)* gpgrt_check_version (Const!(char)* req_version);
-Const!(char)* gpg_error_check_version(Const!(char)* req_version);
+const(char)* gpgrt_check_version (const(char)* req_version);
+const(char)* gpg_error_check_version(const(char)* req_version);

--- a/src/ocean/util/cipher/gcrypt/c/kdf.d
+++ b/src/ocean/util/cipher/gcrypt/c/kdf.d
@@ -18,8 +18,6 @@
 
 module ocean.util.cipher.gcrypt.c.kdf;
 
-import ocean.transition;
-
 public import ocean.util.cipher.gcrypt.c.gpgerror;
 
 extern (C):
@@ -36,7 +34,7 @@ enum gcry_kdf_algos
 }
 
 /* Derive a key from a passphrase.  */
-gpg_error_t gcry_kdf_derive (Const!(void)* passphrase, size_t passphraselen,
-                             int algo, int subalgo, Const!(void)* salt,
+gpg_error_t gcry_kdf_derive (const(void)* passphrase, size_t passphraselen,
+                             int algo, int subalgo, const(void)* salt,
                              size_t saltlen, ulong iterations,
                              size_t keysize, void* keybuffer);

--- a/src/ocean/util/cipher/gcrypt/c/libversion.d
+++ b/src/ocean/util/cipher/gcrypt/c/libversion.d
@@ -23,10 +23,8 @@
 
 module ocean.util.cipher.gcrypt.c.libversion;
 
-import ocean.transition;
-
 // The minimum version supported by the bindings
-public istring gcrypt_version = "1.5.0";
+public string gcrypt_version = "1.5.0";
 
 /*******************************************************************************
 
@@ -44,4 +42,4 @@ shared static this ( )
 }
 
 /// See original's library documentation for details.
-extern (C) Const!(char)* gcry_check_version ( Const!(char)* req_version);
+extern (C) const(char)* gcry_check_version (const(char)* req_version);

--- a/src/ocean/util/cipher/gcrypt/c/md.d
+++ b/src/ocean/util/cipher/gcrypt/c/md.d
@@ -25,8 +25,6 @@ module ocean.util.cipher.gcrypt.c.md;
 
 public import ocean.util.cipher.gcrypt.c.general;
 
-import ocean.transition;
-
 extern (C):
 
 /// See original's library documentation for details.
@@ -84,7 +82,7 @@ gcry_error_t gcry_md_ctl (gcry_md_hd_t hd, int cmd,
                           void* buffer, size_t buflen);
 
 /// See original's library documentation for details.
-void gcry_md_write (gcry_md_hd_t hd, Const!(void)* buffer, size_t length);
+void gcry_md_write (gcry_md_hd_t hd, const(void)* buffer, size_t length);
 
 /// See original's library documentation for details.
 ubyte* gcry_md_read (gcry_md_hd_t hd, gcry_md_algos algo = gcry_md_algos.init);
@@ -103,7 +101,7 @@ extern (D) ubyte[] gcry_md_read_slice (gcry_md_hd_t hd, gcry_md_algos algo = gcr
 
 /// See original's library documentation for details.
 void gcry_md_hash_buffer (gcry_md_algos algo, void* digest,
-                          Const!(void)* buffer, size_t length);
+                          const(void)* buffer, size_t length);
 
 /// See original's library documentation for details.
 gcry_md_algos gcry_md_get_algo (gcry_md_hd_t hd);
@@ -126,16 +124,16 @@ gcry_error_t gcry_md_algo_info (gcry_md_algos algo, gcry_ctl_cmds what, void* bu
                                size_t* nbytes);
 
 /// See original's library documentation for details.
-Const!(char)* gcry_md_algo_name (gcry_md_algos algo);
+const(char)* gcry_md_algo_name (gcry_md_algos algo);
 
 /// See original's library documentation for details.
-int gcry_md_map_name (Const!(char)* name);
+int gcry_md_map_name (const(char)* name);
 
 /// See original's library documentation for details.
-gcry_error_t gcry_md_setkey (gcry_md_hd_t hd, Const!(void)* key, size_t keylen);
+gcry_error_t gcry_md_setkey (gcry_md_hd_t hd, const(void)* key, size_t keylen);
 
 /// See original's library documentation for details.
-void gcry_md_debug (gcry_md_hd_t hd, Const!(char)* suffix);
+void gcry_md_debug (gcry_md_hd_t hd, const(char)* suffix);
 
 
 /// See original's library documentation for details.

--- a/src/ocean/util/cipher/gcrypt/c/random.d
+++ b/src/ocean/util/cipher/gcrypt/c/random.d
@@ -25,8 +25,6 @@ module ocean.util.cipher.gcrypt.c.random;
 
 import ocean.util.cipher.gcrypt.c.general;
 
-import ocean.transition;
-
 extern (C):
 
 /// See original's library documentation for details.
@@ -43,7 +41,7 @@ void gcry_randomize (void* buffer, size_t length,
                      gcry_random_level level);
 
 /// See original's library documentation for details.
-gcry_error_t gcry_random_add_bytes (Const!(void)* buffer, size_t length,
+gcry_error_t gcry_random_add_bytes (const(void)* buffer, size_t length,
                                     int quality = -1);
 
 /// See original's library documentation for details.

--- a/src/ocean/util/cipher/gcrypt/core/Gcrypt.d
+++ b/src/ocean/util/cipher/gcrypt/core/Gcrypt.d
@@ -25,11 +25,9 @@
 
 module ocean.util.cipher.gcrypt.core.Gcrypt;
 
-
-
-import ocean.util.cipher.gcrypt.c.gcrypt;
-import ocean.transition;
 import ocean.core.Verify;
+import ocean.meta.types.Qualifiers;
+import ocean.util.cipher.gcrypt.c.gcrypt;
 
 version (unittest)
 {
@@ -427,7 +425,7 @@ private class GcryptBase ( Algorithm algorithm, Mode mode )
 
         ***********************************************************************/
 
-        public static void testFixedKeyLength (Const!(ubyte)[] key)
+        public static void testFixedKeyLength (const(ubyte)[] key)
         {
             // Too short should fail
             testThrown!(GcryptException)(new typeof(this)(key[0 .. $-1]));

--- a/src/ocean/util/cipher/gcrypt/core/KeyDerivationCore.d
+++ b/src/ocean/util/cipher/gcrypt/core/KeyDerivationCore.d
@@ -21,8 +21,6 @@
 
 module ocean.util.cipher.gcrypt.core.KeyDerivationCore;
 
-
-import ocean.transition;
 import ocean.util.cipher.gcrypt.c.kdf;
 import ocean.util.cipher.gcrypt.c.md;
 
@@ -62,7 +60,7 @@ public class KeyDerivationCore ( KDF algorithm, Hasher hasher )
 
     ***************************************************************************/
 
-    private Const!(ubyte)[] passphrase;
+    private const(ubyte)[] passphrase;
 
     /***************************************************************************
 
@@ -70,7 +68,7 @@ public class KeyDerivationCore ( KDF algorithm, Hasher hasher )
 
     ***************************************************************************/
 
-    private Const!(ubyte)[] salt;
+    private const(ubyte)[] salt;
 
     /***************************************************************************
 

--- a/src/ocean/util/cipher/gcrypt/core/MessageDigestCore.d
+++ b/src/ocean/util/cipher/gcrypt/core/MessageDigestCore.d
@@ -25,8 +25,6 @@
 module ocean.util.cipher.gcrypt.core.MessageDigestCore;
 
 
-import ocean.transition;
-
 /******************************************************************************/
 
 abstract class MessageDigestCore
@@ -59,7 +57,7 @@ abstract class MessageDigestCore
     ***************************************************************************/
 
     protected this ( gcry_md_algos algorithm, gcry_md_flags flags = cast(gcry_md_flags)0,
-                     istring file = __FILE__, int line = __LINE__ )
+                     string file = __FILE__, int line = __LINE__ )
     out
     {
         assert(this.md !is null);
@@ -102,7 +100,7 @@ abstract class MessageDigestCore
 
     ***************************************************************************/
 
-    protected ubyte[] calculate_ ( Const!(ubyte)[][] input_data )
+    protected ubyte[] calculate_ ( const(ubyte)[][] input_data )
     {
         foreach (chunk; input_data)
         {


### PR DESCRIPTION
This package can be almost stand-alone, making it easy to extract from Ocean if needed.