### PR TITLE
Replace D1 operator overloads in SignalSet struct

### DIFF
--- a/relnotes/signalset-ops.deprecation.md
+++ b/relnotes/signalset-ops.deprecation.md
@@ -1,0 +1,12 @@
+### Deprecate D1 operator overloads in `SignalSet`
+
+DMD 2.088.0 has deprecated D1 operator overloads, which are expected to
+be replaced with the newer D2 `op{Unary,Binary,BinaryRight,OpAssign}`
+templated methods: <https://dlang.org/changelog/2.088.0.html#dep_d1_ops>
+
+The D1 operator overloads in `SignalSet` are used in a rather weird way
+which does not really seem appropriate to use for insertion and removal
+from a set.  Rather than replace them with D2 operator overloads, they
+have simply been deprecated in favour of using the existing `add` and
+`remove` methods directly.  Support for the operator overloads will be
+dropped in the next major release of ocean.

--- a/src/ocean/sys/SignalMask.d
+++ b/src/ocean/sys/SignalMask.d
@@ -92,6 +92,10 @@ public struct SignalSet
         sigdelset(&(&this).sigset, signal);
     }
 
+    // deprecated not only because D1 binary operators are being deprecated
+    // in more recent D2 versions, but because this is an inappropriate way
+    // to represent removing signals from the mask
+    deprecated("Use `remove` method instead of subtraction operator!")
     public alias remove opSub;
 
 
@@ -111,6 +115,10 @@ public struct SignalSet
         sigaddset(&(&this).sigset, signal);
     }
 
+    // deprecated not only because D1 binary operators are being deprecated
+    // in more recent D2 versions, but because this is an inappropriate way
+    // to represent adding signals to the mask
+    deprecated("Use `add` method instead of addition operator!")
     public alias add opAdd;
 
 
@@ -133,6 +141,10 @@ public struct SignalSet
         }
     }
 
+    // deprecated not only because D1 binary operators are being deprecated
+    // in more recent D2 versions, but because this is an inappropriate way
+    // to represent removing signals from the mask
+    deprecated("Use `remove` method instead of subtraction operator!")
     public alias remove opSub;
 
 
@@ -155,6 +167,10 @@ public struct SignalSet
         }
     }
 
+    // deprecated not only because D1 binary operators are being deprecated
+    // in more recent D2 versions, but because this is an inappropriate way
+    // to represent adding signals to the mask
+    deprecated("Use `add` method instead of addition operator!")
     public alias add opAdd;
 
 


### PR DESCRIPTION
DMD 2.088.0 has deprecated D1 operator overloads, which are expected to be replaced with the newer D2 `op{Unary,Binary,BinaryRight,OpAssign}` templated methods: https://dlang.org/changelog/2.088.0.html#dep_d1_ops

The `SignalSet` struct has a slightly unusual setup, using custom `add` and `remove` methods doing the real work, and using aliases to these to define addition and subtraction operator overloads.

Since this is a struct rather than a class, we do not have to care about whether these methods are overrideable.  What is more problematic is the fact that as written, these aliases do not correctly implement addition or subtraction operators, which are supposed to return the result.

It therefore looks like `b + c` will update `b` in place and result in a `void` result (i.e. we cannot use the result of the addition).

This honestly feels like a serious code smell, and without knowing what the downstream use cases are it is hard to know the best way to approach this.  I've therefore made the decision to try to implement the newer D2 operators as correctly as possible, since any resulting breakages likely reveal code that was relying on bugs in the first place.

The `add` and `remove` methods have been kept as is, but the D1 operator aliases have been replaced with `opBinary` methods that copy the current struct instance, call its own `add`/`remove` method as needed and return the updated struct.

This means that downstreams using `signal_set.{add,remove}` will get the same behaviour as before, but that we can now correctly use expressions of the form:

   signal_set_2 = signal_set_1 + new_signal

... where `signal_set_1` will not be affected by the addition.

Note however that this might have a weird impact on downstreams if they ever used the old addition/subtraction operators.

The only use case I've found is in ocean itself in `ocean.sys.SignalFD`, where only `add` and `remove` are ever used.  I think it likely that the operator overloads were therefore never actually used, but just included because they seemed like the right thing to someone at the time, perhaps with some misunderstanding of what was the best operator to use.

However, technically this could be a breaking change for someone, albeit someone whose code was likely doing something weird in the first place.

Part of https://github.com/sociomantic-tsunami/ocean/issues/747.