### PR TITLE
Remove unused import from prometheus

### DIFF
--- a/src/ocean/io/compress/lzo/LzoHeader.d
+++ b/src/ocean/io/compress/lzo/LzoHeader.d
@@ -641,8 +641,6 @@ template SizeofTuple ( T ... )
 
 version (unittest):
 
-import ocean.io.Stdout : Stderr;
-
 import ocean.time.StopWatch;
 
 import ocean.text.util.MetricPrefix;

--- a/src/ocean/util/prometheus/collector/StatFormatter.d
+++ b/src/ocean/util/prometheus/collector/StatFormatter.d
@@ -14,8 +14,6 @@
 
 module ocean.util.prometheus.collector.StatFormatter;
 
-import ocean.net.http.TaskHttpConnectionHandler;
-
 import core.stdc.time;
 import ocean.meta.traits.Basic;
 import ocean.meta.codegen.Identifier;


### PR DESCRIPTION
This make the package completely self-contained.