### PR TITLE
Make BufferedDirectReadFile.DirectReadFile protected, not private

### DIFF
--- a/src/ocean/io/device/DirectIO.d
+++ b/src/ocean/io/device/DirectIO.d
@@ -574,7 +574,7 @@ public class BufferedDirectReadFile: InputStream
 
     ***************************************************************************/
 
-    static private class DirectReadFile : File
+    static protected class DirectReadFile : File
     {
         override public void open (cstring path, Style style = this.ReadExisting)
         {


### PR DESCRIPTION
At least one downstream overrides this nested static class, and this appears to be intended usage.  As of DMD 2.087.0 `private` protection will be properly enforced, and builds of such downstreams will fail.

This patch therefore switches `private` to `protected`, matching what is already in place for `BufferedDirectWriteFile.DirectWriteFile`.