### PR TITLE
Replace D1 operator overloads in SuspendableThrottlerCount

### DIFF
--- a/relnotes/d1-ops.migration.md
+++ b/relnotes/d1-ops.migration.md
@@ -1,0 +1,13 @@
+### Replace D1 operator overloads with D2 operator overloads
+
+`ocean.io.model.SuspendableThrottlerCount`
+
+DMD 2.088.0 has deprecated D1 operator overloads, which are expected to
+be replaced with the newer D2 `op{Unary,Binary,BinaryRight,OpAssign}`
+templated methods: <https://dlang.org/changelog/2.088.0.html#dep_d1_ops>
+
+Since templated methods cannot be overridden this may in some rare cases
+cause breaking change for classes that implemented the old operators.
+In general however this will likely make no practical difference, other
+than the absence of scores of deprecation messages with more recent DMD
+versions.

--- a/src/ocean/io/model/SuspendableThrottlerCount.d
+++ b/src/ocean/io/model/SuspendableThrottlerCount.d
@@ -78,8 +78,6 @@ public class SuspendableThrottlerCount : ISuspendableThrottlerCount
 
         Increases the count of pending items and throttles the suspendables.
 
-        Aliased as opPostInc.
-
     ***************************************************************************/
 
     public void inc ( )
@@ -90,11 +88,16 @@ public class SuspendableThrottlerCount : ISuspendableThrottlerCount
         super.throttledSuspend();
     }
 
+    /// ditto
+    public void opUnary ( string op ) ( ) if (op == "++")
+    {
+        return this.inc();
+    }
+
     // WORKAROUND: DMD 2.068 had difficulties  resolving multiple overloads of
     // `add` when one came from alias and other was "native" method. Creating
     // distinct name (`inc`) allowed to disambugate it manually
     public alias inc add;
-    public alias inc opPostInc;
 
 
     /***************************************************************************
@@ -103,8 +106,6 @@ public class SuspendableThrottlerCount : ISuspendableThrottlerCount
 
         Params:
             n = number of pending items to add
-
-        Aliased as opAddAssign.
 
     ***************************************************************************/
 
@@ -116,14 +117,16 @@ public class SuspendableThrottlerCount : ISuspendableThrottlerCount
         super.throttledSuspend();
     }
 
-    public alias add opAddAssign;
+    /// ditto
+    public void opOpAssign ( string op ) ( size_t n ) if (op == "+")
+    {
+        this.add(n);
+    }
 
 
     /***************************************************************************
 
         Decreases the count of pending items and throttles the suspendables.
-
-        Aliased as opPostDec.
 
     ***************************************************************************/
 
@@ -135,11 +138,16 @@ public class SuspendableThrottlerCount : ISuspendableThrottlerCount
         super.throttledResume();
     }
 
+    /// ditto
+    public void opUnary ( string op ) ( ) if (op == "--")
+    {
+        return this.dec();
+    }
+
     // WORKAROUND: DMD 2.068 had difficulties  resolving multiple overloads of
     // `remove` when one came from alias and other was "native" method. Creating
     // distinct name (`dec`) allowed to disambugate it manually
     public alias dec remove;
-    public alias dec opPostDec;
 
 
     /***************************************************************************
@@ -148,8 +156,6 @@ public class SuspendableThrottlerCount : ISuspendableThrottlerCount
 
         Params:
             n = number of pending items to remove
-
-        Aliased as opSubAssign.
 
     ***************************************************************************/
 
@@ -160,7 +166,11 @@ public class SuspendableThrottlerCount : ISuspendableThrottlerCount
         super.throttledResume();
     }
 
-    public alias remove opSubAssign;
+    /// ditto
+    public void opOpAssign ( string op ) ( size_t n ) if (op == "-")
+    {
+        this.remove(n);
+    }
 
 
     /***************************************************************************


### PR DESCRIPTION
DMD 2.088.0 has deprecated D1 operator overloads, which are expected to be replaced with the newer D2 `op{Unary,Binary,BinaryRight,OpAssign}` templated methods: https://dlang.org/changelog/2.088.0.html#dep_d1_ops

`SuspendableThrottlerCount` has a slightly finnicky implementation of these, so it seems worth updating it in a separate patch.  Its original design defined local methods (`inc`/`dec`, `add`/`remove`) that provide the actual implementation, and used aliases to these to implement the actual operator overloads.  This is a problem because these methods may be (and in at least some test cases are) overridden by subclasses.  We therefore cannot just replace them with standard D2 operator overloads, as templated methods cannot be overridden by subclasses.

The simplest solution therefore seems to be to continue to support these custom local methods, and replace each D1 operator overload alias with a D2 operator overload implemented as a thin wrapper of the local method.

This should allow overloads of the implementations to continue to work, while having no impact on subclasses or users of the operators.

Part of https://github.com/sociomantic-tsunami/ocean/issues/747.