### PR TITLE
Make Arguments public in CliApp

### DIFF
--- a/src/ocean/util/app/CliApp.d
+++ b/src/ocean/util/app/CliApp.d
@@ -36,7 +36,9 @@ import ocean.transition;
 
 abstract class CliApp : Application, IArgumentsExtExtension
 {
-    import ocean.text.Arguments : Arguments;
+    static import ocean.text.Arguments;
+    public alias ocean.text.Arguments.Arguments Arguments;
+
     import ocean.util.app.ext.ArgumentsExt;
     import ocean.util.app.ext.VersionArgsExt;
     import ocean.util.app.ext.TaskExt;


### PR DESCRIPTION
This corresponding change was made for DaemonApp in c238e880bc8e802c3f1e22b8896d76e01185444a

but CliApp was overlooked.
This is required by the import visibility fixes to DMD.