### PR TITLE
Undeprecate fieldIdentifier in meta.codegen

### DIFF
--- a/relnotes/undeprecate_fieldIdentifier.bug.md
+++ b/relnotes/undeprecate_fieldIdentifier.bug.md
@@ -1,0 +1,6 @@
+### Template `Identifier.fieldIdentifier` is no longer deprecated
+
+`ocean.meta.codegen.Identifier.fieldIdentifier`
+
+This template was erroneously marked as deprecated in ocean v5.0.0, but
+it is still required. Using it will no longer generate a deprecation warning.

--- a/src/ocean/core/Traits.d
+++ b/src/ocean/core/Traits.d
@@ -305,7 +305,7 @@ public M* GetField ( size_t i, M, T ) ( T* t )
 
 *******************************************************************************/
 
-deprecated("Use ocean.meta.codegen.Identifier.identifier!(T.tupleof[i])")
+deprecated("Use ocean.meta.codegen.Identifier.fieldIdentifier!(T, i)")
 public template FieldName ( size_t i, T )
 {
     static if ( !isCompoundType!(T) )

--- a/src/ocean/meta/codegen/Identifier.d
+++ b/src/ocean/meta/codegen/Identifier.d
@@ -73,7 +73,7 @@ unittest
     Template to get the name of the ith member of a struct / class.
 
     Used over plain `identifier` when iterating over aggregate fields with
-    `.tupleof` as D1 compiler refuses to pass such field as template alias
+    `.tupleof` as compiler refuses to pass such field as template alias
     parameter.
 
     Params:
@@ -85,13 +85,12 @@ unittest
 
 *******************************************************************************/
 
-deprecated("Use ocean.meta.codegen.identifier!(T.tupleof[i])")
 public template fieldIdentifier ( T, size_t i )
 {
     enum fieldIdentifier = identifier!(T.tupleof[i]);
 }
 
-deprecated unittest
+unittest
 {
     static struct TestStruct
     {


### PR DESCRIPTION
This template should not have been deprecated. It is required in D2 as well as D1. The suggested replacement in the deprecation message of `FieldName` is not correct, it does not compile in most cases.