### PR TITLE
Replace useless `(&this)` with `this`

### DIFF
--- a/src/ocean/application/components/PidLock.d
+++ b/src/ocean/application/components/PidLock.d
@@ -70,7 +70,7 @@ public struct PidLock
 
     public void parseConfig ( ConfigParser config )
     {
-        (&this).pidlock_path = config.get("PidLock", "path", "").dup;
+        this.pidlock_path = config.get("PidLock", "path", "").dup;
     }
 
     /***************************************************************************
@@ -84,12 +84,12 @@ public struct PidLock
 
     public void lock ( )
     {
-        if ((&this).pidlock_path.length)
+        if (this.pidlock_path.length)
         {
             istring msg =
-                idup("Couldn't lock the pid lock file '" ~ (&this).pidlock_path
+                idup("Couldn't lock the pid lock file '" ~ this.pidlock_path
                  ~ "'. Probably another instance of the application is running.");
-            enforce((&this).tryLockPidFile(), msg);
+            enforce(this.tryLockPidFile(), msg);
         }
     }
 
@@ -104,14 +104,14 @@ public struct PidLock
 
     public void unlock ( )
     {
-        if (!(&this).is_locked)
+        if (!this.is_locked)
         {
             return;
         }
 
         // releases the lock and closes the lock file
-        (&this).enforcePosix!(close)((&this).lock_fd);
-        (&this).enforcePosix!(unlink)(StringC.toCString((&this).pidlock_path));
+        this.enforcePosix!(close)(this.lock_fd);
+        this.enforcePosix!(unlink)(StringC.toCString(this.pidlock_path));
     }
 
     /***************************************************************************
@@ -134,7 +134,7 @@ public struct PidLock
 
     private bool tryLockPidFile ( )
     {
-        (&this).lock_fd = (&this).enforcePosix!(open)(StringC.toCString((&this).pidlock_path),
+        this.lock_fd = this.enforcePosix!(open)(StringC.toCString(this.pidlock_path),
                 O_RDWR | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 
         // TODO these will be available in tango v1.6.0
@@ -147,7 +147,7 @@ public struct PidLock
         fl.l_start = 0;
         fl.l_len = 0;
 
-        if (fcntl((&this).lock_fd, F_SETLK, &fl) == -1)
+        if (fcntl(this.lock_fd, F_SETLK, &fl) == -1)
         {
             // Region already locked, can't acquire a lock
             if (errno == EAGAIN || errno == EACCES)
@@ -161,14 +161,14 @@ public struct PidLock
         }
 
         // Clear the any previous contents of the file
-        (&this).enforcePosix!(ftruncate)((&this).lock_fd, 0);
+        this.enforcePosix!(ftruncate)(this.lock_fd, 0);
 
         char[512] buf;
         auto pid_string = snformat(buf, "{}\n", getpid());
 
-        (&this).writeNonInterrupted((&this).lock_fd, pid_string);
+        this.writeNonInterrupted(this.lock_fd, pid_string);
 
-        (&this).is_locked = true;
+        this.is_locked = true;
         return true;
     }
 

--- a/src/ocean/core/BitArray.d
+++ b/src/ocean/core/BitArray.d
@@ -490,10 +490,10 @@ struct BitArray
      */
     int opCmp( BitArray rhs )
     {
-        auto len = (&this).length;
+        auto len = this.length;
         if( rhs.length < len )
             len = rhs.length;
-        uint* p1 = (&this).ptr;
+        uint* p1 = this.ptr;
         uint* p2 = rhs.ptr;
         size_t n = len / 32;
         size_t i;
@@ -510,7 +510,7 @@ struct BitArray
             uint v2=p2[i] & mask;
             if (v1 != v2) return ((v1<v2)?-1:1);
         }
-        return (((&this).length<rhs.length)?-1:(((&this).length==rhs.length)?0:1));
+        return ((this.length<rhs.length)?-1:((this.length==rhs.length)?0:1));
     }
 
     unittest
@@ -582,13 +582,13 @@ struct BitArray
      */
     BitArray opCom()
     {
-        auto dim = (&this).dim();
+        auto dim = this.dim();
 
         BitArray result;
 
         result.length = len;
         for( size_t i = 0; i < dim; ++i )
-            result.ptr[i] = ~(&this).ptr[i];
+            result.ptr[i] = ~this.ptr[i];
         if( len & 31 )
             result.ptr[dim - 1] &= ~(~0 << (len & 31));
         return result;
@@ -625,13 +625,13 @@ struct BitArray
     {
         verify(len == rhs.length);
 
-        auto dim = (&this).dim();
+        auto dim = this.dim();
 
         BitArray result;
 
         result.length = len;
         for( size_t i = 0; i < dim; ++i )
-            result.ptr[i] = (&this).ptr[i] & rhs.ptr[i];
+            result.ptr[i] = this.ptr[i] & rhs.ptr[i];
         return result;
     }
 
@@ -668,13 +668,13 @@ struct BitArray
     {
         verify(len == rhs.length);
 
-        auto dim = (&this).dim();
+        auto dim = this.dim();
 
         BitArray result;
 
         result.length = len;
         for( size_t i = 0; i < dim; ++i )
-            result.ptr[i] = (&this).ptr[i] | rhs.ptr[i];
+            result.ptr[i] = this.ptr[i] | rhs.ptr[i];
         return result;
     }
 
@@ -711,13 +711,13 @@ struct BitArray
     {
         verify(len == rhs.length);
 
-        auto dim = (&this).dim();
+        auto dim = this.dim();
 
         BitArray result;
 
         result.length = len;
         for( size_t i = 0; i < dim; ++i )
-            result.ptr[i] = (&this).ptr[i] ^ rhs.ptr[i];
+            result.ptr[i] = this.ptr[i] ^ rhs.ptr[i];
         return result;
     }
 
@@ -753,13 +753,13 @@ struct BitArray
     {
         verify(len == rhs.length);
 
-        auto dim = (&this).dim();
+        auto dim = this.dim();
 
         BitArray result;
 
         result.length = len;
         for( size_t i = 0; i < dim; ++i )
-            result.ptr[i] = (&this).ptr[i] & ~rhs.ptr[i];
+            result.ptr[i] = this.ptr[i] & ~rhs.ptr[i];
         return result;
     }
 
@@ -792,7 +792,7 @@ struct BitArray
     {
         BitArray result;
 
-        result = (&this).dup;
+        result = this.dup;
         result.length = len + 1;
         result[len] = rhs;
         return result;
@@ -817,7 +817,7 @@ struct BitArray
     {
         BitArray result;
 
-        result = (&this).dup();
+        result = this.dup();
         result ~= rhs;
         return result;
     }
@@ -891,7 +891,7 @@ struct BitArray
     {
         verify(len == rhs.length);
 
-        auto dim = (&this).dim();
+        auto dim = this.dim();
 
         for( size_t i = 0; i < dim; ++i )
             ptr[i] &= rhs.ptr[i];
@@ -928,7 +928,7 @@ struct BitArray
     {
         verify(len == rhs.length);
 
-        auto dim = (&this).dim();
+        auto dim = this.dim();
 
         for( size_t i = 0; i < dim; ++i )
             ptr[i] |= rhs.ptr[i];
@@ -966,7 +966,7 @@ struct BitArray
     {
         verify(len == rhs.length);
 
-        auto dim = (&this).dim();
+        auto dim = this.dim();
 
         for( size_t i = 0; i < dim; ++i )
             ptr[i] ^= rhs.ptr[i];
@@ -1004,7 +1004,7 @@ struct BitArray
     {
         verify(len == rhs.length);
 
-        auto dim = (&this).dim();
+        auto dim = this.dim();
 
         for( size_t i = 0; i < dim; ++i )
             ptr[i] &= ~rhs.ptr[i];

--- a/src/ocean/core/Buffer.d
+++ b/src/ocean/core/Buffer.d
@@ -98,7 +98,7 @@ struct Buffer ( T )
 
     void reset ( )
     {
-        (&this).length = 0;
+        this.length = 0;
     }
 
     /***************************************************************************
@@ -110,7 +110,7 @@ struct Buffer ( T )
 
     size_t length ( ) const
     {
-        return (&this).data.length;
+        return this.data.length;
     }
 
     /***************************************************************************
@@ -163,7 +163,7 @@ struct Buffer ( T )
 
     Inout!(T[]) opSlice ( size_t begin, size_t end ) inout
     {
-        return (&this).data[begin .. end];
+        return this.data[begin .. end];
     }
 
     /***************************************************************************
@@ -177,7 +177,7 @@ struct Buffer ( T )
 
     Inout!(T[]) opSlice ( ) inout
     {
-        return (&this).data[];
+        return this.data[];
     }
 }
 

--- a/src/ocean/core/Optional.d
+++ b/src/ocean/core/Optional.d
@@ -46,8 +46,8 @@ struct Optional ( T )
 
     public void opAssign ( T rhs )
     {
-        (&this).defined = true;
-        (&this).value = rhs;
+        this.defined = true;
+        this.value = rhs;
     }
 
     /**************************************************************************
@@ -58,7 +58,7 @@ struct Optional ( T )
 
     public void reset()
     {
-        (&this).tupleof[] = Optional.undefined.tupleof[];
+        this.tupleof[] = Optional.undefined.tupleof[];
     }
 
     /**************************************************************************
@@ -87,8 +87,8 @@ struct Optional ( T )
     public void visit ( scope void delegate() cb_undefined,
         scope void delegate(ref T) cb_defined )
     {
-        if ((&this).defined)
-            cb_defined((&this).value);
+        if (this.defined)
+            cb_defined(this.value);
         else
             cb_undefined();
     }
@@ -111,9 +111,9 @@ struct Optional ( T )
 
     public bool get ( ref T value )
     {
-        if ((&this).defined)
-            value = (&this).value;
-        return (&this).defined;
+        if (this.defined)
+            value = this.value;
+        return this.defined;
     }
 
     /**************************************************************************
@@ -125,7 +125,7 @@ struct Optional ( T )
 
     public bool isDefined ( )
     {
-        return (&this).defined;
+        return this.defined;
     }
 }
 

--- a/src/ocean/core/SmartEnum.d
+++ b/src/ocean/core/SmartEnum.d
@@ -885,13 +885,13 @@ public struct TwoWayMap ( A )
 
     invariant ( )
     {
-        assert((&this).a_to_b.length == (&this).b_to_a.length);
+        assert(this.a_to_b.length == this.b_to_a.length);
 
         debug ( TwoWayMapFullConsistencyCheck )
         {
-            foreach ( a, b; (&this).a_to_b )
+            foreach ( a, b; this.a_to_b )
             {
-                assert((&this).a_to_index[a] == (&this).b_to_index[b]);
+                assert(this.a_to_index[a] == this.b_to_index[b]);
             }
         }
     }
@@ -908,38 +908,38 @@ public struct TwoWayMap ( A )
 
     public void opAssign ( ValueType[KeyType] assoc_array )
     {
-        (&this).keys_list.length = 0;
-        (&this).values_list.length = 0;
+        this.keys_list.length = 0;
+        this.values_list.length = 0;
 
-        (&this).a_to_b = assoc_array;
+        this.a_to_b = assoc_array;
 
-        foreach ( a, b; (&this).a_to_b )
+        foreach ( a, b; this.a_to_b )
         {
-            (&this).b_to_a[b] = a;
+            this.b_to_a[b] = a;
 
-            (&this).keys_list ~= *(b in (&this).b_to_a);
-            (&this).values_list ~= *(a in (&this).a_to_b);
+            this.keys_list ~= *(b in this.b_to_a);
+            this.values_list ~= *(a in this.a_to_b);
         }
 
-        (&this).updateIndices();
+        this.updateIndices();
     }
 
     public void opAssign ( KeyType[ValueType] assoc_array )
     {
-        (&this).keys_list.length = 0;
-        (&this).values_list.length = 0;
+        this.keys_list.length = 0;
+        this.values_list.length = 0;
 
-        (&this).b_to_a = assoc_array;
+        this.b_to_a = assoc_array;
 
-        foreach ( b, a; (&this).b_to_a )
+        foreach ( b, a; this.b_to_a )
         {
-            (&this).a_to_b[a] = b;
+            this.a_to_b[a] = b;
 
-            (&this).keys_list ~= *(b in (&this).b_to_a);
-            (&this).values_list ~= *(a in (&this).a_to_b);
+            this.keys_list ~= *(b in this.b_to_a);
+            this.values_list ~= *(a in this.a_to_b);
         }
 
-        (&this).updateIndices();
+        this.updateIndices();
     }
 
 
@@ -956,45 +956,45 @@ public struct TwoWayMap ( A )
     public void opIndexAssign ( KeyType a, ValueType b )
     out
     {
-        assert((&this).a_to_index[a] < (&this).keys_list.length);
-        assert((&this).b_to_index[b] < (&this).values_list.length);
+        assert(this.a_to_index[a] < this.keys_list.length);
+        assert(this.b_to_index[b] < this.values_list.length);
     }
     body
     {
-        auto already_exists = !!(a in (&this).a_to_b);
+        auto already_exists = !!(a in this.a_to_b);
 
-        (&this).a_to_b[a] = b;
-        (&this).b_to_a[b] = a;
+        this.a_to_b[a] = b;
+        this.b_to_a[b] = a;
 
         if ( !already_exists )
         {
-            (&this).keys_list ~= *(b in (&this).b_to_a);
-            (&this).values_list ~= *(a in (&this).a_to_b);
+            this.keys_list ~= *(b in this.b_to_a);
+            this.values_list ~= *(a in this.a_to_b);
         }
 
-        (&this).updateIndices();
+        this.updateIndices();
     }
 
     public void opIndexAssign ( ValueType b, KeyType a )
     out
     {
-        assert((&this).a_to_index[a] < (&this).keys_list.length);
-        assert((&this).b_to_index[b] < (&this).values_list.length);
+        assert(this.a_to_index[a] < this.keys_list.length);
+        assert(this.b_to_index[b] < this.values_list.length);
     }
     body
     {
-        auto already_exists = !!(a in (&this).a_to_b);
+        auto already_exists = !!(a in this.a_to_b);
 
-        (&this).a_to_b[a] = b;
-        (&this).b_to_a[b] = a;
+        this.a_to_b[a] = b;
+        this.b_to_a[b] = a;
 
         if ( !already_exists )
         {
-            (&this).keys_list ~= *(b in (&this).b_to_a);
-            (&this).values_list ~= *(a in (&this).a_to_b);
+            this.keys_list ~= *(b in this.b_to_a);
+            this.values_list ~= *(a in this.a_to_b);
         }
 
-        (&this).updateIndices();
+        this.updateIndices();
     }
 
 
@@ -1006,10 +1006,10 @@ public struct TwoWayMap ( A )
 
     public void rehash ( )
     {
-        (&this).a_to_b.rehash;
-        (&this).b_to_a.rehash;
+        this.a_to_b.rehash;
+        this.b_to_a.rehash;
 
-        (&this).updateIndices();
+        this.updateIndices();
     }
 
 
@@ -1029,7 +1029,7 @@ public struct TwoWayMap ( A )
 
     public KeyType* opIn_r ( cstring b )
     {
-        return b in (&this).b_to_a;
+        return b in this.b_to_a;
     }
 
 
@@ -1049,7 +1049,7 @@ public struct TwoWayMap ( A )
 
     public ValueType* opIn_r ( KeyType a )
     {
-        return a in (&this).a_to_b;
+        return a in this.a_to_b;
     }
 
 
@@ -1071,7 +1071,7 @@ public struct TwoWayMap ( A )
 
     public KeyType opIndex ( cstring b )
     {
-        return (&this).b_to_a[b];
+        return this.b_to_a[b];
     }
 
 
@@ -1093,7 +1093,7 @@ public struct TwoWayMap ( A )
 
     public ValueType opIndex ( KeyType a )
     {
-        return (&this).a_to_b[a];
+        return this.a_to_b[a];
     }
 
 
@@ -1106,7 +1106,7 @@ public struct TwoWayMap ( A )
 
     public size_t length ( )
     {
-        return (&this).a_to_b.length;
+        return this.a_to_b.length;
     }
 
 
@@ -1119,7 +1119,7 @@ public struct TwoWayMap ( A )
 
     public KeyType[] keys ( )
     {
-        return (&this).keys_list;
+        return this.keys_list;
     }
 
 
@@ -1132,7 +1132,7 @@ public struct TwoWayMap ( A )
 
     public ValueType[] values ( )
     {
-        return (&this).values_list;
+        return this.values_list;
     }
 
 
@@ -1148,7 +1148,7 @@ public struct TwoWayMap ( A )
     public int opApply ( scope int delegate ( ref KeyType a, ref ValueType b ) dg )
     {
         int res;
-        foreach ( a, b; (&this).a_to_b )
+        foreach ( a, b; this.a_to_b )
         {
             res = dg(a, b);
         }
@@ -1168,9 +1168,9 @@ public struct TwoWayMap ( A )
     public int opApply ( scope int delegate ( ref size_t index, ref KeyType a, ref ValueType b ) dg )
     {
         int res;
-        foreach ( a, b; (&this).a_to_b )
+        foreach ( a, b; this.a_to_b )
         {
-            auto index = (&this).indexOf(a);
+            auto index = this.indexOf(a);
             verify(index !is null);
 
             res = dg(*index, a, b);
@@ -1196,7 +1196,7 @@ public struct TwoWayMap ( A )
     public size_t* indexOf ( KeyType a )
     {
         auto index = a in this.a_to_index;
-        enforce(index, typeof((&this)).stringof ~ ".indexOf - element not present in map");
+        enforce(index, typeof(this).stringof ~ ".indexOf - element not present in map");
         return index;
     }
 
@@ -1218,7 +1218,7 @@ public struct TwoWayMap ( A )
     public size_t* indexOf ( cstring b )
     {
         auto index = b in this.b_to_index;
-        enforce(index, typeof((&this)).stringof ~ ".indexOf - element not present in map");
+        enforce(index, typeof(this).stringof ~ ".indexOf - element not present in map");
         return index;
     }
 
@@ -1231,10 +1231,10 @@ public struct TwoWayMap ( A )
 
     private void updateIndices ( )
     {
-        foreach ( a, b; (&this).a_to_b )
+        foreach ( a, b; this.a_to_b )
         {
-            (&this).a_to_index[a] = (&this).keys_list.find(a);
-            (&this).b_to_index[b] = (&this).values_list.find(b);
+            this.a_to_index[a] = this.keys_list.find(a);
+            this.b_to_index[b] = this.values_list.find(b);
         }
     }
 }

--- a/src/ocean/core/SmartUnion.d
+++ b/src/ocean/core/SmartUnion.d
@@ -71,7 +71,7 @@ struct SmartUnion ( U )
 
      **************************************************************************/
 
-    Active active ( ) { return (&this)._.active; }
+    Active active ( ) { return this._.active; }
 
     /***************************************************************************
 
@@ -83,7 +83,7 @@ struct SmartUnion ( U )
 
     public istring active_name ( )
     {
-        return (&this)._.active_names[(&this)._.active];
+        return this._.active_names[this._.active];
     }
 
     /**************************************************************************

--- a/src/ocean/core/TypeConvert.d
+++ b/src/ocean/core/TypeConvert.d
@@ -342,7 +342,7 @@ ReturnTypeOf!(F) delegate() toContextDg ( alias F ) ( void* context )
     {
         ReturnTypeOf!(F) method ( )
         {
-            void* context = cast(void*) (&this);
+            void* context = cast(void*) &this;
 
             // do real work via provided F function:
             return F(context);

--- a/src/ocean/io/compress/lzo/LzoHeader.d
+++ b/src/ocean/io/compress/lzo/LzoHeader.d
@@ -165,14 +165,14 @@ align (1) struct LzoHeader ( bool LengthInline = true )
             static assert ((this).sizeof == SizeofTuple!(typeof (this.tupleof)),
                            this.ErrMsgSource ~ ": Bad data alignment");
 
-            enforce!(CompressException)(chunk.length >= (&this).read_length,
-                                         (&this).ErrMsgSource ~ ": Chunk too short to write header");
+            enforce!(CompressException)(chunk.length >= this.read_length,
+                                         this.ErrMsgSource ~ ": Chunk too short to write header");
 
-            (&this).chunk_length = chunk.length - (&this).chunk_length.sizeof;
+            this.chunk_length = chunk.length - this.chunk_length.sizeof;
 
-            (&this).crc32_ = (&this).crc32((&this).strip(chunk));
+            this.crc32_ = this.crc32(this.strip(chunk));
 
-            *(cast (typeof ((&this))) chunk.ptr) = this;
+            *(cast(typeof(&this)) chunk.ptr) = this;
 
             return chunk;
         }
@@ -193,17 +193,17 @@ align (1) struct LzoHeader ( bool LengthInline = true )
 
          **************************************************************************/
 
-        typeof ((&this)) uncompressed ( void[] payload )
+        typeof(&this) uncompressed ( void[] payload )
         {
-            (&this).type = (&this).type.None;
+            this.type = this.type.None;
 
-            (&this).uncompressed_length = payload.length;
+            this.uncompressed_length = payload.length;
 
-            (&this).chunk_length += payload.length;
+            this.chunk_length += payload.length;
 
-            (&this).crc32_ = (&this).crc32(payload);
+            this.crc32_ = this.crc32(payload);
 
-            return (&this);
+            return &this;
         }
 
         /**************************************************************************
@@ -220,17 +220,17 @@ align (1) struct LzoHeader ( bool LengthInline = true )
 
          **************************************************************************/
 
-        typeof ((&this)) start ( size_t total_uncompressed_length )
+        typeof(&this) start ( size_t total_uncompressed_length )
         {
-            *(&this) = typeof (this).init;
+            this = typeof (this).init;
 
-            (&this).type = (&this).type.Start;
+            this.type = this.type.Start;
 
-            (&this).uncompressed_length = total_uncompressed_length;
+            this.uncompressed_length = total_uncompressed_length;
 
-            (&this).crc32_ = (&this).crc32();
+            this.crc32_ = this.crc32();
 
-            return (&this);
+            return &this;
         }
 
         /**************************************************************************
@@ -243,15 +243,15 @@ align (1) struct LzoHeader ( bool LengthInline = true )
 
          **************************************************************************/
 
-        typeof ((&this)) stop ( )
+        typeof(&this) stop ( )
         {
-            *(&this) = typeof (this).init;
+            this = typeof (this).init;
 
-            (&this).type = (&this).type.Stop;
+            this.type = this.type.Stop;
 
-            (&this).crc32_ = (&this).crc32();
+            this.crc32_ = this.crc32();
 
-            return (&this);
+            return &this;
         }
 
         /**************************************************************************
@@ -272,14 +272,14 @@ align (1) struct LzoHeader ( bool LengthInline = true )
 
          **************************************************************************/
 
-        typeof ((&this)) readStart ( void[] chunk )
+        typeof(&this) readStart ( void[] chunk )
         {
-            (&this).read(chunk);
+            this.read(chunk);
 
-            enforce!(CompressException)((&this).type == Type.Start || (&this).type == Type.Stop,
-                                         (&this).ErrMsgSource ~ ": Not a Start header as expected");
+            enforce!(CompressException)(this.type == Type.Start || this.type == Type.Stop,
+                                         this.ErrMsgSource ~ ": Not a Start header as expected");
 
-            return (&this);
+            return &this;
         }
 
         /**************************************************************************
@@ -297,18 +297,18 @@ align (1) struct LzoHeader ( bool LengthInline = true )
 
         bool tryRead ( void[] chunk )
         {
-            if ( chunk.length >= (&this).read_length )
+            if ( chunk.length >= this.read_length )
             {
-                if ((&this).isNullChunk(chunk))
+                if (this.isNullChunk(chunk))
                 {
-                    (&this).stop();
+                    this.stop();
                     return true;
                 }
                 else
                 {
-                    (&this).setHeader(chunk);
-                    auto payload = (&this).strip(chunk);
-                    return (&this).crc32_ == (&this).crc32(payload);
+                    this.setHeader(chunk);
+                    auto payload = this.strip(chunk);
+                    return this.crc32_ == this.crc32(payload);
                 }
             }
 
@@ -362,7 +362,7 @@ align (1) struct LzoHeader ( bool LengthInline = true )
 
         void[] data ( )
         {
-            return (cast (void*) (&this))[0 .. this.read_length];
+            return (cast(void*) &this)[0 .. this.read_length];
         }
 
         /**************************************************************************
@@ -377,7 +377,7 @@ align (1) struct LzoHeader ( bool LengthInline = true )
 
         void[] data_without_length ( )
         {
-            return (cast (void*) (&this))[size_t.sizeof .. this.read_length];
+            return (cast(void*) &this)[size_t.sizeof .. this.read_length];
         }
 
         /**************************************************************************
@@ -400,21 +400,21 @@ align (1) struct LzoHeader ( bool LengthInline = true )
         {
             void[] payload = null;
 
-            if ((&this).isNullChunk(chunk))
+            if (this.isNullChunk(chunk))
             {
-                (&this).stop();
+                this.stop();
             }
             else
             {
-                (&this).setHeader(chunk);
+                this.setHeader(chunk);
 
-                payload = (&this).strip(chunk);
+                payload = this.strip(chunk);
 
-                enforce!(CompressException)((&this).lengthValid(chunk),
-                                         (&this).ErrMsgSource ~ ": Chunk length mismatch");
+                enforce!(CompressException)(this.lengthValid(chunk),
+                                         this.ErrMsgSource ~ ": Chunk length mismatch");
 
-                enforce!(CompressException)((&this).crc32_ == (&this).crc32(payload),
-                                             (&this).ErrMsgSource ~ ": Chunk data corrupted (CRC32 mismatch)");
+                enforce!(CompressException)(this.crc32_ == this.crc32(payload),
+                                             this.ErrMsgSource ~ ": Chunk data corrupted (CRC32 mismatch)");
             }
 
             return payload;
@@ -436,11 +436,11 @@ align (1) struct LzoHeader ( bool LengthInline = true )
         {
             static if ( LengthInline )
             {
-                return chunk.length == (&this).chunk_length + (&this).chunk_length.sizeof;
+                return chunk.length == this.chunk_length + this.chunk_length.sizeof;
             }
             else
             {
-                return chunk.length == (&this).chunk_length;
+                return chunk.length == this.chunk_length;
             }
         }
 
@@ -456,25 +456,25 @@ align (1) struct LzoHeader ( bool LengthInline = true )
 
          **************************************************************************/
 
-        typeof((&this)) setHeader ( void[] chunk )
+        typeof(&this) setHeader ( void[] chunk )
         {
             static if ( LengthInline )
             {
-                *(&this) = *cast (typeof ((&this))) chunk.ptr;
+                this = *cast(typeof(&this)) chunk.ptr;
             }
             else
             {
-                (&this).chunk_length = chunk.length;
+                this.chunk_length = chunk.length;
 
                 void* read_ptr = chunk.ptr;
-                (&this).crc32_ = *(cast(typeof((&this).crc32_)*) read_ptr);
-                read_ptr += (&this).crc32_.sizeof;
-                (&this).type = *(cast(typeof((&this).type)*) read_ptr);
-                read_ptr += (&this).type.sizeof;
-                (&this).uncompressed_length = *(cast(typeof((&this).uncompressed_length)*) read_ptr);
+                this.crc32_ = *(cast(typeof(this.crc32_)*) read_ptr);
+                read_ptr += this.crc32_.sizeof;
+                this.type = *(cast(typeof(this.type)*) read_ptr);
+                read_ptr += this.type.sizeof;
+                this.uncompressed_length = *(cast(typeof(this.uncompressed_length)*) read_ptr);
             }
 
-            return (&this);
+            return &this;
         }
 
         /**************************************************************************
@@ -485,7 +485,7 @@ align (1) struct LzoHeader ( bool LengthInline = true )
 
         uint crc32 ( void[] payload = null )
         {
-            uint crc32 = LzoCrc.crc32((cast (void*) (&this))[this.crc32_.offsetof + this.crc32_.sizeof .. this.length]);
+            uint crc32 = LzoCrc.crc32((cast (void*) &this)[this.crc32_.offsetof + this.crc32_.sizeof .. this.length]);
 
             if (payload)
             {
@@ -521,28 +521,28 @@ align (1) struct LzoHeader ( bool LengthInline = true )
         {
             bool validated = false;
 
-            if (allow_null && (&this).isNullChunk(chunk))
+            if (allow_null && this.isNullChunk(chunk))
             {
-                (&this).stop();
+                this.stop();
 
                 validated = true;
             }
-            else if (chunk.length == (&this).read_length)
+            else if (chunk.length == this.read_length)
             {
-                (&this).setHeader(chunk);
+                this.setHeader(chunk);
 
-                if ((&this).type == check_type)
+                if (this.type == check_type)
                 {
                     static if ( LengthInline )
                     {
-                        if (chunk.length == (&this).chunk_length + (&this).chunk_length.sizeof)
+                        if (chunk.length == this.chunk_length + this.chunk_length.sizeof)
                         {
-                            validated = (&this).crc32_ == (&this).crc32;
+                            validated = this.crc32_ == this.crc32;
                         }
                     }
                     else
                     {
-                        validated = (&this).crc32_ == (&this).crc32;
+                        validated = this.crc32_ == this.crc32;
                     }
                 }
             }

--- a/src/ocean/io/console/Tables.d
+++ b/src/ocean/io/console/Tables.d
@@ -408,12 +408,12 @@ public class Table
 
             *******************************************************************/
 
-            public typeof((&this)) setString ( cstring str )
+            public typeof(&this) setString ( cstring str )
             {
-                (&this).type = Type.String;
-                (&this).contents.utf8.copy(str);
+                this.type = Type.String;
+                this.contents.utf8.copy(str);
 
-                return (&this);
+                return &this;
             }
 
 
@@ -431,14 +431,14 @@ public class Table
 
             *******************************************************************/
 
-            public typeof((&this)) setInteger ( ulong num,
+            public typeof(&this) setInteger ( ulong num,
                 bool use_thousands_separator = true )
             {
-                (&this).type = Type.Integer;
-                (&this).use_thousands_separator = use_thousands_separator;
-                (&this).contents.integer = num;
+                this.type = Type.Integer;
+                this.use_thousands_separator = use_thousands_separator;
+                this.contents.integer = num;
 
-                return (&this);
+                return &this;
             }
 
 
@@ -457,13 +457,13 @@ public class Table
 
             *******************************************************************/
 
-            public typeof((&this)) setBinaryMetric ( ulong num, cstring metric_string = "" )
+            public typeof(&this) setBinaryMetric ( ulong num, cstring metric_string = "" )
             {
-                (&this).type = Type.BinaryMetric;
-                (&this).contents.integer = num;
-                (&this).metric_string.copy(metric_string);
+                this.type = Type.BinaryMetric;
+                this.contents.integer = num;
+                this.metric_string.copy(metric_string);
 
-                return (&this);
+                return &this;
             }
 
 
@@ -482,13 +482,13 @@ public class Table
 
             *******************************************************************/
 
-            public typeof((&this)) setDecimalMetric ( ulong num, cstring metric_string = "" )
+            public typeof(&this) setDecimalMetric ( ulong num, cstring metric_string = "" )
             {
-                (&this).type = Type.DecimalMetric;
-                (&this).contents.integer = num;
-                (&this).metric_string.copy(metric_string);
+                this.type = Type.DecimalMetric;
+                this.contents.integer = num;
+                this.metric_string.copy(metric_string);
 
-                return (&this);
+                return &this;
             }
 
 
@@ -504,12 +504,12 @@ public class Table
 
             *******************************************************************/
 
-            public typeof((&this)) setFloat ( double num )
+            public typeof(&this) setFloat ( double num )
             {
-                (&this).type = Type.Float;
-                (&this).contents.floating = num;
+                this.type = Type.Float;
+                this.contents.floating = num;
 
-                return (&this);
+                return &this;
             }
 
 
@@ -522,11 +522,11 @@ public class Table
 
             *******************************************************************/
 
-            public typeof((&this)) setEmpty ( )
+            public typeof(&this) setEmpty ( )
             {
-                (&this).type = Type.Empty;
+                this.type = Type.Empty;
 
-                return (&this);
+                return &this;
             }
 
 
@@ -539,11 +539,11 @@ public class Table
 
             *******************************************************************/
 
-            public typeof((&this)) setDivider ( )
+            public typeof(&this) setDivider ( )
             {
-                (&this).type = Type.Divider;
+                this.type = Type.Divider;
 
-                return (&this);
+                return &this;
             }
 
 
@@ -556,11 +556,11 @@ public class Table
 
             *******************************************************************/
 
-            public typeof((&this)) setMerged ( )
+            public typeof(&this) setMerged ( )
             {
-                (&this).type = Type.Merged;
+                this.type = Type.Merged;
 
-                return (&this);
+                return &this;
             }
 
 
@@ -576,12 +576,12 @@ public class Table
 
             *******************************************************************/
 
-            public typeof((&this)) setForegroundColour ( Terminal.Colour colour )
+            public typeof(&this) setForegroundColour ( Terminal.Colour colour )
             {
                 auto colour_str = Terminal.fg_colour_codes[colour];
-                (&this).fg_colour_string.concat(Terminal.CSI, colour_str);
+                this.fg_colour_string.concat(Terminal.CSI, colour_str);
 
-                return (&this);
+                return &this;
             }
 
 
@@ -597,12 +597,12 @@ public class Table
 
             *******************************************************************/
 
-            public typeof((&this)) setBackgroundColour ( Terminal.Colour colour )
+            public typeof(&this) setBackgroundColour ( Terminal.Colour colour )
             {
                 auto colour_str = Terminal.bg_colour_codes[colour];
-                (&this).bg_colour_string.concat(Terminal.CSI, colour_str);
+                this.bg_colour_string.concat(Terminal.CSI, colour_str);
 
-                return (&this);
+                return &this;
             }
 
 
@@ -615,7 +615,7 @@ public class Table
 
             public size_t width ( )
             {
-                switch ( (&this).type )
+                switch ( this.type )
                 {
                     case Cell.Type.Merged:
                     case Cell.Type.Empty:
@@ -623,20 +623,20 @@ public class Table
                         return 0;
                     case Cell.Type.BinaryMetric:
                         MetricPrefix metric;
-                        metric.bin((&this).contents.integer);
-                        return (&this).floatWidth(metric.scaled) + 3 +
-                            (&this).metric_string.length;
+                        metric.bin(this.contents.integer);
+                        return this.floatWidth(metric.scaled) + 3 +
+                            this.metric_string.length;
                     case Cell.Type.DecimalMetric:
                         MetricPrefix metric;
-                        metric.dec((&this).contents.integer);
-                        return (&this).floatWidth(metric.scaled) + 2 +
-                            (&this).metric_string.length;
+                        metric.dec(this.contents.integer);
+                        return this.floatWidth(metric.scaled) + 2 +
+                            this.metric_string.length;
                     case Cell.Type.Integer:
-                        return (&this).integerWidth((&this).contents.integer);
+                        return this.integerWidth(this.contents.integer);
                     case Cell.Type.Float:
-                        return (&this).floatWidth((&this).contents.floating);
+                        return this.floatWidth(this.contents.floating);
                     case Cell.Type.String:
-                        return utf8Length((&this).contents.utf8);
+                        return utf8Length(this.contents.utf8);
 
                     default:
                         assert(0);
@@ -667,13 +667,13 @@ public class Table
                     Terminal.CSI ~ Terminal.bg_colour_codes[Terminal.Colour.Default];
 
                 // set the colour of this cell
-                if ( (&this).fg_colour_string.length > 0 ||
-                     (&this).bg_colour_string.length > 0 )
+                if ( this.fg_colour_string.length > 0 ||
+                     this.bg_colour_string.length > 0 )
                 {
-                    output.format("{}{}", (&this).fg_colour_string, (&this).bg_colour_string);
+                    output.format("{}{}", this.fg_colour_string, this.bg_colour_string);
                 }
 
-                if ( (&this).type == Type.Divider )
+                if ( this.type == Type.Divider )
                 {
                     content_buf.length = width + inter_cell_spacing;
                     enableStomping(content_buf);
@@ -682,15 +682,15 @@ public class Table
                     output.format("{}", content_buf);
 
                     // reset colour to default
-                    if ( (&this).fg_colour_string.length > 0 ||
-                         (&this).bg_colour_string.length > 0 )
+                    if ( this.fg_colour_string.length > 0 ||
+                         this.bg_colour_string.length > 0 )
                     {
                         output.format("{}", default_colours);
                     }
                 }
                 else
                 {
-                    switch ( (&this).type )
+                    switch ( this.type )
                     {
                         case Type.Empty:
                             content_buf.length = 0;
@@ -701,19 +701,19 @@ public class Table
                             enableStomping(content_buf);
 
                             MetricPrefix metric;
-                            metric.bin((&this).contents.integer);
+                            metric.bin(this.contents.integer);
 
                             if ( metric.prefix == ' ' )
                             {
                                 sformat(content_buf,
                                     "{}      {}", cast(uint)metric.scaled,
-                                    (&this).metric_string);
+                                    this.metric_string);
                             }
                             else
                             {
                                 sformat(content_buf,
                                     "{} {}i{}", metric.scaled, metric.prefix,
-                                    (&this).metric_string);
+                                    this.metric_string);
                             }
                             break;
                         case Type.DecimalMetric:
@@ -721,42 +721,42 @@ public class Table
                             enableStomping(content_buf);
 
                             MetricPrefix metric;
-                            metric.dec((&this).contents.integer);
+                            metric.dec(this.contents.integer);
 
                             if ( metric.prefix == ' ' )
                             {
                                 sformat(content_buf,
                                     "{}     {}", cast(uint)metric.scaled,
-                                    (&this).metric_string);
+                                    this.metric_string);
                             }
                             else
                             {
                                 sformat(content_buf,
                                     "{} {}{}", metric.scaled, metric.prefix,
-                                    (&this).metric_string);
+                                    this.metric_string);
                             }
                             break;
                         case Type.Integer:
-                            if ( (&this).use_thousands_separator )
+                            if ( this.use_thousands_separator )
                             {
-                                DigitGrouping.format((&this).contents.integer, content_buf);
+                                DigitGrouping.format(this.contents.integer, content_buf);
                             }
                             else
                             {
                                 content_buf.length = 0;
                                 enableStomping(content_buf);
                                 sformat(content_buf,
-                                    "{}", (&this).contents.integer);
+                                    "{}", this.contents.integer);
                             }
                             break;
                         case Type.Float:
                             content_buf.length = 0;
                             enableStomping(content_buf);
                             sformat(content_buf,
-                                    "{}", (&this).contents.floating);
+                                    "{}", this.contents.floating);
                             break;
                         case Type.String:
-                            content_buf = (&this).contents.utf8;
+                            content_buf = this.contents.utf8;
                             break;
                         default:
                             return;
@@ -792,7 +792,7 @@ public class Table
 
             private size_t integerWidth ( ulong i )
             {
-                if ( (&this).use_thousands_separator )
+                if ( this.use_thousands_separator )
                 {
                     return DigitGrouping.length(i);
                 }

--- a/src/ocean/io/digest/Fnv1.d
+++ b/src/ocean/io/digest/Fnv1.d
@@ -353,7 +353,7 @@ public class Fnv1Generic ( bool FNV1A = false, T = hash_t ) : FnvDigest
 
          public ubyte[] opCall ( DigestType value )
          {
-             (&this).value = value;
+             this.value = value;
 
              version (LittleEndian) toBigEnd(array);
 
@@ -832,4 +832,3 @@ unittest
 
     test (chash == mhash, "Combined hash failed");
 }
-

--- a/src/ocean/io/select/selector/EpollFdSanity.d
+++ b/src/ocean/io/select/selector/EpollFdSanity.d
@@ -119,7 +119,7 @@ public struct FdObjEpollData
 
     public bool verifyFd (int fd)
     {
-        return (&this).fd == (fd & 0xFF);
+        return this.fd == (fd & 0xFF);
     }
 }
 

--- a/src/ocean/io/serialize/StructSerializer.d
+++ b/src/ocean/io/serialize/StructSerializer.d
@@ -970,29 +970,29 @@ version (unittest)
 
         void push (T element)
         {
-            if ((&this).elements.length == (&this).write)
+            if (this.elements.length == this.write)
             {
-                if ((&this).elements.length < (&this).maxLength)
+                if (this.elements.length < this.maxLength)
                 {
-                    (&this).elements.length = (&this).elements.length + 1;
+                    this.elements.length = this.elements.length + 1;
                 }
                 else
                 {
-                    (&this).write = 0;
+                    this.write = 0;
                 }
             }
 
             static if (isArrayType!(T))
             {
-                (&this).elements[(&this).write].length = element.length;
-                (&this).elements[(&this).write][] = element[];
+                this.elements[this.write].length = element.length;
+                this.elements[this.write][] = element[];
             }
             else
             {
-                (&this).elements[(&this).write] = element;
+                this.elements[this.write] = element;
             }
 
-            ++(&this).write;
+            ++this.write;
         }
 
         /***********************************************************************
@@ -1008,14 +1008,14 @@ version (unittest)
 
         T* get (size_t offset=0)
         {
-            if (offset < (&this).elements.length)
+            if (offset < this.elements.length)
             {
-                if (cast(int)((&this).write - 1 - offset) < 0)
+                if (cast(int)(this.write - 1 - offset) < 0)
                 {
-                    return &elements[$ - offset + (&this).write - 1];
+                    return &elements[$ - offset + this.write - 1];
                 }
 
-                return &elements[(&this).write - 1 - offset];
+                return &elements[this.write - 1 - offset];
             }
 
             throw new Exception("Element does not exist");

--- a/src/ocean/math/BinaryHistogram.d
+++ b/src/ocean/math/BinaryHistogram.d
@@ -196,9 +196,9 @@ public struct BinaryHistogram ( uint MaxPow2, istring Suffix = "" )
 
     public ulong add ( ulong n )
     {
-        (&this).count++;
-        (&this).total += n;
-        (&this).bins[n? (n < (1UL << MaxPow2))? bsr(n) + 1 : $ - 1 : 0]++;
+        this.count++;
+        this.total += n;
+        this.bins[n? (n < (1UL << MaxPow2))? bsr(n) + 1 : $ - 1 : 0]++;
         return n;
     }
 
@@ -212,9 +212,9 @@ public struct BinaryHistogram ( uint MaxPow2, istring Suffix = "" )
 
     public double mean ( )
     {
-        verify((&this).count || !(&this).total);
+        verify(this.count || !this.total);
 
-        return (&this).total / cast(double)(&this).count;
+        return this.total / cast(double)this.count;
     }
 
     /***************************************************************************
@@ -248,7 +248,7 @@ public struct BinaryHistogram ( uint MaxPow2, istring Suffix = "" )
 
     public Bins stats ( )
     {
-        return Bins.fromArray((&this).bins);
+        return Bins.fromArray(this.bins);
     }
 }
 

--- a/src/ocean/math/IncrementalAverage.d
+++ b/src/ocean/math/IncrementalAverage.d
@@ -83,13 +83,13 @@ public struct IncrementalAverage
         if (count == 0)
             return;
 
-        (&this).count_ += count;
+        this.count_ += count;
 
-        auto delta = (value - (&this).average_) * count;
+        auto delta = (value - this.average_) * count;
 
-        (&this).average_ += delta / (&this).count_;
+        this.average_ += delta / this.count_;
 
-        (&this).mean_of_square += delta * (value - (&this).average_);
+        this.mean_of_square += delta * (value - this.average_);
     }
 
 
@@ -102,7 +102,7 @@ public struct IncrementalAverage
 
     public double average ()
     {
-        return (&this).average_;
+        return this.average_;
     }
 
 
@@ -115,7 +115,7 @@ public struct IncrementalAverage
 
     public ulong count ()
     {
-        return (&this).count_;
+        return this.count_;
     }
 
 
@@ -127,9 +127,9 @@ public struct IncrementalAverage
 
     public void clear ()
     {
-        (&this).average_ = 0;
-        (&this).count_ = 0;
-        (&this).mean_of_square = 0;
+        this.average_ = 0;
+        this.count_ = 0;
+        this.mean_of_square = 0;
     }
 
     /***************************************************************************
@@ -163,13 +163,13 @@ public struct IncrementalAverage
 
     public double variance (double correction_factor = 0)
     {
-        if ((&this).count_ < 2)
+        if (this.count_ < 2)
             return 0;
 
-        verify((&this).count_ > correction_factor, "Correction factor is same "
+        verify(this.count_ > correction_factor, "Correction factor is same "
                ~ "size or bigger than the number of elements added.");
 
-        return (&this).mean_of_square / ((&this).count_ - correction_factor);
+        return this.mean_of_square / (this.count_ - correction_factor);
     }
 
     /***************************************************************************
@@ -191,7 +191,7 @@ public struct IncrementalAverage
 
     public double stdDeviation (double correction_factor = 0)
     {
-        return sqrt((&this).variance(correction_factor));
+        return sqrt(this.variance(correction_factor));
     }
 }
 

--- a/src/ocean/math/IrregularMovingAverage.d
+++ b/src/ocean/math/IrregularMovingAverage.d
@@ -128,32 +128,32 @@ public struct IrregularMovingAverage (Time = time_t, Value = real)
 
     invariant ()
     {
-        assert(!isNaN((&this).beta_));
-        assert(!isInfinity((&this).beta_));
-        assert(0 < (&this).beta_);
-        assert((&this).beta_ < 1);
+        assert(!isNaN(this.beta_));
+        assert(!isInfinity(this.beta_));
+        assert(0 < this.beta_);
+        assert(this.beta_ < 1);
 
-        assert(!isNaN((&this).alpha));
-        assert(!isInfinity((&this).alpha));
-        assert(0 <= (&this).alpha);
-        assert((&this).alpha <= 1);
+        assert(!isNaN(this.alpha));
+        assert(!isInfinity(this.alpha));
+        assert(0 <= this.alpha);
+        assert(this.alpha <= 1);
 
-        assert(!isNaN((&this).w));
-        assert(!isInfinity((&this).w));
+        assert(!isNaN(this.w));
+        assert(!isInfinity(this.w));
 
-        assert(!isNaN((&this).z));
-        assert(!isInfinity((&this).z));
+        assert(!isNaN(this.z));
+        assert(!isInfinity(this.z));
 
-        assert(!isNaN((&this).s));
-        assert(!isInfinity((&this).s));
+        assert(!isNaN(this.s));
+        assert(!isInfinity(this.s));
 
-        assert(!isNaN((&this).s2));
-        assert(!isInfinity((&this).s2));
+        assert(!isNaN(this.s2));
+        assert(!isInfinity(this.s2));
 
         static if (isFloatingPointType!(Time))
         {
-            assert(!isNaN((&this).update_time_));
-            assert(!isInfinity((&this).update_time_));
+            assert(!isNaN(this.update_time_));
+            assert(!isInfinity(this.update_time_));
         }
     }
 
@@ -249,30 +249,30 @@ public struct IrregularMovingAverage (Time = time_t, Value = real)
             verify(!isInfinity(value_time));
         }
 
-        enforce(value_time > (&this).update_time,
+        enforce(value_time > this.update_time,
                 "Cannot incorporate data point from the past!");
 
         // values re-used multiple times updating parameters
-        Value time_diff = value_time - (&this).update_time;
-        Value beta_pow  = pow((&this).beta, time_diff);
+        Value time_diff = value_time - this.update_time;
+        Value beta_pow  = pow(this.beta, time_diff);
 
-        (&this).update_time_ = value_time;
+        this.update_time_ = value_time;
 
         // update w based using old alpha value
-        (&this).w = (&this).w /
-            (beta_pow + (time_diff * beta_pow * (&this).w / (&this).alpha));
+        this.w = this.w /
+            (beta_pow + (time_diff * beta_pow * this.w / this.alpha));
 
-        (&this).alpha = (&this).alpha / (beta_pow + (&this).alpha);
+        this.alpha = this.alpha / (beta_pow + this.alpha);
 
         // update z using new alpha and w values
-        (&this).z = (&this).z /
-            (beta_pow + ((&this).alpha * (&this).z / (&this).w));
+        this.z = this.z /
+            (beta_pow + (this.alpha * this.z / this.w));
 
         // update s using new alpha value
-        (&this).s  = ((&this).alpha * value)  + ((1.0 - (&this).alpha) * (&this).s);
+        this.s  = (this.alpha * value)  + ((1.0 - this.alpha) * this.s);
 
         // update s2 using new alpha and new s value
-        (&this).s2 = ((&this).alpha * (&this).s) + ((1.0 - (&this).alpha) * (&this).s2);
+        this.s2 = (this.alpha * this.s) + ((1.0 - this.alpha) * this.s2);
     }
 
 
@@ -285,7 +285,7 @@ public struct IrregularMovingAverage (Time = time_t, Value = real)
 
     public Value value ()
     {
-        return (&this).s2;
+        return this.s2;
     }
 
 
@@ -314,15 +314,15 @@ public struct IrregularMovingAverage (Time = time_t, Value = real)
     }
     body
     {
-        enforce(t >= (&this).update_time_,
+        enforce(t >= this.update_time_,
                 "Cannot calculate predicted value from the past!");
 
-        Time k = t - (&this).update_time;
+        Time k = t - this.update_time;
 
         assert(k >= 0);
 
-        Value estimate = (&this).s +
-            ( (((&this).z / (&this).w) + (((&this).z / (&this).alpha) * k)) * ((&this).s - (&this).s2) );
+        Value estimate = this.s +
+            ( ((this.z / this.w) + ((this.z / this.alpha) * k)) * (this.s - this.s2) );
 
         return estimate;
     }
@@ -338,7 +338,7 @@ public struct IrregularMovingAverage (Time = time_t, Value = real)
 
     public Time update_time ()
     {
-        return (&this).update_time_;
+        return this.update_time_;
     }
 
 
@@ -362,9 +362,9 @@ public struct IrregularMovingAverage (Time = time_t, Value = real)
             verify(!isInfinity(value_time));
         }
 
-        verify(t > (&this).update_time_);
+        verify(t > this.update_time_);
 
-        return (&this).update_time_ = t;
+        return this.update_time_ = t;
     }
 
 
@@ -377,7 +377,7 @@ public struct IrregularMovingAverage (Time = time_t, Value = real)
 
     public Value beta ()
     {
-        return (&this).beta_;
+        return this.beta_;
     }
 
 
@@ -405,7 +405,7 @@ public struct IrregularMovingAverage (Time = time_t, Value = real)
         verify(0 < b);
         verify(b < 1);
 
-        return (&this).beta_ = b;
+        return this.beta_ = b;
     }
 }
 

--- a/src/ocean/math/Range.d
+++ b/src/ocean/math/Range.d
@@ -106,7 +106,7 @@ public struct Range ( T )
             // useful for test!("==")
             public istring toString ()
             {
-                return format("<{}|{}>", (&this).value, cast(char)('A' + (&this).owner_index));
+                return format("<{}|{}>", this.value, cast(char)('A' + this.owner_index));
             }
         }
     }
@@ -208,20 +208,20 @@ public struct Range ( T )
 
     invariant()
     {
-        assert(This.isValid((&this).min_, (&this).max_));
+        assert(This.isValid(this.min_, this.max_));
     }
 
     version (unittest)
     {
         public istring toString()
         {
-            auto msg = format("{}({}, {}", This.stringof, (&this).min_, (&this).max_);
+            auto msg = format("{}({}, {}", This.stringof, this.min_, this.max_);
 
-            if ((&this).is_empty)
+            if (this.is_empty)
             {
                 msg ~= " empty";
             }
-            else if ((&this).is_full_range)
+            else if (this.is_full_range)
             {
                 msg ~= " full";
             }
@@ -390,7 +390,7 @@ public struct Range ( T )
 
     public T min ( )
     {
-        return (&this).min_;
+        return this.min_;
     }
 
 
@@ -403,7 +403,7 @@ public struct Range ( T )
 
     public T max ( )
     {
-        return (&this).max_;
+        return this.max_;
     }
 
 
@@ -421,7 +421,7 @@ public struct Range ( T )
 
     public T min ( T min )
     {
-        return (&this).min_ = min;
+        return this.min_ = min;
     }
 
 
@@ -439,7 +439,7 @@ public struct Range ( T )
 
     public T max ( T max )
     {
-        return (&this).max_ = max;
+        return this.max_ = max;
     }
 
 
@@ -452,7 +452,7 @@ public struct Range ( T )
 
     public bool is_empty ( )
     {
-        return This.isEmpty((&this).min_, (&this).max_);
+        return This.isEmpty(this.min_, this.max_);
     }
 
 
@@ -465,7 +465,7 @@ public struct Range ( T )
 
     public bool is_full_range ( )
     {
-        return This.isFullRange((&this).min_, (&this).max_);
+        return This.isFullRange(this.min_, this.max_);
     }
 
 
@@ -483,7 +483,7 @@ public struct Range ( T )
 
     public bool is_valid ( )
     {
-        return This.isValid((&this).min_, (&this).max_);
+        return This.isValid(this.min_, this.max_);
     }
 
 
@@ -500,11 +500,11 @@ public struct Range ( T )
 
     public size_t length ( )
     {
-        enforce(!(&this).is_full_range, This.stringof ~ ".length(): full range");
+        enforce(!this.is_full_range, This.stringof ~ ".length(): full range");
 
-        if ( (&this).is_empty ) return 0;
+        if ( this.is_empty ) return 0;
 
-        return ((&this).max_ - (&this).min_) + 1;
+        return (this.max_ - this.min_) + 1;
     }
 
     unittest
@@ -531,10 +531,10 @@ public struct Range ( T )
 
     public bool contains ( T x )
     {
-        if ((&this).is_empty)
+        if (this.is_empty)
             return false;
 
-        return (&this).min_ <= x && x <= (&this).max_;
+        return this.min_ <= x && x <= this.max_;
     }
 
     unittest
@@ -576,7 +576,7 @@ public struct Range ( T )
 
     public equals_t opEquals ( This other )
     {
-        return (&this).min_ == other.min && (&this).max_ == other.max_;
+        return this.min_ == other.min && this.max_ == other.max_;
     }
 
     unittest
@@ -677,10 +677,10 @@ public struct Range ( T )
 
     public bool isSubsetOf ( This other )
     {
-        if ( (&this).is_empty || other.is_empty )
+        if ( this.is_empty || other.is_empty )
             return false;
 
-        return (&this).min_ >= other.min_ && (&this).max_ <= other.max_;
+        return this.min_ >= other.min_ && this.max_ <= other.max_;
     }
 
     unittest
@@ -786,7 +786,7 @@ public struct Range ( T )
 
     public bool isTessellatedBy ( This[] ranges )
     {
-        return (*(&this) == extent(ranges)) && isContiguous(ranges);
+        return (this == extent(ranges)) && isContiguous(ranges);
     }
 
     unittest
@@ -869,7 +869,7 @@ public struct Range ( T )
 
     public bool isCoveredBy ( This[] ranges )
     {
-        return (&this).isSubsetOf(extent(ranges)) && !hasGap(ranges);
+        return this.isSubsetOf(extent(ranges)) && !hasGap(ranges);
     }
 
     unittest
@@ -1034,10 +1034,10 @@ public struct Range ( T )
 
     public size_t overlapAmount ( Range other )
     {
-        enforce(!((&this).is_full_range && other.is_full_range),
+        enforce(!(this.is_full_range && other.is_full_range),
                  This.stringof ~ ".overlapAmount(): both ranges are full");
 
-        if ( (&this).is_empty || other.is_empty ) return 0;
+        if ( this.is_empty || other.is_empty ) return 0;
 
         RangeEndpoint[4] a;
         This.sortEndpoints(this, other, a);
@@ -1110,9 +1110,9 @@ public struct Range ( T )
 
     public bool overlaps ( This other )
     {
-        if ( (&this).is_empty || other.is_empty ) return false;
+        if ( this.is_empty || other.is_empty ) return false;
 
-        return !(other.max_ < (&this).min_ || other.min > (&this).max_);
+        return !(other.max_ < this.min_ || other.min > this.max_);
     }
 
     unittest
@@ -1176,7 +1176,7 @@ public struct Range ( T )
     public void subtract ( This other, out This lower, out This upper )
     {
         // this empty -- empty result
-        if ( (&this).is_empty ) return;
+        if ( this.is_empty ) return;
 
         // other empty -- no change
         if ( other.is_empty )

--- a/src/ocean/math/TimeHistogram.d
+++ b/src/ocean/math/TimeHistogram.d
@@ -196,9 +196,9 @@ struct TimeHistogram
 
     public ulong countMicros ( ulong us )
     {
-        (&this).count++;
-        (&this).total_time_micros += us;
-        (&this).bins[binIndex(us)]++;
+        this.count++;
+        this.total_time_micros += us;
+        this.bins[binIndex(us)]++;
         return us;
     }
 
@@ -213,11 +213,11 @@ struct TimeHistogram
     public double mean_time_micros ( )
     in
     {
-        assert((&this).count || !(&this).total_time_micros);
+        assert(this.count || !this.total_time_micros);
     }
     body
     {
-        return cast(double)(&this).total_time_micros / (&this).count;
+        return cast(double)this.total_time_micros / this.count;
     }
 
     /***************************************************************************
@@ -258,7 +258,7 @@ struct TimeHistogram
 
     public Bins stats ( )
     {
-        return Bins.fromArray((&this).bins);
+        return Bins.fromArray(this.bins);
     }
 
     unittest

--- a/src/ocean/math/WideUInt.d
+++ b/src/ocean/math/WideUInt.d
@@ -87,7 +87,7 @@ public struct WideUInt ( size_t N )
 
     public size_t decimal_digits ( )
     {
-        if ((&this).opEquals(0))
+        if (this.opEquals(0))
             return 1;
 
         WideUInt copy = this;
@@ -129,7 +129,7 @@ public struct WideUInt ( size_t N )
     public istring toString ( )
     {
         mstring result;
-        (&this).toString((cstring s) { result ~= s; });
+        this.toString((cstring s) { result ~= s; });
         return assumeUnique(result);
     }
 
@@ -160,7 +160,7 @@ public struct WideUInt ( size_t N )
 
     public void toString ( scope void delegate (cstring) sink )
     {
-        auto n = (&this).decimal_digits();
+        auto n = this.decimal_digits();
         static mstring buffer;
         buffer.length = n;
         enableStomping(buffer);
@@ -186,7 +186,7 @@ public struct WideUInt ( size_t N )
 
     public void opAssign ( ulong rhs )
     {
-        (&this).assign(rhs);
+        this.assign(rhs);
     }
 
     unittest
@@ -221,13 +221,13 @@ public struct WideUInt ( size_t N )
 
     public equals_t opEquals ( ulong rhs )
     {
-        if ((&this).payload[0] != (rhs & uint.max))
+        if (this.payload[0] != (rhs & uint.max))
             return false;
 
-        if ((&this).payload[1] != (rhs >> 32))
+        if (this.payload[1] != (rhs >> 32))
             return false;
 
-        foreach (ref word; (&this).payload[2 .. N])
+        foreach (ref word; this.payload[2 .. N])
         {
             if (word != 0)
                 return false;
@@ -268,7 +268,7 @@ public struct WideUInt ( size_t N )
 
     public equals_t opEquals ( WideUInt rhs )
     {
-        return (&this).payload[] == rhs.payload[];
+        return this.payload[] == rhs.payload[];
     }
 
     unittest
@@ -338,8 +338,8 @@ public struct WideUInt ( size_t N )
 
     public void opAddAssign ( uint rhs )
     {
-        if (add((&this).payload[0], rhs))
-            enforce(.wideint_exception, (&this).checkAndInc(1));
+        if (add(this.payload[0], rhs))
+            enforce(.wideint_exception, this.checkAndInc(1));
     }
 
     unittest
@@ -373,13 +373,13 @@ public struct WideUInt ( size_t N )
     {
         ulong remainder = 0;
 
-        for (ptrdiff_t idx = (&this).payload.length - 1; idx >= 0; --idx)
+        for (ptrdiff_t idx = this.payload.length - 1; idx >= 0; --idx)
         {
-            remainder = (remainder << 32) + (&this).payload[idx];
+            remainder = (remainder << 32) + this.payload[idx];
             ulong result = remainder / rhs;
             remainder -= rhs * result;
             verify(result <= uint.max);
-            (&this).payload[idx] = cast(uint) result;
+            this.payload[idx] = cast(uint) result;
         }
 
         verify(remainder <= uint.max);
@@ -415,10 +415,10 @@ public struct WideUInt ( size_t N )
     {
         ulong overflow = 0;
 
-        for (size_t i = 0; i < (&this).payload.length; ++i)
+        for (size_t i = 0; i < this.payload.length; ++i)
         {
-            overflow += cast(ulong)((&this).payload[i]) * rhs;
-            (&this).payload[i] = cast(uint) (overflow & uint.max);
+            overflow += cast(ulong)(this.payload[i]) * rhs;
+            this.payload[i] = cast(uint) (overflow & uint.max);
             overflow >>= 32;
         }
 
@@ -443,23 +443,23 @@ public struct WideUInt ( size_t N )
     public double toDouble ( )
     {
         // find most significant word with non-zero value
-        int idx = (&this).payload.length-1;
-        while ((&this).payload[idx] == 0 && idx > 0)
+        int idx = this.payload.length-1;
+        while (this.payload[idx] == 0 && idx > 0)
             --idx;
 
         // if stored value <= ulong.max, just use plain cast
         if (idx < 2)
         {
-            ulong value = (&this).payload[1];
+            ulong value = this.payload[1];
             value <<= 32;
-            value |= (&this).payload[0];
+            value |= this.payload[0];
             return cast(double) value;
         }
 
         // else calculate floating point value from 3 most significant words
         double MAXWORD = pow(2.0, 32.0);
-        return (((&this).payload[idx] * MAXWORD + (&this).payload[idx-1])
-                * MAXWORD + (&this).payload[idx-2])
+        return ((this.payload[idx] * MAXWORD + this.payload[idx-1])
+                * MAXWORD + this.payload[idx-2])
             * ldexp(1.0, (idx-2)*32);
     }
 
@@ -492,9 +492,9 @@ public struct WideUInt ( size_t N )
         if (idx >= N)
             return false;
 
-        uint after = ++(&this).payload[idx];
+        uint after = ++this.payload[idx];
         if (after == 0)
-            return (&this).checkAndInc(idx+1);
+            return this.checkAndInc(idx+1);
 
         return true;
     }
@@ -519,9 +519,9 @@ public struct WideUInt ( size_t N )
 
     private void assign ( ulong value )
     {
-        (&this).payload[] = 0;
-        (&this).payload[0] = cast(uint) value;
-        (&this).payload[1] = cast(uint) (value >> 32);
+        this.payload[] = 0;
+        this.payload[0] = cast(uint) value;
+        this.payload[1] = cast(uint) (value >> 32);
     }
 
     /***************************************************************************

--- a/src/ocean/meta/values/Reset_test.d
+++ b/src/ocean/meta/values/Reset_test.d
@@ -28,13 +28,13 @@ unittest
 
                 void InitStructure()
                 {
-                    (&this).h = -52;
-                    (&this).i.copy("even even more test text");
-                    (&this).j.length = 3;
-                    (&this).j[0].copy("abc");
-                    (&this).j[1].copy("def");
-                    (&this).j[2].copy("ghi");
-                    foreach ( ref item; (&this).k )
+                    this.h = -52;
+                    this.i.copy("even even more test text");
+                    this.j.length = 3;
+                    this.j[0].copy("abc");
+                    this.j[1].copy("def");
+                    this.j[2].copy("ghi");
+                    foreach ( ref item; this.k )
                     {
                         item = 120000;
                     }
@@ -43,12 +43,12 @@ unittest
 
             void InitStructure()
             {
-                (&this).d = 32;
-                (&this).e.copy("even more test text");
+                this.d = 32;
+                this.e.copy("even more test text");
 
-                (&this).f.length = 1;
-                (&this).f[0].copy("abc");
-                foreach ( ref item; (&this).g )
+                this.f.length = 1;
+                this.f[0].copy("abc");
+                foreach ( ref item; this.g )
                 {
                     item = 32400;
                 }

--- a/src/ocean/meta/values/VisitValue.d
+++ b/src/ocean/meta/values/VisitValue.d
@@ -100,7 +100,7 @@ private struct VisitImpl ( Visitor )
 
     private void visitAll ( T ) ( T* value )
     {
-        auto deeper = (&this).visitor.visit(value);
+        auto deeper = this.visitor.visit(value);
 
         if (!deeper)
             return;
@@ -112,7 +112,7 @@ private struct VisitImpl ( Visitor )
         else static if (isTypedef!(T))
         {
             auto reinterp = cast(TypedefBaseType!(T)*) value;
-            (&this).visitAll(reinterp);
+            this.visitAll(reinterp);
         }
         else static if (isAggregateType!(T))
         {
@@ -130,7 +130,7 @@ private struct VisitImpl ( Visitor )
                         static if (Base.init.tupleof.length)
                         {
                             Base base = *value; // implicit upcast
-                            (&this).visitAll(&base);
+                            this.visitAll(&base);
                         }
                     }
                 }
@@ -140,7 +140,7 @@ private struct VisitImpl ( Visitor )
             {
                 foreach (ref field; (*value).tupleof)
                 {
-                    (&this).visitAll(&field);
+                    this.visitAll(&field);
                 }
             }
         }
@@ -151,7 +151,7 @@ private struct VisitImpl ( Visitor )
                 || isArrayType!(T) == ArrayKind.Dynamic)
             {
                 foreach (ref elem; *value)
-                    (&this).visitAll(&elem);
+                    this.visitAll(&elem);
             }
             else
             {
@@ -165,12 +165,12 @@ private struct VisitImpl ( Visitor )
         else static if (isPointerType!(T))
         {
             if (*value !is null)
-                (&this).visitAll(*value);
+                this.visitAll(*value);
         }
         else static if (is(T U == enum))
         {
             auto reinterp = cast(U*) value;
-            (&this).visitAll(reinterp);
+            this.visitAll(reinterp);
         }
         else
         {

--- a/src/ocean/net/collectd/Identifier.d
+++ b/src/ocean/net/collectd/Identifier.d
@@ -125,9 +125,9 @@ public struct Identifier
 
     invariant ()
     {
-        assert((&this).host.length, "No host for identifier");
-        assert((&this).plugin.length, "No plugin for identifier");
-        assert((&this).type.length, "No type for identifier");
+        assert(this.host.length, "No host for identifier");
+        assert(this.plugin.length, "No plugin for identifier");
+        assert(this.type.length, "No type for identifier");
     }
 
 
@@ -361,11 +361,11 @@ public struct Identifier
 
     public istring toString ()
     {
-        auto pi = (&this).plugin_instance.length ? "-" : null;
-        auto ti = (&this).type_instance.length ? "-" : null;
+        auto pi = this.plugin_instance.length ? "-" : null;
+        auto ti = this.type_instance.length ? "-" : null;
 
-        return format("{}/{}{}{}/{}{}{}", (&this).host,
-                      (&this).plugin, pi, (&this).plugin_instance,
-                      (&this).type, ti, (&this).type_instance);
+        return format("{}/{}{}{}/{}{}{}", this.host,
+                      this.plugin, pi, this.plugin_instance,
+                      this.type, ti, this.type_instance);
     }
 }

--- a/src/ocean/net/collectd/SocketReader.d
+++ b/src/ocean/net/collectd/SocketReader.d
@@ -66,7 +66,7 @@ package struct SocketReader (size_t MAX_FIELD_SIZE = 512, size_t FIELDS = 16)
 
     public cstring front ()
     {
-        return (&this).current_field;
+        return this.current_field;
     }
 
 
@@ -93,46 +93,46 @@ package struct SocketReader (size_t MAX_FIELD_SIZE = 512, size_t FIELDS = 16)
 
     public ssize_t popFront (ISocket socket = null, int flags = 0)
     {
-        auto off = (&this).locateChar('\n');
+        auto off = this.locateChar('\n');
 
-        if (off != (&this).length)
+        if (off != this.length)
         {
             // Worst case scenario: the field starts at the end of the buffer
             // and continues at the beginning. In this case, we have no choice
             // but to copy data to our field_buffer to get something sane.
-            if ((&this).start_idx + off > (&this).buffer.length)
+            if (this.start_idx + off > this.buffer.length)
             {
-                auto p1len = (&this).buffer.length - (&this).start_idx;
+                auto p1len = this.buffer.length - this.start_idx;
                 verify(p1len < off);
 
-                (&this).field_buffer[0 .. p1len]
-                    = (&this).buffer[(&this).start_idx .. (&this).buffer.length];
+                this.field_buffer[0 .. p1len]
+                    = this.buffer[this.start_idx .. this.buffer.length];
 
-                (&this).field_buffer[p1len .. off] = (&this).buffer[0 .. off - p1len];
+                this.field_buffer[p1len .. off] = this.buffer[0 .. off - p1len];
 
-                (&this).current_field = (&this).field_buffer[0 .. off];
+                this.current_field = this.field_buffer[0 .. off];
             }
             else
             {
                 // Usual case: We just return a slice to our buffer
-                (&this).current_field = (&this).buffer[(&this).start_idx .. (&this).start_idx + off];
+                this.current_field = this.buffer[this.start_idx .. this.start_idx + off];
             }
-            (&this).length -= (off + 1);
-            (&this).start_idx = !(&this).length ? 0 : (&this).calc((&this).start_idx, off + 1);
+            this.length -= (off + 1);
+            this.start_idx = !this.length ? 0 : this.calc(this.start_idx, off + 1);
         }
         else if (socket !is null)
         {
-            auto r = (&this).recv(socket, flags);
+            auto r = this.recv(socket, flags);
             if (r <= 0)
             {
-                (&this).current_field = null;
-                throw (&this).e.useGlobalErrno("recv");
+                this.current_field = null;
+                throw this.e.useGlobalErrno("recv");
             }
-            (&this).popFront(socket, flags);
+            this.popFront(socket, flags);
         }
         else
         {
-            (&this).current_field = null;
+            this.current_field = null;
         }
         return 0;
     }
@@ -149,7 +149,7 @@ package struct SocketReader (size_t MAX_FIELD_SIZE = 512, size_t FIELDS = 16)
 
     public bool empty ()
     {
-        return (&this).current_field is null;
+        return this.current_field is null;
     }
 
 
@@ -173,17 +173,17 @@ package struct SocketReader (size_t MAX_FIELD_SIZE = 512, size_t FIELDS = 16)
     {
         verify(socket !is null, "Cannot recv with a null socket");
 
-        auto start = (&this).calc((&this).start_idx, (&this).length);
-        auto end   = start < (&this).start_idx ? (&this).start_idx : (&this).buffer.length;
+        auto start = this.calc(this.start_idx, this.length);
+        auto end   = start < this.start_idx ? this.start_idx : this.buffer.length;
 
-        ssize_t ret = socket.recv((&this).buffer[start .. end], flags);
+        ssize_t ret = socket.recv(this.buffer[start .. end], flags);
 
         // Errors are handled from popFront
         if (ret <= 0)
             return ret;
 
-        (&this).length += ret;
-        verify((&this).length <= (&this).buffer.length);
+        this.length += ret;
+        verify(this.length <= this.buffer.length);
 
         return ret;
     }
@@ -198,7 +198,7 @@ package struct SocketReader (size_t MAX_FIELD_SIZE = 512, size_t FIELDS = 16)
 
     private bool isLinear ()
     {
-        return !((&this).start_idx + (&this).length > (&this).buffer.length);
+        return !(this.start_idx + this.length > this.buffer.length);
     }
 
 
@@ -214,23 +214,23 @@ package struct SocketReader (size_t MAX_FIELD_SIZE = 512, size_t FIELDS = 16)
 
     private size_t linearEnd ()
     {
-        return (&this).isLinear()
-            ? ((&this).start_idx + (&this).length)
-            : ((&this).buffer.length);
+        return this.isLinear()
+            ? (this.start_idx + this.length)
+            : (this.buffer.length);
     }
 
 
     /**************************************************************************
-*
+
         Returns: the maximum amount of data we can read
 
     ***************************************************************************/
 
     private size_t linearSpace ()
     {
-        return (&this).isLinear()
-            ? ((&this).buffer.length - (&this).calc((&this).start_idx, (&this).length))
-            : ((&this).start_idx - (&this).calc((&this).start_idx, (&this).length));
+        return this.isLinear()
+            ? (this.buffer.length - this.calc(this.start_idx, this.length))
+            : (this.start_idx - this.calc(this.start_idx, this.length));
     }
 
 
@@ -250,14 +250,14 @@ package struct SocketReader (size_t MAX_FIELD_SIZE = 512, size_t FIELDS = 16)
     private size_t locateChar (char tok)
     {
         auto after = StringSearch!(false).locateChar(
-            (&this).buffer[(&this).start_idx .. (&this).linearEnd()], tok);
-        if ((&this).isLinear() || (&this).start_idx  + after < (&this).buffer.length)
+            this.buffer[this.start_idx .. this.linearEnd()], tok);
+        if (this.isLinear() || this.start_idx  + after < this.buffer.length)
         {
             return after;
         }
         // In this case, after ==> buffer.length - start_idx
         return after + StringSearch!(false).locateChar(
-            (&this).buffer[0 .. (&this).length - after],
+            this.buffer[0 .. this.length - after],
             tok);
     }
 
@@ -277,7 +277,7 @@ package struct SocketReader (size_t MAX_FIELD_SIZE = 512, size_t FIELDS = 16)
 
     private size_t calc (size_t idx, size_t val)
     {
-        return (idx + val) % (&this).buffer.length;
+        return (idx + val) % this.buffer.length;
     }
 
 

--- a/src/ocean/net/http/time/HttpTimeFormatter.d
+++ b/src/ocean/net/http/time/HttpTimeFormatter.d
@@ -85,7 +85,7 @@ struct HttpTimeFormatter
 
     public mstring format ( time_t t )
     {
-        return (&this).format((&this).buf, t);
+        return this.format(this.buf, t);
     }
 
     /**************************************************************************
@@ -103,7 +103,7 @@ struct HttpTimeFormatter
 
     public mstring format ( )
     {
-        return (&this).format((&this).buf);
+        return this.format(this.buf);
     }
 
     /**************************************************************************

--- a/src/ocean/net/util/GetSocketAddress.d
+++ b/src/ocean/net/util/GetSocketAddress.d
@@ -98,7 +98,7 @@ class GetSocketAddress
 
         public sockaddr addr ( )
         {
-            return (&this).addr_;
+            return this.addr_;
         }
 
         /**********************************************************************
@@ -110,7 +110,7 @@ class GetSocketAddress
 
         public Family family ( )
         {
-            return cast (Family) (&this).addr_.sa_family;
+            return cast (Family) this.addr_.sa_family;
         }
 
         /**********************************************************************
@@ -123,7 +123,7 @@ class GetSocketAddress
 
         public bool supported_family ( )
         {
-            switch ((&this).family)
+            switch (this.family)
             {
                 case Family.INET, Family.INET6:
                     return true;
@@ -151,9 +151,9 @@ class GetSocketAddress
         }
         body
         {
-            void* addrp = &(&this).addr_;
+            void* addrp = &this.addr_;
 
-            switch ((&this).family)
+            switch (this.family)
             {
                 case Family.INET:
                     addrp += sockaddr_in.init.sin_addr.offsetof;
@@ -164,13 +164,13 @@ class GetSocketAddress
                     break;
 
                 default:
-                    throw (&this).e.set(.EAFNOSUPPORT);
+                    throw this.e.set(.EAFNOSUPPORT);
             }
 
-            auto str = .inet_ntop((&this).addr_.sa_family, addrp,
-                                   (&this).addr_string_buffer.ptr, (&this).addr_string_buffer.length);
+            auto str = .inet_ntop(this.addr_.sa_family, addrp,
+                                   this.addr_string_buffer.ptr, this.addr_string_buffer.length);
 
-            (&this).e.enforce(!!str, "inet_ntop");
+            this.e.enforce(!!str, "inet_ntop");
 
             return str[0 .. strlen(str)];
         }
@@ -190,18 +190,18 @@ class GetSocketAddress
         {
             in_port_t port;
 
-            switch ((&this).family)
+            switch (this.family)
             {
                 case Family.INET:
-                    port = (cast (sockaddr_in*) &(&this).addr_).sin_port;
+                    port = (cast (sockaddr_in*) &this.addr_).sin_port;
                     break;
 
                 case Family.INET6:
-                    port = (cast (sockaddr_in6*) &(&this).addr_).sin6_port;
+                    port = (cast (sockaddr_in6*) &this.addr_).sin6_port;
                     break;
 
                 default:
-                    throw (&this).e.set(.EAFNOSUPPORT);
+                    throw this.e.set(.EAFNOSUPPORT);
             }
 
             return .ntohs(port);

--- a/src/ocean/stdc/posix/sys/un.d
+++ b/src/ocean/stdc/posix/sys/un.d
@@ -43,7 +43,7 @@ struct sockaddr_un
         public static sockaddr_un create (cstring path)
         in
         {
-            assert(typeof((&this)).sun_path.length > path.length,
+            assert(typeof(this).sun_path.length > path.length,
                     "Can't set path longer than UNIX_PATH_MAX.");
         }
         body

--- a/src/ocean/sys/CmdPath.d
+++ b/src/ocean/sys/CmdPath.d
@@ -77,9 +77,9 @@ struct CmdPath
 
         path.set(PathUtil.normalize(path.folder));
 
-        (&this).dir = path.absolute(Environment.cwd()).toString();
+        this.dir = path.absolute(Environment.cwd()).toString();
 
-        return (&this).get();
+        return this.get();
 }
 
     /**************************************************************************
@@ -93,7 +93,7 @@ struct CmdPath
 
     public istring get ( )
     {
-        return (&this).dir;
+        return this.dir;
     }
 
     /**************************************************************************
@@ -110,6 +110,6 @@ struct CmdPath
 
     public istring prepend ( istring[] path ... )
     {
-        return FilePath.join((&this).dir ~ path);
+        return FilePath.join(this.dir ~ path);
     }
 }

--- a/src/ocean/sys/Epoll.d
+++ b/src/ocean/sys/Epoll.d
@@ -213,7 +213,7 @@ align (1) union epoll_data_t
 
     Object obj ( Object o )
     {
-        return cast (Object) ((&this).ptr = cast (void*) o);
+        return cast (Object) (this.ptr = cast (void*) o);
     }
 
     /**************************************************************************
@@ -227,7 +227,7 @@ align (1) union epoll_data_t
 
     Object obj ( )
     {
-        return cast (Object) (&this).ptr;
+        return cast (Object) this.ptr;
     }
 }
 
@@ -540,7 +540,7 @@ struct Epoll
 
     public int create ( CreateFlags flags = CreateFlags.None )
     {
-        return (&this).fd = epoll_create1(
+        return this.fd = epoll_create1(
             setCloExec(flags, EpollCreateFlags.EPOLL_CLOEXEC)
         );
     }
@@ -566,7 +566,7 @@ struct Epoll
 
     public int ctl ( CtlOp op, int fd, epoll_event_t event )
     {
-        return epoll_ctl((&this).fd, op, fd, &event);
+        return epoll_ctl(this.fd, op, fd, &event);
     }
 
     template ctlT ( size_t i = 0 )
@@ -606,7 +606,7 @@ struct Epoll
                 event.events          = events;
                 event.data.tupleof[i] = data;
 
-                return epoll_ctl((&this).fd, op, fd, &event);
+                return epoll_ctl(this.fd, op, fd, &event);
             }
 
             mixin ctlT!(i + 1);
@@ -677,7 +677,7 @@ struct Epoll
         event.events   = events;
         event.data.obj = obj;
 
-        return epoll_ctl((&this).fd, op, fd, &event);
+        return epoll_ctl(this.fd, op, fd, &event);
     }
 
     /**************************************************************************
@@ -711,7 +711,7 @@ struct Epoll
         event.events   = events;
         event.data.u64 = u64;
 
-        return epoll_ctl((&this).fd, op, fd, &event);
+        return epoll_ctl(this.fd, op, fd, &event);
     }
 
     /**************************************************************************
@@ -745,7 +745,7 @@ struct Epoll
     body
     {
         verify(events.length <= int.max);
-        return epoll_wait((&this).fd, events.ptr, cast (int) events.length, timeout_ms);
+        return epoll_wait(this.fd, events.ptr, cast (int) events.length, timeout_ms);
     }
 
     /**************************************************************************
@@ -759,6 +759,6 @@ struct Epoll
 
     public int close ( )
     {
-        return .close((&this).fd);
+        return .close(this.fd);
     }
 }

--- a/src/ocean/sys/ErrnoException.d
+++ b/src/ocean/sys/ErrnoException.d
@@ -418,10 +418,10 @@ public struct Caller ( T )
 
     public ReturnTypeOf!(T) call ( ParametersOf!(T) args )
     {
-        auto ret = (&this).fn(args);
+        auto ret = this.fn(args);
         if (!verify(ret))
-            throw e.useGlobalErrno(e.func_name, (&this).original_file,
-                (&this).original_line);
+            throw e.useGlobalErrno(e.func_name, this.original_file,
+                this.original_line);
         return ret;
     }
 }

--- a/src/ocean/sys/Inotify.d
+++ b/src/ocean/sys/Inotify.d
@@ -102,7 +102,7 @@ public class Inotify : ISelectable
             int result = 0;
 
             ssize_t read_bytes;
-            read_loop: while ( (read_bytes = read((&this).outer.fd, buffer.ptr, buffer.length)) > 0 )
+            read_loop: while ( (read_bytes = read(this.outer.fd, buffer.ptr, buffer.length)) > 0 )
             {
                 inotify_event *i_event;
 

--- a/src/ocean/sys/Process.d
+++ b/src/ocean/sys/Process.d
@@ -213,7 +213,7 @@ class Process
         /// Convenience overload that format this as a string
         public istring toString ()
         {
-            return format("{}", (&this));
+            return format("{}", &this);
         }
     }
 

--- a/src/ocean/sys/SignalMask.d
+++ b/src/ocean/sys/SignalMask.d
@@ -60,7 +60,7 @@ public struct SignalSet
 
     public void clear ( )
     {
-        sigemptyset(&(&this).sigset);
+        sigemptyset(&this.sigset);
     }
 
 
@@ -72,7 +72,7 @@ public struct SignalSet
 
     public void setAll ( )
     {
-        sigfillset(&(&this).sigset);
+        sigfillset(&this.sigset);
     }
 
 
@@ -89,7 +89,7 @@ public struct SignalSet
 
     public void remove ( int signal )
     {
-        sigdelset(&(&this).sigset, signal);
+        sigdelset(&this.sigset, signal);
     }
 
     // deprecated not only because D1 binary operators are being deprecated
@@ -112,7 +112,7 @@ public struct SignalSet
 
     public void add ( int signal )
     {
-        sigaddset(&(&this).sigset, signal);
+        sigaddset(&this.sigset, signal);
     }
 
     // deprecated not only because D1 binary operators are being deprecated
@@ -137,7 +137,7 @@ public struct SignalSet
     {
         foreach ( signal; signals )
         {
-            (&this).remove(signal);
+            this.remove(signal);
         }
     }
 
@@ -163,7 +163,7 @@ public struct SignalSet
     {
         foreach ( signal; signals )
         {
-            (&this).add(signal);
+            this.add(signal);
         }
     }
 
@@ -188,7 +188,7 @@ public struct SignalSet
 
     public bool isSet ( int signal )
     {
-        return !!sigismember(&(&this).sigset, signal);
+        return !!sigismember(&this.sigset, signal);
     }
 
     /***************************************************************************
@@ -233,7 +233,7 @@ public struct SignalSet
     {
         typeof(this) old_set;
 
-        pthread_sigmask(how, &(&this).sigset, &old_set.sigset);
+        pthread_sigmask(how, &this.sigset, &old_set.sigset);
 
         return old_set;
     }
@@ -252,7 +252,7 @@ public struct SignalSet
 
     public typeof(this) block ( )
     {
-        return (&this).mask(SIG_BLOCK);
+        return this.mask(SIG_BLOCK);
     }
 
     /***************************************************************************
@@ -269,7 +269,7 @@ public struct SignalSet
 
     public typeof(this) unblock ( )
     {
-        return (&this).mask(SIG_UNBLOCK);
+        return this.mask(SIG_UNBLOCK);
     }
 
     /***************************************************************************
@@ -284,7 +284,7 @@ public struct SignalSet
 
     public void callBlocked ( lazy void op )
     {
-        auto old_sigset = (&this).block();
+        auto old_sigset = this.block();
 
         scope ( exit )
         {
@@ -293,7 +293,7 @@ public struct SignalSet
                 sigset_t pending;
                 sigpending(&pending);
 
-                foreach ( signal; (&this).signals )
+                foreach ( signal; this.signals )
                 {
                     if ( sigismember(&pending, signal) )
                     {
@@ -335,6 +335,6 @@ public struct SignalSet
 
     public sigset_t opCast ( )
     {
-        return (&this).sigset;
+        return this.sigset;
     }
 }

--- a/src/ocean/sys/socket/AddrInfo.d
+++ b/src/ocean/sys/socket/AddrInfo.d
@@ -101,7 +101,7 @@ struct addrinfo
     socklen_t       ai_addrlen;               // The manpage says size_t: WRONG!
     sockaddr*       ai_addr;
     char*           ai_canonname;
-    typeof ((&this))   ai_next;
+    typeof(&this)   ai_next;
 
     alias .INET6_ADDRSTRLEN INET6_ADDRSTRLEN;
     alias .INET_ADDRSTRLEN  INET_ADDRSTRLEN;
@@ -143,9 +143,9 @@ struct addrinfo
     {
         void sanity_check ( )
         {
-            verify((&this).ai_addr !is null);
+            verify(this.ai_addr !is null);
 
-            switch ((&this).ai_family)
+            switch (this.ai_family)
             {
                 case AF_INET:
                     verify(
@@ -171,14 +171,14 @@ struct addrinfo
 
         void* addr;
 
-        switch ((&this).ai_family)
+        switch (this.ai_family)
         {
             case AF_INET:
-                addr = &(*cast (sockaddr_in*) (&this).ai_addr).sin_addr;
+                addr = &(*cast (sockaddr_in*) this.ai_addr).sin_addr;
                 break;
 
             case AF_INET6:
-                addr = &(*cast (sockaddr_in6*) (&this).ai_addr).sin6_addr;
+                addr = &(*cast (sockaddr_in6*) this.ai_addr).sin6_addr;
                 break;
 
             default:
@@ -186,7 +186,7 @@ struct addrinfo
                 return null;
         }
 
-        auto address_p = .inet_ntop((&this).ai_family, addr, dst.ptr,
+        auto address_p = .inet_ntop(this.ai_family, addr, dst.ptr,
             castFrom!(size_t).to!(int)(dst.length));
         // inet_ntop returns const pointer even if spec says it will always
         // use `dst` memory. Using `dst` directly to avoid casts.
@@ -212,16 +212,16 @@ struct addrinfo
 
     ushort port ( )
     {
-        verify((&this).ai_addr !is null);
+        verify(this.ai_addr !is null);
         .errno = 0;
 
-        switch ((&this).ai_family)
+        switch (this.ai_family)
         {
             case AF_INET:
-                return .ntohs((cast (sockaddr_in*) (&this).ai_addr).sin_port);
+                return .ntohs((cast (sockaddr_in*) this.ai_addr).sin_port);
 
             case AF_INET6:
-                return .ntohs((cast (sockaddr_in6*) (&this).ai_addr).sin6_port);
+                return .ntohs((cast (sockaddr_in6*) this.ai_addr).sin6_port);
 
             default:
                 .errno = EAFNOSUPPORT;
@@ -240,7 +240,7 @@ struct addrinfo
 
     char[] canonname ( )
     {
-        return (&this).ai_canonname? (&this).ai_canonname[0 .. strlen((&this).ai_canonname)] : null;
+        return this.ai_canonname? this.ai_canonname[0 .. strlen(this.ai_canonname)] : null;
     }
 
     /**************************************************************************
@@ -256,7 +256,7 @@ struct addrinfo
     {
         int result = 0;
 
-        for (typeof ((&this)) info = (&this); info && !result; info = info.ai_next)
+        for (typeof(&this) info = &this; info && !result; info = info.ai_next)
         {
             result = dg(*info);
         }

--- a/src/ocean/sys/socket/InetAddress.d
+++ b/src/ocean/sys/socket/InetAddress.d
@@ -142,11 +142,11 @@ struct InetAddress ( bool IPv6 = false )
     {
         static if (IPv6)
         {
-            return .ntohs((&this).addr.sin6_port);
+            return .ntohs(this.addr.sin6_port);
         }
         else
         {
-            return .ntohs((&this).addr.sin_port);
+            return .ntohs(this.addr.sin_port);
         }
     }
 
@@ -166,12 +166,12 @@ struct InetAddress ( bool IPv6 = false )
     {
         static if (IPv6)
         {
-            (&this).addr.sin6_port = .htons(p);
+            this.addr.sin6_port = .htons(p);
 
         }
         else
         {
-            (&this).addr.sin_port = .htons(p);
+            this.addr.sin_port = .htons(p);
         }
 
         return p;
@@ -193,14 +193,14 @@ struct InetAddress ( bool IPv6 = false )
 
     int inet_pton ( cstring ip_address_str )
     {
-        if (ip_address_str.length < (&this).addrstrlen)
+        if (ip_address_str.length < this.addrstrlen)
         {
-            char[(&this).addrstrlen] nultermbuf;
+            char[this.addrstrlen] nultermbuf;
 
             nultermbuf[0 .. ip_address_str.length] = ip_address_str[];
             nultermbuf[ip_address_str.length]      = '\0';
 
-            return (&this).inet_pton(nultermbuf.ptr);
+            return this.inet_pton(nultermbuf.ptr);
         }
         else
         {
@@ -229,7 +229,7 @@ struct InetAddress ( bool IPv6 = false )
 
     int inet_pton ( in char* ip_address_str )
     {
-        return .inet_pton((&this).family, ip_address_str, (&this).address_n.ptr);
+        return .inet_pton(this.family, ip_address_str, this.address_n.ptr);
     }
 
     /**************************************************************************
@@ -245,14 +245,14 @@ struct InetAddress ( bool IPv6 = false )
     {
         static if (IPv6)
         {
-            (&this).addr.sin6_addr = (&this).addr.sin6_addr.init;
+            this.addr.sin6_addr = this.addr.sin6_addr.init;
         }
         else
         {
-            (&this).addr.sin_addr.s_addr = htonl(INADDR_ANY);
+            this.addr.sin_addr.s_addr = htonl(INADDR_ANY);
         }
 
-        return cast (sockaddr*) &(&this).addr;
+        return cast (sockaddr*) &this.addr;
     }
 
     /**************************************************************************
@@ -277,11 +277,11 @@ struct InetAddress ( bool IPv6 = false )
     mstring inet_ntop ( mstring dst )
     {
         verify(
-            dst.length >= (&this).addrstrlen,
+            dst.length >= this.addrstrlen,
             "dst.length expected to be at least addrstrlen"
         );
 
-        auto address_p = .inet_ntop((&this).family, (&this).address_n.ptr, dst.ptr,
+        auto address_p = .inet_ntop(this.family, this.address_n.ptr, dst.ptr,
             castFrom!(size_t).to!(int)(dst.length));
 
         return address_p? dst.ptr[0 .. strlen(dst.ptr)] : null;
@@ -305,10 +305,10 @@ struct InetAddress ( bool IPv6 = false )
 
     public sockaddr* opCall ( cstring ip_address_str, ushort port = 0 )
     {
-        if ((&this).inet_pton(ip_address_str) == 1)
+        if (this.inet_pton(ip_address_str) == 1)
         {
-            (&this).port = port;
-            return cast (sockaddr*) &(&this).addr;
+            this.port = port;
+            return cast (sockaddr*) &this.addr;
         }
         else
         {
@@ -331,9 +331,9 @@ struct InetAddress ( bool IPv6 = false )
 
     public sockaddr* opCall ( ushort port )
     {
-        (&this).port = port;
+        this.port = port;
 
-        return (&this).setAddressAny();
+        return this.setAddressAny();
     }
 
     /**************************************************************************
@@ -350,9 +350,9 @@ struct InetAddress ( bool IPv6 = false )
 
     public sockaddr* opAssign ( Addr addr )
     {
-        (&this).addr = addr;
+        this.addr = addr;
 
-        return cast (sockaddr*) &(&this).addr;
+        return cast (sockaddr*) &this.addr;
     }
 
     /**************************************************************************
@@ -373,9 +373,9 @@ struct InetAddress ( bool IPv6 = false )
     public sockaddr* opAssign ( Addr* addr )
     {
         verify(addr !is null);
-        (&this).addr = *addr;
+        this.addr = *addr;
 
-        return cast (sockaddr*) &(&this).addr;
+        return cast (sockaddr*) &this.addr;
     }
 
     /**************************************************************************
@@ -386,7 +386,7 @@ struct InetAddress ( bool IPv6 = false )
 
     public void clear ( )
     {
-        (&this).addr = (&this).addr_init;
+        this.addr = this.addr_init;
     }
 
     /**************************************************************************
@@ -401,7 +401,7 @@ struct InetAddress ( bool IPv6 = false )
 
     public void[] address_n ( )
     {
-        with ((&this).addr) static if (IPv6)
+        with (this.addr) static if (IPv6)
         {
             return (cast (void*) &sin6_addr)[0 .. sin6_addr.sizeof];
         }
@@ -417,7 +417,7 @@ struct InetAddress ( bool IPv6 = false )
                            GetNameInfoFlags flags = GetNameInfoFlags.None)
     {
         return core.sys.posix.netdb.getnameinfo(
-            cast (sockaddr*) &(&this).addr, (&this).addr.sizeof,
+            cast (sockaddr*) &this.addr, this.addr.sizeof,
             host.ptr, castFrom!(size_t).to!(int)(host.length), serv.ptr,
             castFrom!(size_t).to!(int)(serv.length), flags);
     }

--- a/src/ocean/sys/stats/linux/ProcVFS.d
+++ b/src/ocean/sys/stats/linux/ProcVFS.d
@@ -321,7 +321,7 @@ public struct ProcUptime
         {
             Time res_time;
 
-            auto t = ((&this).seconds * 100 + (&this).cents) -
+            auto t = (this.seconds * 100 + this.cents) -
                 (rhs.seconds * 100 + rhs.cents);
 
             res_time.seconds = t / 100;

--- a/src/ocean/task/extensions/ExceptionForwarding.d
+++ b/src/ocean/task/extensions/ExceptionForwarding.d
@@ -40,12 +40,12 @@ struct ExceptionForwarding
 
     void onResumed ( )
     {
-        if ((&this).to_throw !is null)
+        if (this.to_throw !is null)
         {
             // reset the reference so it won't throw again
             // if the same fiber handles an exception and suspends again
-            auto to_throw = (&this).to_throw;
-            (&this).to_throw = null;
+            auto to_throw = this.to_throw;
+            this.to_throw = null;
             throw to_throw;
         }
     }

--- a/src/ocean/task/util/Event.d
+++ b/src/ocean/task/util/Event.d
@@ -50,15 +50,15 @@ struct TaskEvent
 
     public void wait ( )
     {
-        if (!(&this).triggered)
+        if (!this.triggered)
         {
-            (&this).task = Task.getThis();
+            this.task = Task.getThis();
             debug_trace("Task {} suspended waiting for event {}",
-                cast(void*) this.task, cast(void*) (&this));
+                cast(void*) this.task, cast(void*) &this);
             this.task.suspend();
         }
 
-        (&this).triggered = false;
+        this.triggered = false;
     }
 
     /***************************************************************************
@@ -70,11 +70,11 @@ struct TaskEvent
 
     public void trigger ( )
     {
-        (&this).triggered = true;
-        if ((&this).task !is null && (&this).task.suspended())
+        this.triggered = true;
+        if (this.task !is null && this.task.suspended())
         {
             debug_trace("Resuming task {} by trigger of event {}",
-                cast(void*) this.task, cast(void*) (&this));
+                cast(void*) this.task, cast(void*) &this);
             this.task.resume();
         }
     }

--- a/src/ocean/text/Search.d
+++ b/src/ocean/text/Search.d
@@ -131,7 +131,7 @@ public struct FindFruct
 
     void match (cstring what)
     {
-        (&this).what = what;
+        this.what = what;
     }
 
     /***********************************************************************
@@ -328,8 +328,8 @@ public struct SearchFruct
     void match (cstring what)
     {
         offsets[] = what.length + 1;
-        (&this).fore = true;
-        (&this).what = what;
+        this.fore = true;
+        this.what = what;
         reset;
     }
 

--- a/src/ocean/text/convert/DateTime_tango.d
+++ b/src/ocean/text/convert/DateTime_tango.d
@@ -172,7 +172,7 @@ struct DateTimeLocale
 
         auto res=Result(output);
         scope sink = (cstring v) { res ~= v; return v.length; };
-        (&this).formatCustom(sink, dateTime, layout);
+        this.formatCustom(sink, dateTime, layout);
         return res.get;
     }
 
@@ -968,7 +968,7 @@ public struct AsPrettyStr
     {
         // Layout defaults to 'G'
         scope dg = (cstring s) { sink(s); return s.length; };
-        DateTimeDefault.format(dg, (&this).value, "");
+        DateTimeDefault.format(dg, this.value, "");
     }
 }
 

--- a/src/ocean/text/formatter/SmartUnion.d
+++ b/src/ocean/text/formatter/SmartUnion.d
@@ -110,20 +110,20 @@ private struct SmartUnionFormatter ( SU )
 
     public void toString ( scope void delegate ( cstring chunk ) sink )
     {
-        if ( (&this).smart_union.active )
+        if ( this.smart_union.active )
         {
-            if ( (&this).include_name )
-                sformat(sink, "<{}>: ", (&this).smart_union.active_name);
+            if ( this.include_name )
+                sformat(sink, "<{}>: ", this.smart_union.active_name);
 
             This.sink = sink;
             scope ( exit ) This.sink = null;
 
-            callWithActive!(formatUnionMember)((&this).smart_union);
+            callWithActive!(formatUnionMember)(this.smart_union);
         }
         else
         {
-            if ( (&this).include_name )
-                sformat(sink, "<{}>", (&this).smart_union.active_name);
+            if ( this.include_name )
+                sformat(sink, "<{}>", this.smart_union.active_name);
         }
     }
 
@@ -181,4 +181,3 @@ unittest
     // s active, plus name formatting.
     test!("==")(format("{}", asActiveField(su, true)), "<s>: hello");
 }
-

--- a/src/ocean/text/json/Json.d
+++ b/src/ocean/text/json/Json.d
@@ -445,7 +445,7 @@ class Json(T) : JsonParser!(T)
         {
             name = key;
             value = val;
-            return (&this);
+            return &this;
         }
     }
 
@@ -470,7 +470,7 @@ class Json(T) : JsonParser!(T)
         Composite reset ()
         {
             head = tail = null;
-            return (&this);
+            return &this;
         }
 
         /***************************************************************
@@ -485,7 +485,7 @@ class Json(T) : JsonParser!(T)
                 tail.next = a, tail = a;
             else
                 head = tail = a;
-            return (&this);
+            return &this;
         }
 
         /***************************************************************
@@ -498,7 +498,7 @@ class Json(T) : JsonParser!(T)
         {
             foreach (attr; set)
                 append (attr);
-            return (&this);
+            return &this;
         }
 
         /***************************************************************
@@ -627,7 +627,7 @@ class Json(T) : JsonParser!(T)
 
         equals_t opEquals (JsonValue rhs)
         {
-            return *(&this) is rhs;
+            return this is rhs;
         }
 
         /***************************************************************
@@ -730,7 +730,7 @@ class Json(T) : JsonParser!(T)
         {
             type = escaped ? Type.String : Type.RawString;
             string = str;
-            return (&this);
+            return &this;
         }
 
         /***************************************************************
@@ -743,7 +743,7 @@ class Json(T) : JsonParser!(T)
         {
             type = Type.Object;
             object = obj;
-            return (&this);
+            return &this;
         }
 
         /***************************************************************
@@ -756,7 +756,7 @@ class Json(T) : JsonParser!(T)
         {
             type = Type.Number;
             number = num;
-            return (&this);
+            return &this;
         }
 
         /***************************************************************
@@ -768,7 +768,7 @@ class Json(T) : JsonParser!(T)
         Value set (bool b)
         {
             type = b ? Type.True : Type.False;
-            return (&this);
+            return &this;
         }
 
         /***************************************************************
@@ -781,7 +781,7 @@ class Json(T) : JsonParser!(T)
         {
             type = Type.Array;
             array = a;
-            return (&this);
+            return &this;
         }
 
         /***************************************************************
@@ -793,7 +793,7 @@ class Json(T) : JsonParser!(T)
         Value reset ()
         {
             type = Type.Null;
-            return (&this);
+            return &this;
         }
 
         /***************************************************************
@@ -931,8 +931,8 @@ class Json(T) : JsonParser!(T)
                 }
             }
 
-            printValue ((&this));
-            return (&this);
+            printValue(&this);
+            return &this;
         }
 
         /***************************************************************
@@ -944,7 +944,7 @@ class Json(T) : JsonParser!(T)
         private Value set (Type type)
         {
             this.type = type;
-            return (&this);
+            return &this;
         }
 
         /***************************************************************

--- a/src/ocean/text/json/JsonParser.d
+++ b/src/ocean/text/json/JsonParser.d
@@ -64,9 +64,9 @@ class JsonParser(T, bool AllowNaN = false)
 
         void reset (Const!(T)[] text)
         {
-            (&this).text = text;
-            (&this).ptr = text.ptr;
-            (&this).end = (&this).ptr + text.length;
+            this.text = text;
+            this.ptr = text.ptr;
+            this.end = this.ptr + text.length;
         }
     }
 

--- a/src/ocean/text/utf/UtfString.d
+++ b/src/ocean/text/utf/UtfString.d
@@ -160,7 +160,7 @@ public struct UtfString ( Char = char, bool pull_dchars = false )
 
     ***************************************************************************/
 
-    public alias typeof((&this)) This;
+    public alias typeof(&this) This;
 
 
     /***************************************************************************
@@ -215,9 +215,9 @@ public struct UtfString ( Char = char, bool pull_dchars = false )
         int res;
         size_t i;
 
-        while ( i < (&this).string.length )
+        while ( i < this.string.length )
         {
-            Char[] process = (&this).string[i..$];
+            Char[] process = this.string[i..$];
 
             size_t width;
             auto c = This.extract(process, width);
@@ -250,9 +250,9 @@ public struct UtfString ( Char = char, bool pull_dchars = false )
         int res;
         size_t i;
 
-        while ( i < (&this).string.length )
+        while ( i < this.string.length )
         {
-            Char[] process = (&this).string[i..$];
+            Char[] process = this.string[i..$];
 
             size_t width;
             auto c = This.extract(process, width);
@@ -284,9 +284,9 @@ public struct UtfString ( Char = char, bool pull_dchars = false )
         int res;
         size_t i;
 
-        while ( i < (&this).string.length )
+        while ( i < this.string.length )
         {
-            Char[] process = (&this).string[i..$];
+            Char[] process = this.string[i..$];
 
             size_t width;
             auto c = This.extract(process, width);
@@ -319,7 +319,7 @@ public struct UtfString ( Char = char, bool pull_dchars = false )
 
     public OutType opIndex ( size_t index )
     {
-        verify((&this).string.length > 0,
+        verify(this.string.length > 0,
             This.stringof ~ ".opIndex - attempted to index into an empty string");
 
         size_t i;
@@ -328,7 +328,7 @@ public struct UtfString ( Char = char, bool pull_dchars = false )
         do
         {
             size_t width;
-            c = This.extract((&this).string[i..$], width);
+            c = This.extract(this.string[i..$], width);
             i += width;
         } while ( count++ < index );
 
@@ -357,11 +357,11 @@ public struct UtfString ( Char = char, bool pull_dchars = false )
 
     public ArrayOutType opSlice ( size_t start, size_t end )
     {
-        verify(end > start, typeof((&this)).stringof ~ ".opSlice - end <= start!");
+        verify(end > start, typeof(this).stringof ~ ".opSlice - end <= start!");
 
         static if ( pull_dchars )
         {
-            return (&this).sliceCopy(start, end, (&this).slice_string);
+            return this.sliceCopy(start, end, this.slice_string);
         }
         else
         {
@@ -369,7 +369,7 @@ public struct UtfString ( Char = char, bool pull_dchars = false )
             size_t char_count;
             size_t src_i;
 
-            while ( src_i < (&this).string.length )
+            while ( src_i < this.string.length )
             {
                 if ( char_count == start )
                 {
@@ -377,10 +377,10 @@ public struct UtfString ( Char = char, bool pull_dchars = false )
                 }
                 if ( char_count >= end )
                 {
-                    return (&this).string[start_i .. src_i];
+                    return this.string[start_i .. src_i];
                 }
 
-                Char[] process = (&this).string[src_i..$];
+                Char[] process = this.string[src_i..$];
 
                 size_t width;
                 This.extract(process, width);
@@ -389,7 +389,7 @@ public struct UtfString ( Char = char, bool pull_dchars = false )
                 char_count++;
             }
 
-            assert(false, typeof((&this)).stringof ~ ".opSlice - end > array length");
+            assert(false, typeof(this).stringof ~ ".opSlice - end > array length");
         }
     }
 
@@ -417,7 +417,7 @@ public struct UtfString ( Char = char, bool pull_dchars = false )
         output.length = 0;
 
         size_t i;
-        foreach ( c; *(&this) )
+        foreach ( c; this )
         {
             if ( i >= start )
             {
@@ -448,7 +448,7 @@ public struct UtfString ( Char = char, bool pull_dchars = false )
     {
         size_t len;
 
-        foreach ( c; *(&this) )
+        foreach ( c; this )
         {
             len++;
         }
@@ -474,7 +474,7 @@ public struct UtfString ( Char = char, bool pull_dchars = false )
     public OutType extract ( bool consume = false )
     {
         size_t width;
-        return (&this).extract(width, consume);
+        return this.extract(width, consume);
     }
 
 
@@ -496,10 +496,10 @@ public struct UtfString ( Char = char, bool pull_dchars = false )
 
     public OutType extract ( out size_t width, bool consume = false )
     {
-        auto extracted = This.extract((&this).string, width);
+        auto extracted = This.extract(this.string, width);
         if ( consume )
         {
-            (&this).string = (&this).string[width..$];
+            this.string = this.string[width..$];
         }
 
         return extracted;

--- a/src/ocean/text/util/EscapeChars.d
+++ b/src/ocean/text/util/EscapeChars.d
@@ -75,7 +75,8 @@ struct EscapeChars
         {
             (&this).copyTokens(tokens);
 
-            str ~= '\0';                                                        // append a 0 to the end, as it is stripped in the scope(exit)
+            // append a 0 to the end, as it is stripped in the scope(exit)
+            str ~= '\0';
 
             scope (exit)
             {
@@ -99,7 +100,8 @@ struct EscapeChars
 
             str.length = str.length + ((&this).occurrences.length * escape.length);
 
-            str[$ - 1] = '\0';                                                  // append a 0 to the end, as it is stripped in the scope(exit)
+            // append a 0 to the end, as it is stripped in the scope(exit)
+            str[$ - 1] = '\0';
 
             foreach_reverse (i, occurrence; (&this).occurrences)
             {

--- a/src/ocean/text/util/EscapeChars.d
+++ b/src/ocean/text/util/EscapeChars.d
@@ -73,7 +73,7 @@ struct EscapeChars
     {
         if (tokens.length)
         {
-            (&this).copyTokens(tokens);
+            this.copyTokens(tokens);
 
             // append a 0 to the end, as it is stripped in the scope(exit)
             str ~= '\0';
@@ -88,22 +88,22 @@ struct EscapeChars
 
             size_t end = str.length - 1;
 
-            (&this).occurrences.length = 0;
-            enableStomping((&this).occurrences);
+            this.occurrences.length = 0;
+            enableStomping(this.occurrences);
 
             for (size_t pos = strcspn(str.ptr, tokens.ptr); pos < end;)
             {
-                (&this).occurrences ~= pos;
+                this.occurrences ~= pos;
 
                 pos += strcspn(str.ptr + ++pos, tokens.ptr);
             }
 
-            str.length = str.length + ((&this).occurrences.length * escape.length);
+            str.length = str.length + (this.occurrences.length * escape.length);
 
             // append a 0 to the end, as it is stripped in the scope(exit)
             str[$ - 1] = '\0';
 
-            foreach_reverse (i, occurrence; (&this).occurrences)
+            foreach_reverse (i, occurrence; this.occurrences)
             {
                 char* src = str.ptr + occurrence;
                 char* dst = src + ((i + 1) * escape.length);
@@ -130,9 +130,9 @@ struct EscapeChars
     private void copyTokens ( cstring tokens )
     out
     {
-        assert ((&this).tokens.length);
-        assert (!(&this).tokens[$ - 1]);
-        assert ((&this).tokens.length - 1 == strlen((&this).tokens.ptr));
+        assert (this.tokens.length);
+        assert (!this.tokens[$ - 1]);
+        assert (this.tokens.length - 1 == strlen(this.tokens.ptr));
     }
     body
     {

--- a/src/ocean/text/util/MetricPrefix.d
+++ b/src/ocean/text/util/MetricPrefix.d
@@ -85,9 +85,9 @@ public struct MetricPrefix
 
     **************************************************************************/
 
-    typeof ((&this)) bin ( T : float ) ( T n )
+    typeof(&this) bin ( T : float ) ( T n )
     {
-        (&this).scaled = n;
+        this.scaled = n;
 
         int i;
 
@@ -104,11 +104,11 @@ public struct MetricPrefix
             i /= 10;
         }
 
-        (&this).scaled = ldexpf((&this).scaled, i * -10);
+        this.scaled = ldexpf(this.scaled, i * -10);
 
-        (&this).prefix = BinaryPrefixes[i];
+        this.prefix = BinaryPrefixes[i];
 
-        return (&this);
+        return &this;
     }
 
     public enum DecimalPrefixes = [cast(wchar)'p', 'n', 'µ', 'm', ' ', 'k', 'M', 'G', 'T'];
@@ -129,11 +129,11 @@ public struct MetricPrefix
 
     **************************************************************************/
 
-    typeof ((&this)) dec ( T : float ) ( T n, int e = 0 )
+    typeof(&this) dec ( T : float ) ( T n, int e = 0 )
     {
         verify (-5 < e && e < 5);
 
-        (&this).scaled = n;
+        this.scaled = n;
 
         int i = 4;
 
@@ -144,7 +144,7 @@ public struct MetricPrefix
                 for (i += e; (n > 1000) && (i+1 < DecimalPrefixes.length); i++)
                 {
                     n           /= 1000;
-                    (&this).scaled /= 1000;
+                    this.scaled /= 1000;
                 }
             }
             else
@@ -152,14 +152,14 @@ public struct MetricPrefix
                 for (i += e; (n < 1) && (i-1 > 0); i--)
                 {
                     n           *= 1000;
-                    (&this).scaled *= 1000;
+                    this.scaled *= 1000;
                 }
             }
         }
 
-        (&this).prefix = DecimalPrefixes[i];
+        this.prefix = DecimalPrefixes[i];
 
-        return (&this);
+        return &this;
     }
 }
 
@@ -218,4 +218,3 @@ public void splitBinaryPrefix ( ulong n, scope void delegate ( char prefix, uint
         output_dg(MetricPrefix.BinaryPrefixes[order], order, order_val);
     }
 }
-

--- a/src/ocean/text/xml/Document.d
+++ b/src/ocean/text/xml/Document.d
@@ -676,7 +676,7 @@ version (Filter)
                 Node prefix (T[] replace)
                 {
                         Array.copy(this.prefixed, replace);
-                        return (&this);
+                        return &this;
                 }
 
                 /***************************************************************
@@ -699,7 +699,7 @@ version (Filter)
                 Node name (T[] replace)
                 {
                         Array.copy(this.localName, replace);
-                        return (&this);
+                        return &this;
                 }
 
                 /***************************************************************
@@ -730,7 +730,7 @@ version (Filter)
                             foreach (child; children)
                                      if (child.id is XmlNodeType.Data)
                                          return child.value (val);
-                        Array.copy((&this).rawValue, val);
+                        Array.copy(this.rawValue, val);
                         mutate;
                 }
 
@@ -804,7 +804,7 @@ version (Filter)
 
                 final XmlPathT.NodeSet query ()
                 {
-                        return doc.xpath.start ((&this));
+                        return doc.xpath.start(&this);
                 }
 
                 /***************************************************************
@@ -981,7 +981,7 @@ version (Filter)
                 {
                         auto node = create (XmlNodeType.Attribute, value);
                         attrib (node.set (prefix, local));
-                        return (&this);
+                        return &this;
                 }
 
                 /***************************************************************
@@ -993,7 +993,7 @@ version (Filter)
                 private Node data_ (T[] data)
                 {
                         append (create (XmlNodeType.Data, data));
-                        return (&this);
+                        return &this;
                 }
 
                 /***************************************************************
@@ -1005,7 +1005,7 @@ version (Filter)
                 private Node cdata_ (T[] cdata)
                 {
                         append (create (XmlNodeType.CData, cdata));
-                        return (&this);
+                        return &this;
                 }
 
                 /***************************************************************
@@ -1017,7 +1017,7 @@ version (Filter)
                 private Node comment_ (T[] comment)
                 {
                         append (create (XmlNodeType.Comment, comment));
-                        return (&this);
+                        return &this;
                 }
 
                 /***************************************************************
@@ -1029,7 +1029,7 @@ version (Filter)
                 private Node pi_ (T[] pi, T[] patch)
                 {
                         append (create(XmlNodeType.PI, pi).patch(patch));
-                        return (&this);
+                        return &this;
                 }
 
                 /***************************************************************
@@ -1041,7 +1041,7 @@ version (Filter)
                 private Node doctype_ (T[] doctype)
                 {
                         append (create (XmlNodeType.Doctype, doctype));
-                        return (&this);
+                        return &this;
                 }
 
                 /***************************************************************
@@ -1054,7 +1054,7 @@ version (Filter)
                 private void attrib (Node node)
                 {
                         verify (node.parent is null);
-                        node.host = (&this);
+                        node.host = &this;
                         if (lastAttr)
                            {
                            lastAttr.nextSibling = node;
@@ -1075,7 +1075,7 @@ version (Filter)
                 private void append (Node node)
                 {
                         verify (node.parent is null);
-                        node.host = (&this);
+                        node.host = &this;
                         if (lastChild)
                            {
                            lastChild.nextSibling = node;
@@ -1096,7 +1096,7 @@ version (Filter)
                 private void prepend (Node node)
                 {
                         verify (node.parent is null);
-                        node.host = (&this);
+                        node.host = &this;
                         if (firstChild)
                            {
                            firstChild.prevSibling = node;
@@ -1117,7 +1117,7 @@ version (Filter)
                 {
                         Array.copy(this.localName, local);
                         Array.copy(this.prefixed, prefix);
-                        return (&this);
+                        return &this;
                 }
 
                 /***************************************************************
@@ -1143,7 +1143,7 @@ version (Filter)
                 private Node remove()
                 {
                         if (! host)
-                              return (&this);
+                              return &this;
 
                         mutate;
                         if (prevSibling && nextSibling)
@@ -1157,7 +1157,7 @@ version (Filter)
                         else
                            if (nextSibling)
                               {
-                              verify(host.firstChild == (&this));
+                              verify(host.firstChild == &this);
                               parent.firstChild = nextSibling;
                               nextSibling.prevSibling = null;
                               nextSibling = null;
@@ -1168,7 +1168,7 @@ version (Filter)
                                  {
                                  if (prevSibling)
                                     {
-                                    verify(host.lastChild == (&this));
+                                    verify(host.lastChild == &this);
                                     host.lastChild = prevSibling;
                                     prevSibling.nextSibling = null;
                                     prevSibling = null;
@@ -1176,8 +1176,8 @@ version (Filter)
                                     }
                                  else
                                     {
-                                    verify(host.firstChild == (&this));
-                                    verify(host.lastChild == (&this));
+                                    verify(host.firstChild == &this);
+                                    verify(host.lastChild == &this);
                                     host.firstChild = null;
                                     host.lastChild = null;
                                     host = null;
@@ -1187,7 +1187,7 @@ version (Filter)
                                  {
                                  if (prevSibling)
                                     {
-                                    verify(host.lastAttr == (&this));
+                                    verify(host.lastAttr == &this);
                                     host.lastAttr = prevSibling;
                                     prevSibling.nextSibling = null;
                                     prevSibling = null;
@@ -1195,15 +1195,15 @@ version (Filter)
                                     }
                                  else
                                     {
-                                    verify(host.firstAttr == (&this));
-                                    verify(host.lastAttr == (&this));
+                                    verify(host.firstAttr == &this);
+                                    verify(host.lastAttr == &this);
                                     host.firstAttr = null;
                                     host.lastAttr = null;
                                     host = null;
                                     }
                                  }
 
-                        return (&this);
+                        return &this;
                 }
 
                 /***************************************************************
@@ -1221,7 +1221,7 @@ version (Filter)
                 {
                         end = text.ptr + text.length;
                         start = text.ptr;
-                        return (&this);
+                        return &this;
                 }
 
                 /***************************************************************
@@ -1233,12 +1233,12 @@ version (Filter)
 
                 private Node mutate ()
                 {
-                        auto node = (&this);
+                        auto node = &this;
                         do {
                            node.end = null;
                            } while ((node = node.host) !is null);
 
-                        return (&this);
+                        return &this;
                 }
 
                 /***************************************************************
@@ -1277,7 +1277,7 @@ version (Filter)
 
                 private void migrate (Document host)
                 {
-                        (&this).doc = host;
+                        this.doc = host;
                         foreach (attr; attributes)
                                  attr.migrate (host);
                         foreach (child; children)

--- a/src/ocean/text/xml/PullParser.d
+++ b/src/ocean/text/xml/PullParser.d
@@ -679,10 +679,10 @@ package struct XmlText(Ch)
 
     final void reset(Ch[] newText)
     {
-        (&this).text = newText;
-        (&this).len = newText.length;
-        (&this).point = text.ptr;
-        (&this).end = point + len;
+        this.text = newText;
+        this.len = newText.length;
+        this.point = text.ptr;
+        this.end = point + len;
     }
 
     static Const!(ubyte[64]) name =

--- a/src/ocean/time/StopWatch.d
+++ b/src/ocean/time/StopWatch.d
@@ -87,7 +87,7 @@ public struct StopWatch
 
         double sec ()
         {
-                return multiplier * (&this).microsec;
+                return multiplier * this.microsec;
         }
 
         /***********************************************************************

--- a/src/ocean/time/Time.d
+++ b/src/ocean/time/Time.d
@@ -653,7 +653,7 @@ struct Time
 
         Time date ()
         {
-                return *(&this) - TimeOfDay.modulo24(ticks_);
+                return this - TimeOfDay.modulo24(ticks_);
         }
 
         /**********************************************************************

--- a/src/ocean/transition.d
+++ b/src/ocean/transition.d
@@ -209,7 +209,7 @@ unittest
 
         equals_t opEquals (S rhs)
         {
-            return (&this).opCmp(rhs) == 0;
+            return this.opCmp(rhs) == 0;
         }
     }
 

--- a/src/ocean/util/DeepReset.d
+++ b/src/ocean/util/DeepReset.d
@@ -326,13 +326,13 @@ unittest
 
                 void InitStructure()
                 {
-                    (&this).h = -52;
-                    (&this).i.copy("even even more test text");
-                    (&this).j.length = 3;
-                    (&this).j[0].copy("abc");
-                    (&this).j[1].copy("def");
-                    (&this).j[2].copy("ghi");
-                    foreach ( ref item; (&this).k )
+                    this.h = -52;
+                    this.i.copy("even even more test text");
+                    this.j.length = 3;
+                    this.j[0].copy("abc");
+                    this.j[1].copy("def");
+                    this.j[2].copy("ghi");
+                    foreach ( ref item; this.k )
                     {
                         item = 120000;
                     }
@@ -341,12 +341,12 @@ unittest
 
             void InitStructure()
             {
-                (&this).d = 32;
-                (&this).e.copy("even more test text");
+                this.d = 32;
+                this.e.copy("even more test text");
 
-                (&this).f.length = 1;
-                (&this).f[0].copy("abc");
-                foreach ( ref item; (&this).g )
+                this.f.length = 1;
+                this.f[0].copy("abc");
+                foreach ( ref item; this.g )
                 {
                     item = 32400;
                 }

--- a/src/ocean/util/aio/internal/JobQueue.d
+++ b/src/ocean/util/aio/internal/JobQueue.d
@@ -192,16 +192,16 @@ public static struct Job
 
     public void finished ()
     {
-        if ((&this).finalize_results)
+        if (this.finalize_results)
         {
-            this.finalize_results((&this));
+            this.finalize_results(&this);
         }
 
-        if ((&this).finish_callback_dgs.length)
+        if (this.finish_callback_dgs.length)
         {
-            foreach (dg; (&this).finish_callback_dgs)
+            foreach (dg; this.finish_callback_dgs)
             {
-                dg((&this).return_value);
+                dg(this.return_value);
             }
         }
     }
@@ -218,7 +218,7 @@ public static struct Job
     public Job* registerCallback (scope void delegate(ssize_t) dg)
     {
         this.finish_callback_dgs ~= dg;
-        return (&this);
+        return &this;
     }
 
     /***************************************************************************
@@ -230,7 +230,7 @@ public static struct Job
 
     public void recycle ()
     {
-        this.owner_queue.recycleJob((&this), &lock_mutex, &unlock_mutex);
+        this.owner_queue.recycleJob(&this, &lock_mutex, &unlock_mutex);
     }
 }
 

--- a/src/ocean/util/config/ConfigFiller.d
+++ b/src/ocean/util/config/ConfigFiller.d
@@ -294,11 +294,11 @@ struct MinMax ( T, T min, T max, T init = T.init )
     private void check_ ( bool found, cstring group, cstring name )
     {
         enforce!(ConfigException)(
-            Value((&this).value) >= min,
+            Value(this.value) >= min,
             format("Configuration key {}.{} is smaller than allowed minimum of {}",
                    group, name, min));
         enforce!(ConfigException)(
-            Value((&this).value) <= max,
+            Value(this.value) <= max,
             format("Configuration key {}.{} is bigger than allowed maximum of {}",
                    group, name, max));
     }
@@ -342,7 +342,7 @@ struct Min ( T, T min, T init = T.init )
     private void check_ ( bool found, cstring group, cstring name )
     {
         enforce!(ConfigException)(
-            Value((&this).value) >= min,
+            Value(this.value) >= min,
             format("Configuration key {}.{} is smaller than allowed minimum of {}",
                    group, name, min));
     }
@@ -387,7 +387,7 @@ struct Max ( T, T max, T init = T.init )
     private void check_ ( bool found, cstring group, cstring name )
     {
         enforce!(ConfigException)(
-            Value((&this).value) <= max,
+            Value(this.value) <= max,
             format("Configuration key {}.{} is bigger than allowed maximum of {}",
                    group, name, max));
     }
@@ -460,7 +460,7 @@ struct LimitCmp ( T, T init = T.init, alias comp = defComp!(T), Set... )
                     ~ typeof(el).stringof ~ " to " ~ T.stringof ~ " )"
             );
 
-            if ( comp(Value((&this).value), el) )
+            if ( comp(Value(this.value), el) )
                 return;
         }
 
@@ -474,7 +474,7 @@ struct LimitCmp ( T, T init = T.init, alias comp = defComp!(T), Set... )
         throw new ConfigException(
             format("Value '{}' of configuration key {}.{} is not within the "
                    ~ "set of allowed values ({})",
-                   Value((&this).value), group, name, allowed_vals[2 .. $]));
+                   Value(this.value), group, name, allowed_vals[2 .. $]));
     }
 }
 
@@ -553,7 +553,7 @@ struct SetInfo ( T )
     {
         if ( set )
         {
-            return Value((&this).value);
+            return Value(this.value);
         }
 
         return def;
@@ -581,7 +581,7 @@ struct SetInfo ( T )
 
     private void check_ ( bool found, cstring group, cstring name )
     {
-        (&this).set = found;
+        this.set = found;
     }
 }
 
@@ -812,7 +812,7 @@ struct ConfigIterator ( T, Source = ConfigParser )
 
     invariant()
     {
-        assert((&this).config !is null,
+        assert(this.config !is null,
             "ConfigFiller.ConfigIterator: Cannot have null config");
     }
 
@@ -829,7 +829,7 @@ struct ConfigIterator ( T, Source = ConfigParser )
     {
         int result = 0;
 
-        foreach ( key; (&this).config )
+        foreach ( key; this.config )
         {
             static if (is (T == struct))
             {
@@ -840,13 +840,13 @@ struct ConfigIterator ( T, Source = ConfigParser )
                 scope T instance = new T;
             }
 
-            if ( key.length > (&this).root.length
-                 && key[0 .. (&this).root.length] == (&this).root
-                 && key[(&this).root.length] == '.' )
+            if ( key.length > this.root.length
+                 && key[0 .. this.root.length] == this.root
+                 && key[this.root.length] == '.' )
             {
-                .fill(key, instance, (&this).config);
+                .fill(key, instance, this.config);
 
-                auto name = key[(&this).root.length + 1 .. $];
+                auto name = key[this.root.length + 1 .. $];
                 result = dg(name, instance);
 
                 if (result) break;
@@ -872,13 +872,13 @@ struct ConfigIterator ( T, Source = ConfigParser )
     {
         int result = 0;
 
-        foreach ( key; (&this).config )
+        foreach ( key; this.config )
         {
-            if ( key.length > (&this).root.length
-                 && key[0 .. (&this).root.length] == (&this).root
-                 && key[(&this).root.length] == '.' )
+            if ( key.length > this.root.length
+                 && key[0 .. this.root.length] == this.root
+                 && key[this.root.length] == '.' )
             {
-                auto name = key[(&this).root.length + 1 .. $];
+                auto name = key[this.root.length + 1 .. $];
                 result = dg(name);
 
                 if (result) break;
@@ -903,9 +903,9 @@ struct ConfigIterator ( T, Source = ConfigParser )
 
     public void fill ( cstring name, ref T instance )
     {
-        auto key = (&this).root ~ "." ~ name;
+        auto key = this.root ~ "." ~ name;
 
-        .fill(key, instance, (&this).config);
+        .fill(key, instance, this.config);
     }
 }
 

--- a/src/ocean/util/config/ConfigParser.d
+++ b/src/ocean/util/config/ConfigParser.d
@@ -105,9 +105,9 @@ public class ConfigParser
 
         public int opApply ( scope int delegate ( ref istring key, ref T val ) dg )
         {
-            if ( (&this).vars !is null )
+            if ( this.vars !is null )
             {
-                foreach ( key, valnode; *(&this).vars )
+                foreach ( key, valnode; *this.vars )
                 {
                     auto val = conv!(T)(valnode.value);
 
@@ -128,7 +128,7 @@ public class ConfigParser
 
         public int opApply ( scope int delegate ( ref istring x ) dg )
         {
-            return (&this).opApply(
+            return this.opApply(
                 (ref istring key, ref istring val)
                 {
                     return dg(key);
@@ -398,7 +398,7 @@ public class ConfigParser
             {
                 int result = 0;
 
-                foreach ( ref line; lines((&this).data) )
+                foreach ( ref line; lines(this.data) )
                 {
                     result = dg(line);
 

--- a/src/ocean/util/container/Clink.d
+++ b/src/ocean/util/container/Clink.d
@@ -42,7 +42,7 @@ struct Clink (V)
 
     Ref set (V v)
     {
-            return set (v, (&this), (&this));
+            return set (v, &this, &this);
     }
 
     /***********************************************************************
@@ -59,7 +59,7 @@ struct Clink (V)
             value = v;
             prev = p;
             next = n;
-            return (&this);
+            return &this;
     }
 
     /**
@@ -68,7 +68,7 @@ struct Clink (V)
 
     bool singleton()
     {
-            return next is (&this);
+            return next is &this;
     }
 
     void linkNext (Ref p)
@@ -77,7 +77,7 @@ struct Clink (V)
                {
                next.prev = p;
                p.next = next;
-               p.prev = (&this);
+               p.prev = &this;
                next = p;
                }
     }
@@ -88,7 +88,7 @@ struct Clink (V)
 
     void addNext (V v, scope Ref delegate() alloc)
     {
-            auto p = alloc().set (v, (&this), next);
+            auto p = alloc().set (v, &this, next);
             next.prev = p;
             next = p;
     }
@@ -100,7 +100,7 @@ struct Clink (V)
     Ref addPrev (V v, scope Ref delegate() alloc)
     {
             auto p = prev;
-            auto c = alloc().set (v, p, (&this));
+            auto c = alloc().set (v, p, &this);
             p.next = c;
             prev = c;
             return c;
@@ -116,7 +116,7 @@ struct Clink (V)
                {
                prev.next = p;
                p.prev = prev;
-               p.next = (&this);
+               p.next = &this;
                prev = p;
                }
     }
@@ -128,11 +128,11 @@ struct Clink (V)
     int size()
     {
             int c = 0;
-            auto p = (&this);
+            auto p = &this;
             do {
                ++c;
                p = p.next;
-               } while (p !is (&this));
+               } while (p !is &this);
             return c;
     }
 
@@ -143,12 +143,12 @@ struct Clink (V)
 
     Ref find (V element)
     {
-            auto p = (&this);
+            auto p = &this;
             do {
                if (element == p.value)
                    return p;
                p = p.next;
-               } while (p !is (&this));
+               } while (p !is &this);
             return null;
     }
 
@@ -160,12 +160,12 @@ struct Clink (V)
     int count (V element)
     {
             int c = 0;
-            auto p = (&this);
+            auto p = &this;
             do {
                if (element == p.value)
                    ++c;
                p = p.next;
-               } while (p !is (&this));
+               } while (p !is &this);
             return c;
     }
 
@@ -175,7 +175,7 @@ struct Clink (V)
 
     Ref nth (size_t n)
     {
-            auto p = (&this);
+            auto p = &this;
             for (ptrdiff_t i = 0; i < n; ++i)
                  p = p.next;
             return p;
@@ -190,7 +190,7 @@ struct Clink (V)
     void unlinkNext ()
     {
             auto nn = next.next;
-            nn.prev = (&this);
+            nn.prev = &this;
             next = nn;
     }
 
@@ -202,7 +202,7 @@ struct Clink (V)
     void unlinkPrev ()
     {
             auto pp = prev.prev;
-            pp.next = (&this);
+            pp.next = &this;
             prev = pp;
     }
 
@@ -218,8 +218,8 @@ struct Clink (V)
             auto n = next;
             p.next = n;
             n.prev = p;
-            prev = (&this);
-            next = (&this);
+            prev = &this;
+            next = &this;
     }
 
     /**
@@ -228,7 +228,7 @@ struct Clink (V)
 
     Ref copyList (scope Ref delegate() alloc)
     {
-            auto hd = (&this);
+            auto hd = &this;
 
             auto newlist = alloc().set (hd.value, null, null);
             auto current = newlist;
@@ -243,5 +243,3 @@ struct Clink (V)
             return newlist;
     }
 }
-
-

--- a/src/ocean/util/container/Container.d
+++ b/src/ocean/util/container/Container.d
@@ -205,7 +205,7 @@ struct Container
 
                 void config (size_t chunks, size_t allocate=0)
                 {
-                        (&this).chunks = chunks;
+                        this.chunks = chunks;
                         if (allocate)
                             for (ptrdiff_t i=allocate/chunks+1; i--;)
                                  newlist;
@@ -363,7 +363,7 @@ struct Container
 
                 void config (size_t chunks, int allocate=0)
                 {
-                        (&this).chunks = chunks;
+                        this.chunks = chunks;
                         if (allocate)
                             for (int i=allocate/chunks+1; i--;)
                                  newlist;
@@ -883,5 +883,3 @@ else
    template DefaultCollect(T) {alias ChunkGC!(T) DefaultCollect;}
 
 }
-
-

--- a/src/ocean/util/container/HashRangeMap.d
+++ b/src/ocean/util/container/HashRangeMap.d
@@ -90,7 +90,7 @@ public struct HashRangeMap ( Value )
 
     invariant()
     {
-        assert((&this).ranges.length == (&this).values.length,
+        assert(this.ranges.length == this.values.length,
                "HashRangeMap: length mismatch between ranges and values");
     }
 
@@ -106,7 +106,7 @@ public struct HashRangeMap ( Value )
 
     public bool empty ( )
     {
-        return (&this).length == 0;
+        return this.length == 0;
     }
 
     unittest
@@ -139,7 +139,7 @@ public struct HashRangeMap ( Value )
 
     public size_t length ( )
     {
-        return (&this).ranges.length;
+        return this.ranges.length;
     }
 
     unittest
@@ -191,16 +191,16 @@ public struct HashRangeMap ( Value )
         enforce(!range.is_empty, "An empty range can't be put in HashRangeMap");
 
         size_t insert_place;
-        added = !bsearch((&this).ranges, range, insert_place);
+        added = !bsearch(this.ranges, range, insert_place);
 
         if (added)
         {
-            insertShift((&this).ranges, insert_place);
-            (&this).ranges[insert_place] = range;
-            insertShift((&this).values, insert_place);
+            insertShift(this.ranges, insert_place);
+            this.ranges[insert_place] = range;
+            insertShift(this.values, insert_place);
         }
 
-        return &(&this).values[insert_place];
+        return &this.values[insert_place];
     }
 
 
@@ -219,12 +219,12 @@ public struct HashRangeMap ( Value )
     public bool remove ( HashRange range )
     {
         size_t remove_place;
-        bool result = bsearch((&this).ranges, range, remove_place);
+        bool result = bsearch(this.ranges, range, remove_place);
 
         if (result)
         {
-            removeShift((&this).ranges, remove_place);
-            removeShift((&this).values, remove_place);
+            removeShift(this.ranges, remove_place);
+            removeShift(this.values, remove_place);
         }
 
         return result;
@@ -239,11 +239,11 @@ public struct HashRangeMap ( Value )
 
     public void clear ()
     {
-        (&this).ranges.length = 0;
-        enableStomping((&this).ranges);
+        this.ranges.length = 0;
+        enableStomping(this.ranges);
 
-        (&this).values.length = 0;
-        enableStomping((&this).values);
+        this.values.length = 0;
+        enableStomping(this.values);
     }
 
     unittest
@@ -277,10 +277,10 @@ public struct HashRangeMap ( Value )
     public Value* opIn_r ( HashRange range )
     {
         size_t insert_place;
-        if (!bsearch((&this).ranges, range, insert_place))
+        if (!bsearch(this.ranges, range, insert_place))
             return null;
 
-        return &(&this).values[insert_place];
+        return &this.values[insert_place];
     }
 
 
@@ -295,9 +295,9 @@ public struct HashRangeMap ( Value )
     public int opApply ( scope int delegate ( ref HashRange r, ref Value v ) dg )
     {
         int result = 0;
-        foreach (i, range; (&this).ranges)
+        foreach (i, range; this.ranges)
         {
-            result = dg(range, (&this).values[i]);
+            result = dg(range, this.values[i]);
 
             if(result)
                 break;
@@ -321,7 +321,7 @@ public struct HashRangeMap ( Value )
 
     public bool isTessellated ()
     {
-        return HashRange(hash_t.min, hash_t.max).isTessellatedBy((&this).ranges);
+        return HashRange(hash_t.min, hash_t.max).isTessellatedBy(this.ranges);
     }
 
     unittest
@@ -402,8 +402,8 @@ public struct HashRangeMap ( Value )
 
     public bool hasGap ()
     {
-        return extent((&this).ranges) != HashRange(hash_t.min, hash_t.max)
-               || ocean.math.Range.hasGap((&this).ranges);
+        return extent(this.ranges) != HashRange(hash_t.min, hash_t.max)
+               || ocean.math.Range.hasGap(this.ranges);
     }
 
     unittest
@@ -465,7 +465,7 @@ public struct HashRangeMap ( Value )
 
     public bool hasOverlap ()
     {
-        return ocean.math.Range.hasOverlap((&this).ranges);
+        return ocean.math.Range.hasOverlap(this.ranges);
     }
 
     unittest
@@ -592,12 +592,12 @@ unittest
 
         equals_t opEquals(S other)
         {
-            return (&this).x == other.x;
+            return this.x == other.x;
         }
 
         istring toString()
         {
-            return "S(" ~ to!(istring)((&this).x) ~ ")";
+            return "S(" ~ to!(istring)(this.x) ~ ")";
         }
     }
 

--- a/src/ocean/util/container/RedBlack.d
+++ b/src/ocean/util/container/RedBlack.d
@@ -105,7 +105,7 @@ struct RedBlack (V, A = AttributeDummy)
                 right = null;
                 parent = null;
                 color = BLACK;
-                return (&this);
+                return &this;
         }
 
         /**
@@ -137,14 +137,14 @@ struct RedBlack (V, A = AttributeDummy)
                 // So restrict to the following
 
                 verify(parent is null ||
-                       (&this) is parent.left ||
-                       (&this) is parent.right);
+                       &this is parent.left ||
+                       &this is parent.right);
 
                 verify(left is null ||
-                       (&this) is left.parent);
+                       &this is left.parent);
 
                 verify(right is null ||
-                       (&this) is right.parent);
+                       &this is right.parent);
 
                 verify(color is BLACK ||
                        (colorOf(left) is BLACK) && (colorOf(right) is BLACK));
@@ -161,7 +161,7 @@ struct RedBlack (V, A = AttributeDummy)
 
         Ref leftmost ()
         {
-                auto p = (&this);
+                auto p = &this;
                 for ( ; p.left; p = p.left) {}
                 return p;
         }
@@ -171,7 +171,7 @@ struct RedBlack (V, A = AttributeDummy)
         **/
         Ref rightmost ()
         {
-                auto p = (&this);
+                auto p = &this;
                 for ( ; p.right; p = p.right) {}
                 return p;
         }
@@ -181,7 +181,7 @@ struct RedBlack (V, A = AttributeDummy)
         **/
         Ref root ()
         {
-                auto p = (&this);
+                auto p = &this;
                 for ( ; p.parent; p = p.parent) {}
                 return p;
         }
@@ -206,7 +206,7 @@ struct RedBlack (V, A = AttributeDummy)
                     return right.leftmost;
 
                 auto p = parent;
-                auto ch = (&this);
+                auto ch = &this;
                 while (p && ch is p.right)
                       {
                       ch = p;
@@ -225,7 +225,7 @@ struct RedBlack (V, A = AttributeDummy)
                     return left.rightmost;
 
                 auto p = parent;
-                auto ch = (&this);
+                auto ch = &this;
                 while (p && ch is p.left)
                       {
                       ch = p;
@@ -256,7 +256,7 @@ struct RedBlack (V, A = AttributeDummy)
 
         Ref find (V value, Compare!(V) cmp)
         {
-                auto t = (&this);
+                auto t = &this;
                 for (;;)
                     {
                     auto diff = cmp (value, t.value);
@@ -282,9 +282,9 @@ struct RedBlack (V, A = AttributeDummy)
         **/
         Ref findFirst (V value, Compare!(V) cmp, bool after = true)
         {
-                auto t = (&this);
-                auto tLower = (&this);
-                auto tGreater  = (&this);
+                auto t = &this;
+                auto tLower = &this;
+                auto tGreater  = &this;
 
                 for (;;)
                     {
@@ -329,7 +329,7 @@ struct RedBlack (V, A = AttributeDummy)
         int count (V value, Compare!(V) cmp)
         {
                 auto c = 0;
-                auto t = (&this);
+                auto t = &this;
                 while (t)
                       {
                       int diff = cmp (value, t.value);
@@ -360,7 +360,7 @@ struct RedBlack (V, A = AttributeDummy)
         {
         Ref findAttribute (A attribute, Compare!(A) cmp)
         {
-                auto t = (&this);
+                auto t = &this;
 
                 while (t)
                       {
@@ -388,7 +388,7 @@ struct RedBlack (V, A = AttributeDummy)
         int countAttribute (A attrib, Compare!(A) cmp)
         {
                 int c = 0;
-                auto t = (&this);
+                auto t = &this;
 
                 while (t)
                       {
@@ -414,7 +414,7 @@ struct RedBlack (V, A = AttributeDummy)
         **/
         Ref find (V value, A attribute, Compare!(V) cmp)
         {
-                auto t = (&this);
+                auto t = &this;
 
                 for (;;)
                     {
@@ -478,7 +478,7 @@ struct RedBlack (V, A = AttributeDummy)
         Ref insertLeft (Ref cell, Ref root)
         {
                 left = cell;
-                cell.parent = (&this);
+                cell.parent = &this;
                 return cell.fixAfterInsertion (root);
         }
 
@@ -494,7 +494,7 @@ struct RedBlack (V, A = AttributeDummy)
         Ref insertRight (Ref cell, Ref root)
         {
                 right = cell;
-                cell.parent = (&this);
+                cell.parent = &this;
                 return cell.fixAfterInsertion (root);
         }
 
@@ -521,7 +521,7 @@ struct RedBlack (V, A = AttributeDummy)
                    // To work nicely with arbitrary subclasses of Ref, we don't want to
                    // just copy successor's fields. since we don't know what
                    // they are.  Instead we swap positions _in the tree.
-                   root = swapPosition ((&this), s, root);
+                   root = swapPosition(&this, s, root);
                    }
 
                 // Start fixup at replacement node (normally a child).
@@ -530,15 +530,15 @@ struct RedBlack (V, A = AttributeDummy)
                 if (left is null && right is null)
                    {
                    if (color is BLACK)
-                       root = (&this).fixAfterDeletion (root);
+                       root = this.fixAfterDeletion (root);
 
                    // Unlink  (Couldn't before since fixAfterDeletion needs parent ptr)
                    if (parent)
                       {
-                      if ((&this) is parent.left)
+                      if (&this is parent.left)
                           parent.left = null;
                       else
-                         if ((&this) is parent.right)
+                         if (&this is parent.right)
                              parent.right = null;
                       parent = null;
                       }
@@ -555,7 +555,7 @@ struct RedBlack (V, A = AttributeDummy)
                    if (parent is null)
                        root = replacement;
                    else
-                      if ((&this) is parent.left)
+                      if (&this is parent.left)
                           parent.left = replacement;
                       else
                          parent.right = replacement;
@@ -770,18 +770,18 @@ struct RedBlack (V, A = AttributeDummy)
                 right = r.left;
 
                 if (r.left)
-                    r.left.parent = (&this);
+                    r.left.parent = &this;
 
                 r.parent = parent;
                 if (parent is null)
                     root = r;
                 else
-                   if (parent.left is (&this))
+                   if (parent.left is &this)
                        parent.left = r;
                    else
                       parent.right = r;
 
-                r.left = (&this);
+                r.left = &this;
                 parent = r;
                 return root;
         }
@@ -793,18 +793,18 @@ struct RedBlack (V, A = AttributeDummy)
                 left = l.right;
 
                 if (l.right !is null)
-                   l.right.parent = (&this);
+                   l.right.parent = &this;
 
                 l.parent = parent;
                 if (parent is null)
                     root = l;
                 else
-                   if (parent.right is (&this))
+                   if (parent.right is &this)
                        parent.right = l;
                    else
                       parent.left = l;
 
-                l.right = (&this);
+                l.right = &this;
                 parent = l;
                 return root;
         }
@@ -814,7 +814,7 @@ struct RedBlack (V, A = AttributeDummy)
         package Ref fixAfterInsertion (Ref root)
         {
                 color = RED;
-                auto x = (&this);
+                auto x = &this;
 
                 while (x && x !is root && x.parent.color is RED)
                       {
@@ -876,7 +876,7 @@ struct RedBlack (V, A = AttributeDummy)
         /** From CLR **/
         package Ref fixAfterDeletion(Ref root)
         {
-                auto x = (&this);
+                auto x = &this;
                 while (x !is root && colorOf(x) is BLACK)
                       {
                       if (x is leftOf(parentOf(x)))

--- a/src/ocean/util/container/Slink.d
+++ b/src/ocean/util/container/Slink.d
@@ -88,13 +88,13 @@ struct Slink (V, K=KeyDummy, bool Identity = false, bool HashCache = false)
                 {
                         static if (Identity == true)
                         {
-                           for (auto p=(&this); p; p = p.next)
+                           for (auto p= &this; p; p = p.next)
                                 if (key is p.key)
                                     return p;
                         }
                         else
                         {
-                           for (auto p=(&this); p; p = p.next)
+                           for (auto p= &this; p; p = p.next)
                                 if (key == p.key)
                                     return p;
                         }
@@ -105,13 +105,13 @@ struct Slink (V, K=KeyDummy, bool Identity = false, bool HashCache = false)
                 {
                         static if (Identity == true)
                         {
-                           for (auto p=(&this); p; p = p.next)
+                           for (auto p= &this; p; p = p.next)
                                 if (key is p.key && value == p.value)
                                     return p;
                         }
                         else
                         {
-                           for (auto p=(&this); p; p = p.next)
+                           for (auto p= &this; p; p = p.next)
                                 if (key == p.key && value == p.value)
                                     return p;
                         }
@@ -123,13 +123,13 @@ struct Slink (V, K=KeyDummy, bool Identity = false, bool HashCache = false)
                         int i = 0;
                         static if (Identity == true)
                         {
-                           for (auto p=(&this); p; p = p.next, ++i)
+                           for (auto p= &this; p; p = p.next, ++i)
                                 if (key is p.key)
                                     return i;
                         }
                         else
                         {
-                           for (auto p=(&this); p; p = p.next, ++i)
+                           for (auto p= &this; p; p = p.next, ++i)
                                 if (key == p.key)
                                     return i;
                         }
@@ -141,13 +141,13 @@ struct Slink (V, K=KeyDummy, bool Identity = false, bool HashCache = false)
                         int i = 0;
                         static if (Identity == true)
                         {
-                           for (auto p=(&this); p; p = p.next, ++i)
+                           for (auto p= &this; p; p = p.next, ++i)
                                 if (key is p.key && value == p.value)
                                     return i;
                         }
                         else
                         {
-                           for (auto p=(&this); p; p = p.next, ++i)
+                           for (auto p= &this; p; p = p.next, ++i)
                                 if (key == p.key && value == p.value)
                                     return i;
                         }
@@ -159,13 +159,13 @@ struct Slink (V, K=KeyDummy, bool Identity = false, bool HashCache = false)
                         int c = 0;
                         static if (Identity == true)
                         {
-                           for (auto p=(&this); p; p = p.next)
+                           for (auto p= &this; p; p = p.next)
                                 if (key is p.key)
                                     ++c;
                         }
                         else
                         {
-                           for (auto p=(&this); p; p = p.next)
+                           for (auto p= &this; p; p = p.next)
                                 if (key == p.key)
                                     ++c;
                         }
@@ -177,13 +177,13 @@ struct Slink (V, K=KeyDummy, bool Identity = false, bool HashCache = false)
                         int c = 0;
                         static if (Identity == true)
                         {
-                           for (auto p=(&this); p; p = p.next)
+                           for (auto p= &this; p; p = p.next)
                                 if (key is p.key && value == p.value)
                                     ++c;
                         }
                         else
                         {
-                           for (auto p=(&this); p; p = p.next)
+                           for (auto p= &this; p; p = p.next)
                                 if (key == p.key && value == p.value)
                                     ++c;
                         }
@@ -203,7 +203,7 @@ struct Slink (V, K=KeyDummy, bool Identity = false, bool HashCache = false)
         {
                 next = n;
                 value = v;
-                return (&this);
+                return &this;
         }
 
         /***********************************************************************
@@ -246,7 +246,7 @@ struct Slink (V, K=KeyDummy, bool Identity = false, bool HashCache = false)
 
         final Ref find (V element)
         {
-                for (auto p = (&this); p; p = p.next)
+                for (auto p = &this; p; p = p.next)
                      if (element == p.value)
                          return p;
                 return null;
@@ -262,7 +262,7 @@ struct Slink (V, K=KeyDummy, bool Identity = false, bool HashCache = false)
         final int index (V element)
         {
                 int i;
-                for (auto p = (&this); p; p = p.next, ++i)
+                for (auto p = &this; p; p = p.next, ++i)
                      if (element == p.value)
                          return i;
 
@@ -278,7 +278,7 @@ struct Slink (V, K=KeyDummy, bool Identity = false, bool HashCache = false)
         final int count (V element)
         {
                 int c;
-                for (auto p = (&this); p; p = p.next)
+                for (auto p = &this; p; p = p.next)
                      if (element == p.value)
                          ++c;
                 return c;
@@ -293,7 +293,7 @@ struct Slink (V, K=KeyDummy, bool Identity = false, bool HashCache = false)
         final int count ()
         {
                 int c;
-                for (auto p = (&this); p; p = p.next)
+                for (auto p = &this; p; p = p.next)
                      ++c;
                 return c;
         }
@@ -307,7 +307,7 @@ struct Slink (V, K=KeyDummy, bool Identity = false, bool HashCache = false)
 
         final Ref tail ()
         {
-                auto p = (&this);
+                auto p = &this;
                 while (p.next)
                        p = p.next;
                 return p;
@@ -323,7 +323,7 @@ struct Slink (V, K=KeyDummy, bool Identity = false, bool HashCache = false)
         {
                 enforce(n >= 0);
 
-                auto p = (&this);
+                auto p = &this;
                 for (long i; i < n && p; ++i)
                      p = p.next;
                 return p;

--- a/src/ocean/util/container/VoidBufferAsArrayOf.d
+++ b/src/ocean/util/container/VoidBufferAsArrayOf.d
@@ -71,7 +71,7 @@ public struct VoidBufferAsArrayOf ( T )
     // The length of the buffer must always be an even multiple of T.sizeof.
     invariant ( )
     {
-        assert((&this).buffer.length % T.sizeof == 0);
+        assert(this.buffer.length % T.sizeof == 0);
     }
 
     /***************************************************************************
@@ -83,7 +83,7 @@ public struct VoidBufferAsArrayOf ( T )
 
     public T[] array ( )
     {
-        return cast(T[])(*(&this).buffer);
+        return cast(T[])(*this.buffer);
     }
 
     /***************************************************************************
@@ -95,7 +95,7 @@ public struct VoidBufferAsArrayOf ( T )
 
     public size_t length ( )
     {
-        return (&this).buffer.length / T.sizeof;
+        return this.buffer.length / T.sizeof;
     }
 
     /***************************************************************************
@@ -109,8 +109,8 @@ public struct VoidBufferAsArrayOf ( T )
 
     public void length ( size_t len )
     {
-        (&this).buffer.length = len * T.sizeof;
-        enableStomping(*(&this).buffer);
+        this.buffer.length = len * T.sizeof;
+        enableStomping(*this.buffer);
     }
 
     /***************************************************************************
@@ -133,7 +133,7 @@ public struct VoidBufferAsArrayOf ( T )
 
     public T[] opCatAssign ( in T[] arr )
     {
-        return cast(T[])((*(&this).buffer) ~= cast(void[])arr);
+        return cast(T[])((*this.buffer) ~= cast(void[])arr);
     }
 
     /***************************************************************************
@@ -153,7 +153,7 @@ public struct VoidBufferAsArrayOf ( T )
 
     public T[] opCatAssign ( in T element )
     {
-        return (&this).opCatAssign((&element)[0 .. 1]);
+        return this.opCatAssign((&element)[0 .. 1]);
     }
 }
 

--- a/src/ocean/util/container/btree/BTreeMap.d
+++ b/src/ocean/util/container/btree/BTreeMap.d
@@ -116,7 +116,7 @@ struct BTreeMap(TreeKeyType, TreeValueType, int tree_degree)
 
     package void initialize (IMemManager allocator = mallocMemManager)
     {
-        (&this).impl.initialize(allocator);
+        this.impl.initialize(allocator);
     }
 
     // Disable constructor, so user always needs to use the makeBTreeMap method
@@ -146,7 +146,7 @@ struct BTreeMap(TreeKeyType, TreeValueType, int tree_degree)
     public bool insert (KeyType key, ValueType value)
     {
         bool added;
-        (&this).impl.insert(key, value, added);
+        this.impl.insert(key, value, added);
         return added;
     }
 
@@ -180,7 +180,7 @@ struct BTreeMap(TreeKeyType, TreeValueType, int tree_degree)
     }
     body
     {
-        return (&this).impl.insert(key, value, added);
+        return this.impl.insert(key, value, added);
     }
 
 
@@ -202,7 +202,7 @@ struct BTreeMap(TreeKeyType, TreeValueType, int tree_degree)
 
     public bool remove (KeyType key)
     {
-        return (&this).impl.remove(key);
+        return this.impl.remove(key);
     }
 
     /******************************************************************************
@@ -227,7 +227,7 @@ struct BTreeMap(TreeKeyType, TreeValueType, int tree_degree)
 
     public ValueType get (KeyType key, out bool found_element)
     {
-        return (&this).impl.get(key, found_element);
+        return this.impl.get(key, found_element);
     }
 
     /**************************************************************************
@@ -249,7 +249,7 @@ struct BTreeMap(TreeKeyType, TreeValueType, int tree_degree)
 
     public ValueType* opIn_r (KeyType key)
     {
-        return (&this).impl.get(key);
+        return this.impl.get(key);
     }
 
     /***********************************************************************
@@ -267,7 +267,7 @@ struct BTreeMap(TreeKeyType, TreeValueType, int tree_degree)
 
     public int opApply (scope int delegate (ref KeyType value, ref ValueType) dg)
     {
-        return (&this).impl.inorder(dg);
+        return this.impl.inorder(dg);
     }
 
     /***********************************************************************
@@ -285,7 +285,7 @@ struct BTreeMap(TreeKeyType, TreeValueType, int tree_degree)
 
     public int opApply (scope int delegate (ref ValueType) dg)
     {
-        return (&this).impl.inorder(dg);
+        return this.impl.inorder(dg);
     }
 
 
@@ -650,8 +650,8 @@ version (unittest)
         {
             //logger.error("setting name: {}", name);
             enforce (name.length <= ubyte.max);
-            (&this).name_length = cast(ubyte)name.length;
-            (&this).name_buf[0..(&this).name_length] = name[];
+            this.name_length = cast(ubyte)name.length;
+            this.name_buf[0..this.name_length] = name[];
         }
    }
 }

--- a/src/ocean/util/container/btree/BTreeMapRange.d
+++ b/src/ocean/util/container/btree/BTreeMapRange.d
@@ -172,7 +172,7 @@ public struct BTreeMapRange(BTreeMap)
 
     invariant ()
     {
-        verify((&this).stack !is null);
+        verify(this.stack !is null);
     }
 
 
@@ -188,8 +188,8 @@ public struct BTreeMapRange(BTreeMap)
 
     public KeyValue front ()
     {
-        (&this).enforceValid();
-        return Pair!(BTreeMap.KeyType, BTreeMap.ValueType)((&this).current_key, (&this).current_value);
+        this.enforceValid();
+        return Pair!(BTreeMap.KeyType, BTreeMap.ValueType)(this.current_key, this.current_value);
     }
 
     /***************************************************************************
@@ -203,8 +203,8 @@ public struct BTreeMapRange(BTreeMap)
 
     public void popFront ()
     {
-        (&this).enforceValid();
-        (&this).iterationStep();
+        this.enforceValid();
+        this.iterationStep();
     }
 
     /***************************************************************************
@@ -219,9 +219,9 @@ public struct BTreeMapRange(BTreeMap)
 
     public bool empty ()
     {
-        (&this).enforceValid();
-        return (&this).tree.root is null ||
-            ((&this).item.node is null && (&this).stack.length == 0);
+        this.enforceValid();
+        return this.tree.root is null ||
+            (this.item.node is null && this.stack.length == 0);
     }
 
     /***************************************************************************
@@ -234,7 +234,7 @@ public struct BTreeMapRange(BTreeMap)
 
     public bool isValid ()
     {
-        return tree_version == (&this).tree.content_version;
+        return tree_version == this.tree.content_version;
     }
 
     /***************************************************************************
@@ -248,7 +248,7 @@ public struct BTreeMapRange(BTreeMap)
 
     private void enforceValid ()
     {
-        if (!(&this).isValid())
+        if (!this.isValid())
         {
             throw .range_exception;
         }
@@ -262,11 +262,11 @@ public struct BTreeMapRange(BTreeMap)
 
     private void start ()
     {
-        if ((&this).tree.root !is null)
+        if (this.tree.root !is null)
         {
-            (&this).tree_version = (&this).tree.content_version;
-            (&this).item = NodeElement((&this).tree.root, 0);
-            (&this).iterationStep();
+            this.tree_version = this.tree.content_version;
+            this.item = NodeElement(this.tree.root, 0);
+            this.iterationStep();
         }
     }
 
@@ -280,44 +280,44 @@ public struct BTreeMapRange(BTreeMap)
     {
         while (true)
         {
-            if ((&this).item.node.is_leaf)
+            if (this.item.node.is_leaf)
             {
                 // Leaf doesn't have subtrees, we can just iterate over it
-                if ((&this).item.index < (&this).item.node.number_of_elements)
+                if (this.item.index < this.item.node.number_of_elements)
                 {
-                    (&this).current_value = (&this).item.value;
-                    (&this).current_key = (&this).item.key;
-                    (&this).item.index++;
+                    this.current_value = this.item.value;
+                    this.current_key = this.item.key;
+                    this.item.index++;
                     return;
                 }
             }
             else
             {
                 // do we have a subtree in the child_elements[index]?
-                if ((&this).item.index <= (&this).item.node.number_of_elements)
+                if (this.item.index <= this.item.node.number_of_elements)
                 {
-                    *(&this).stack ~= NodeElement((&this).item.node, (&this).item.index);
-                    (&this).item = NodeElement(item.node.child_nodes[(&this).item.index], 0);
+                    *this.stack ~= NodeElement(this.item.node, this.item.index);
+                    this.item = NodeElement(item.node.child_nodes[this.item.index], 0);
                     continue;
                 }
             }
 
-            if ((*(&this).stack).pop((&this).item) == false)
+            if ((*this.stack).pop(this.item) == false)
             {
                 return;
             }
 
             // We got the item from the stack, and we should see if we
             // have any more elements to call the delegate on it
-            if ((&this).item.index < (&this).item.node.number_of_elements)
+            if (this.item.index < this.item.node.number_of_elements)
             {
-                (&this).current_value = (&this).item.value;
-                (&this).current_key = (&this).item.key;
-                (&this).item.index++;
+                this.current_value = this.item.value;
+                this.current_key = this.item.key;
+                this.item.index++;
                 return;
             }
             // There's no more elements, just skip to the next one
-            (&this).item.index++;
+            this.item.index++;
         }
     }
 }

--- a/src/ocean/util/container/btree/Implementation.d
+++ b/src/ocean/util/container/btree/Implementation.d
@@ -142,8 +142,8 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
 
     package void initialize (IMemManager allocator = mallocMemManager)
     {
-        verify ((&this).allocator is null);
-        (&this).allocator = allocator;
+        verify (this.allocator is null);
+        this.allocator = allocator;
     }
 
 
@@ -163,14 +163,14 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
 
     package ValueType* insert (KeyType key, ValueType el, out bool added)
     {
-        verify((&this).allocator !is null);
+        verify(this.allocator !is null);
 
-        if ((&this).root is null)
+        if (this.root is null)
         {
-            (&this).root = (&this).insertNewNode();
+            this.root = this.insertNewNode();
         }
 
-        if (auto ptr = (&this).get(key))
+        if (auto ptr = this.get(key))
         {
             return ptr;
         }
@@ -178,13 +178,13 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
         // unqualed for internal storage only. User will never access it as
         // unqualed reference.
         auto unqualed_el = cast(Unqual!(ValueType))el;
-        auto r = (&this).root;
+        auto r = this.root;
         added = true;
-        if ((&this).root.number_of_elements == (&this).root.elements.length)
+        if (this.root.number_of_elements == this.root.elements.length)
         {
-            auto node = (&this).insertNewNode();
+            auto node = this.insertNewNode();
             // this is a new root
-            (&this).root = node;
+            this.root = node;
             node.is_leaf = false;
             node.number_of_elements = 0;
 
@@ -221,12 +221,12 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
 
     package bool remove (KeyType key)
     {
-        verify((&this).allocator !is null);
+        verify(this.allocator !is null);
 
         BTreeMapNode* parent = null;
 
         bool rebalance_parent;
-        auto res = (&this).deleteFromNode((&this).root,
+        auto res = this.deleteFromNode(this.root,
                 parent, key, rebalance_parent);
 
         // can't rebalance the root node here, as they should all be
@@ -236,7 +236,7 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
         debug (BTreeMapSanity) check_invariants(this);
 
         if (res)
-            (&this).content_version++;
+            this.content_version++;
 
         return res;
     }
@@ -250,7 +250,7 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
 
     package bool empty ()
     {
-        return (&this).root is null;
+        return this.root is null;
     }
 
     /******************************************************************************
@@ -270,7 +270,7 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
     package ValueType get (KeyType key, out bool found_element)
     {
         size_t index;
-        auto node = (&this).get(key, index);
+        auto node = this.get(key, index);
         if (!node) return ValueType.init;
 
         found_element = true;
@@ -294,7 +294,7 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
     {
         size_t index;
 
-        if (auto node = (&this).get(key, index))
+        if (auto node = this.get(key, index))
             return &node.elements[index].value;
         else
             return null;
@@ -350,12 +350,12 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
             return getImpl(root.child_nodes[pos], key, index);
         }
 
-        if ((&this).root is null)
+        if (this.root is null)
         {
             return null;
         }
 
-        return getImpl((&this).root, key, index);
+        return getImpl(this.root, key, index);
     }
 
     /******************************************************************************
@@ -391,7 +391,7 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
                                                     node, to_delete, rebalance_parent);
                 if (rebalance_parent)
                 {
-                    (&this).rebalanceAfterDeletion(node, parent, rebalance_parent);
+                    this.rebalanceAfterDeletion(node, parent, rebalance_parent);
                 }
 
                 return delete_result;
@@ -402,7 +402,7 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
                 if (node.is_leaf)
                 {
                     deleteFromLeaf(node, i);
-                    (&this).rebalanceAfterDeletion(node, parent, rebalance_parent);
+                    this.rebalanceAfterDeletion(node, parent, rebalance_parent);
 
                     return true;
                 }
@@ -430,7 +430,7 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
                     // and rebalance the tree starting from that node.
                     if (rebalance_parent)
                     {
-                        (&this).rebalanceAfterDeletion(node, parent, rebalance_parent);
+                        this.rebalanceAfterDeletion(node, parent, rebalance_parent);
                     }
                     return delete_result;
                 }
@@ -452,7 +452,7 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
             if (rebalance_parent)
 
             {
-                (&this).rebalanceAfterDeletion(node, parent, rebalance_parent);
+                this.rebalanceAfterDeletion(node, parent, rebalance_parent);
             }
 
             return delete_result;
@@ -467,7 +467,7 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
 
     private BTreeMapNode* insertNewNode()
     {
-        auto node = cast(BTreeMapNode*)(&this).allocator.create(BTreeMapNode.sizeof).ptr;
+        auto node = cast(BTreeMapNode*)this.allocator.create(BTreeMapNode.sizeof).ptr;
         *node = BTreeMapNode.init;
 
         node.is_leaf = true;
@@ -550,7 +550,7 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
         int child_index,
         BTreeMapNode* child)
     {
-        auto new_node = (&this).insertNewNode();
+        auto new_node = this.insertNewNode();
         // new node is a leaf if old node was
         new_node.is_leaf = child.is_leaf;
         moveElementsAt(new_node, 0, child, degree);
@@ -584,7 +584,7 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
         // element from the neighbouring nodes
         // note that the root is the only node which is allowed to have
         // more than a minimum elements, so we will never rebalance it
-        if (node != (&this).root && node.number_of_elements < (&this).degree - 1)
+        if (node != this.root && node.number_of_elements < this.degree - 1)
         {
             long position_in_parent = -1;
 
@@ -613,7 +613,7 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
                 // it has the spare elements, or it does't (in which case
                 // it's merged with the parent
 
-                if (next_neighbour && next_neighbour.number_of_elements > (&this).degree -1)
+                if (next_neighbour && next_neighbour.number_of_elements > this.degree -1)
                 {
                     // copy the separator from the parent node
                     // into the deficient node
@@ -640,7 +640,7 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
                 // it has the spare elements, or it does't (in which case
                 // it's merged with the parent
 
-                if (previous_neighbour.number_of_elements > (&this).degree -1)
+                if (previous_neighbour.number_of_elements > this.degree -1)
                 {
                     shiftElements(node, 0, 1);
                     // copy the separator from the parent node
@@ -690,7 +690,7 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
 
                 remaining_node = node;
 
-                (&this).allocator.destroy(cast(ubyte[])(next_neighbour[0..1]));
+                this.allocator.destroy(cast(ubyte[])(next_neighbour[0..1]));
             }
             else
             {
@@ -708,17 +708,17 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
 
                 remaining_node = previous_neighbour;
 
-                (&this).allocator.destroy(cast(ubyte[])((node)[0..1]));
+                this.allocator.destroy(cast(ubyte[])((node)[0..1]));
             }
 
             // TODO: comment this
-            if (parent == (&this).root && parent.number_of_elements == 0)
+            if (parent == this.root && parent.number_of_elements == 0)
             {
-                (&this).allocator.destroy(cast(ubyte[])(parent[0..1]));
-                (&this).root = remaining_node;
+                this.allocator.destroy(cast(ubyte[])(parent[0..1]));
+                this.root = remaining_node;
                 return;
             }
-            else if (parent != (&this).root && parent.number_of_elements < (&this).degree - 1)
+            else if (parent != this.root && parent.number_of_elements < this.degree - 1)
             {
                 rebalance_parent = true;
                 return;
@@ -949,12 +949,12 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
 
     package int inorder (scope int delegate(ref KeyType key, ref ValueType value) dg)
     {
-        if ((&this).root is null)
+        if (this.root is null)
         {
             return 0;
         }
 
-        return inorderImpl((&this).content_version, *(&this).root, dg);
+        return inorderImpl(this.content_version, *this.root, dg);
     }
 
     /******************************************************************************
@@ -973,12 +973,12 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
 
     package int inorder (scope int delegate(ref ValueType value) dg)
     {
-        if ((&this).root is null)
+        if (this.root is null)
         {
             return 0;
         }
 
-        return inorderImpl((&this).content_version, *(&this).root, dg);
+        return inorderImpl(this.content_version, *this.root, dg);
     }
 
     /***************************************************************************
@@ -1025,7 +1025,7 @@ package struct BTreeMapImplementation (KeyType, ValueType, int tree_degree)
                 }
 
                 // check if the tree is valid
-                if (start_version != (&this).content_version) return 1;
+                if (start_version != this.content_version) return 1;
 
                 if (res)
                     return res;

--- a/src/ocean/util/container/cache/Cache.d
+++ b/src/ocean/util/container/cache/Cache.d
@@ -300,12 +300,12 @@ class Cache ( size_t ValueSize = 0, bool TrackCreateTimes = false ) : CacheBase!
         {
             static if ( is_dynamic )
             {
-                (&this).value = value;
-                return &(&this).value;
+                this.value = value;
+                return &this.value;
             }
             else
             {
-                return (&this).value[] = value[];
+                return this.value[] = value[];
             }
         }
 
@@ -313,14 +313,14 @@ class Cache ( size_t ValueSize = 0, bool TrackCreateTimes = false ) : CacheBase!
         {
             ValueRef value_ref ( )
             {
-                return &(&this).value;
+                return &this.value;
             }
         }
         else
         {
             ValueRef value_ref ( )
             {
-                return (&this).value[];
+                return this.value[];
             }
         }
     }
@@ -1524,4 +1524,3 @@ unittest
         }
     }
 }
-

--- a/src/ocean/util/container/cache/CachingStructLoader.d
+++ b/src/ocean/util/container/cache/CachingStructLoader.d
@@ -80,10 +80,10 @@ class CachingStructLoader ( S )
 
          **********************************************************************/
 
-        static typeof((&this)) opCall ( void[] data )
+        static typeof(&this) opCall ( void[] data )
         {
             verify (data.length == typeof(this).sizeof);
-            return cast(typeof((&this)))data.ptr;
+            return cast(typeof(&this))data.ptr;
         }
     }
 

--- a/src/ocean/util/container/cache/ExpiredCacheReloader.d
+++ b/src/ocean/util/container/cache/ExpiredCacheReloader.d
@@ -80,11 +80,11 @@ class ExpiredCacheReloader ( S )
 
          **********************************************************************/
 
-        static typeof((&this)) opCall ( void[] data )
+        static typeof(&this) opCall ( void[] data )
         {
             verify (data.length == typeof(this).sizeof);
 
-            return cast(typeof((&this)))data.ptr;
+            return cast(typeof(&this))data.ptr;
         }
     }
 

--- a/src/ocean/util/container/cache/model/Value.d
+++ b/src/ocean/util/container/cache/model/Value.d
@@ -71,7 +71,7 @@ template Value ( size_t ValueSize )
 
             public void[] opAssign ( void[] val )
             {
-                return (&this).array = val;
+                return this.array = val;
             }
 
             /*******************************************************************
@@ -91,16 +91,16 @@ template Value ( size_t ValueSize )
 
             public void[] opSliceAssign ( void[] val )
             {
-                if ((&this).array is null)
+                if (this.array is null)
                 {
-                    (&this).array = new ubyte[val.length];
+                    this.array = new ubyte[val.length];
                 }
                 else
                 {
-                    (&this).array.length = val.length;
+                    this.array.length = val.length;
                 }
 
-                return (&this).array[] = val[];
+                return this.array[] = val[];
             }
 
             /*******************************************************************
@@ -112,7 +112,7 @@ template Value ( size_t ValueSize )
 
             public void[] opSlice ( )
             {
-                return (&this).array;
+                return this.array;
             }
 
             /*******************************************************************
@@ -128,7 +128,7 @@ template Value ( size_t ValueSize )
 
             public void[]* opCast ( )
             {
-                return &(&this).array;
+                return &this.array;
             }
 
             /*******************************************************************
@@ -140,7 +140,7 @@ template Value ( size_t ValueSize )
 
             public size_t length ( )
             {
-                return (&this).array.length;
+                return this.array.length;
             }
         }
 

--- a/src/ocean/util/container/cache/model/containers/TimeToIndex.d
+++ b/src/ocean/util/container/cache/model/containers/TimeToIndex.d
@@ -57,7 +57,7 @@ class TimeToIndex: EBTree128!()
 
         static assert(typeof(this).sizeof % 16 == 0,
                       typeof(this).stringof ~ ".sizeof must be an integer "
-                    ~ "multiple of 16, not " ~ typeof(*(&(&this))).sizeof.stringof);
+                    ~ "multiple of 16, not " ~ typeof(this).sizeof.stringof);
     }
 
     /**************************************************************************/

--- a/src/ocean/util/container/ebtree/EBTree128.d
+++ b/src/ocean/util/container/ebtree/EBTree128.d
@@ -124,7 +124,7 @@ class EBTree128 ( bool signed = false ) : IEBTree
 
         public equals_t opEquals(Key rhs)
         {
-            return (&this).opCmp(rhs) == 0;
+            return this.opCmp(rhs) == 0;
         }
     }
 

--- a/src/ocean/util/container/ebtree/EBTree32.d
+++ b/src/ocean/util/container/ebtree/EBTree32.d
@@ -174,7 +174,7 @@ class EBTree32 ( bool signed = false ) : IEBTree
 
         private EBTree32!(signed).Key opCast ( )
         {
-            return ((cast (int) (&this).hi) << 0x10) | (&this).lo;
+            return ((cast (int) this.hi) << 0x10) | this.lo;
         }
     }
 

--- a/src/ocean/util/container/ebtree/EBTree64.d
+++ b/src/ocean/util/container/ebtree/EBTree64.d
@@ -164,7 +164,7 @@ class EBTree64 ( bool signed = false ) : IEBTree
 
         public equals_t opEquals(Dual32Key rhs)
         {
-            return (&this).opCmp(rhs) == 0;
+            return this.opCmp(rhs) == 0;
         }
 
         /**********************************************************************
@@ -178,7 +178,7 @@ class EBTree64 ( bool signed = false ) : IEBTree
 
         private EBTree64!(signed).Key opCast ( )
         {
-            return ((cast (long) (&this).hi) << 0x20) | (&this).lo;
+            return ((cast (long) this.hi) << 0x20) | this.lo;
         }
     }
 

--- a/src/ocean/util/container/ebtree/c/eb128tree.d
+++ b/src/ocean/util/container/ebtree/c/eb128tree.d
@@ -78,7 +78,7 @@ struct UCent
 
     public equals_t opEquals(UCent rhs)
     {
-        return (&this).opCmp(rhs) == 0;
+        return this.opCmp(rhs) == 0;
     }
 }
 
@@ -120,7 +120,7 @@ struct Cent
 
     public equals_t opEquals(Cent rhs)
     {
-        return (&this).opCmp(rhs) == 0;
+        return this.opCmp(rhs) == 0;
     }
 }
 
@@ -162,7 +162,7 @@ struct eb128_node
 
     UCent key ( ) ( UCent key_ )
     {
-        eb128_node_setkey_264((&this), key_.lo, key_.hi);
+        eb128_node_setkey_264(&this, key_.lo, key_.hi);
 
         return key_;
     }
@@ -175,7 +175,7 @@ struct eb128_node
 
     Cent key ( ) ( Cent key_ )
     {
-        eb128i_node_setkey_264((&this), key_.lo, key_.hi);
+        eb128i_node_setkey_264(&this, key_.lo, key_.hi);
 
         return key_;
     }
@@ -198,13 +198,13 @@ struct eb128_node
         {
             Cent result;
 
-            eb128i_node_getkey_264((&this), &result.lo, &result.hi);
+            eb128i_node_getkey_264(&this, &result.lo, &result.hi);
         }
         else
         {
             UCent result;
 
-            eb128_node_getkey_264((&this), &result.lo, &result.hi);
+            eb128_node_getkey_264(&this, &result.lo, &result.hi);
         }
 
         return result;
@@ -212,30 +212,30 @@ struct eb128_node
 
     /// Return next node in the tree, skipping duplicates, or NULL if none
 
-    typeof ((&this)) next ( )
+    typeof(&this) next ( )
     {
-        return eb128_next((&this));
+        return eb128_next(&this);
     }
 
     /// Return previous node in the tree, or NULL if none
 
-    typeof ((&this)) prev ( )
+    typeof(&this) prev ( )
     {
-        return eb128_prev((&this));
+        return eb128_prev(&this);
     }
 
     /// Return next node in the tree, skipping duplicates, or NULL if none
 
-    typeof ((&this)) next_unique ( )
+    typeof(&this) next_unique ( )
     {
-        return eb128_next_unique((&this));
+        return eb128_next_unique(&this);
     }
 
     /// Return previous node in the tree, skipping duplicates, or NULL if none
 
-    typeof ((&this)) prev_unique ( )
+    typeof(&this) prev_unique ( )
     {
-        return eb128_prev_unique((&this));
+        return eb128_prev_unique(&this);
     }
 }
 

--- a/src/ocean/util/container/ebtree/c/eb32tree.d
+++ b/src/ocean/util/container/ebtree/c/eb32tree.d
@@ -34,30 +34,30 @@ struct eb32_node
 
     /// Return next node in the tree, skipping duplicates, or NULL if none
 
-    typeof ((&this)) next ( )
+    typeof(&this) next ( )
     {
-        return eb32_next((&this));
+        return eb32_next(&this);
     }
 
     /// Return previous node in the tree, or NULL if none
 
-    typeof ((&this)) prev ( )
+    typeof(&this) prev ( )
     {
-        return eb32_prev((&this));
+        return eb32_prev(&this);
     }
 
     /// Return next node in the tree, skipping duplicates, or NULL if none
 
-    typeof ((&this)) next_unique ( )
+    typeof(&this) next_unique ( )
     {
-        return eb32_next_unique((&this));
+        return eb32_next_unique(&this);
     }
 
     /// Return previous node in the tree, skipping duplicates, or NULL if none
 
-    typeof ((&this)) prev_unique ( )
+    typeof(&this) prev_unique ( )
     {
-        return eb32_prev_unique((&this));
+        return eb32_prev_unique(&this);
     }
 }
 

--- a/src/ocean/util/container/ebtree/c/eb64tree.d
+++ b/src/ocean/util/container/ebtree/c/eb64tree.d
@@ -34,30 +34,30 @@ struct eb64_node
 
     /// Return next node in the tree, skipping duplicates, or NULL if none
 
-    typeof ((&this)) next ( )
+    typeof(&this) next ( )
     {
-        return eb64_next((&this));
+        return eb64_next(&this);
     }
 
     /// Return previous node in the tree, or NULL if none
 
-    typeof ((&this)) prev ( )
+    typeof(&this) prev ( )
     {
-        return eb64_prev((&this));
+        return eb64_prev(&this);
     }
 
     /// Return next node in the tree, skipping duplicates, or NULL if none
 
-    typeof ((&this)) next_unique ( )
+    typeof(&this) next_unique ( )
     {
-        return eb64_next_unique((&this));
+        return eb64_next_unique(&this);
     }
 
     /// Return previous node in the tree, skipping duplicates, or NULL if none
 
-    typeof ((&this)) prev_unique ( )
+    typeof(&this) prev_unique ( )
     {
-        return eb64_prev_unique((&this));
+        return eb64_prev_unique(&this);
     }
 }
 

--- a/src/ocean/util/container/ebtree/c/ebtree.d
+++ b/src/ocean/util/container/ebtree/c/ebtree.d
@@ -46,7 +46,7 @@ struct eb_root
 
     bool is_empty ( )
     {
-        return !!eb_is_empty((&this));
+        return !!eb_is_empty(&this);
     }
 
     /***************************************************************************
@@ -62,7 +62,7 @@ struct eb_root
 
     bool unique ( )
     {
-        return (&this).b[RGHT] is UNIQUE;
+        return this.b[RGHT] is UNIQUE;
     }
 
     /***************************************************************************
@@ -84,7 +84,7 @@ struct eb_root
 
     bool unique ( bool enable )
     {
-        (&this).b[RGHT] = enable? UNIQUE : NORMAL;
+        this.b[RGHT] = enable? UNIQUE : NORMAL;
         return enable;
     }
 }
@@ -102,29 +102,29 @@ struct eb_node
 
     alias .eb_last last;
 
-    typeof ((&this)) prev( )
+    typeof(&this) prev( )
     {
-        return eb_prev((&this));
+        return eb_prev(&this);
     }
 
-    typeof ((&this)) next ( )
+    typeof(&this) next ( )
     {
-        return eb_next((&this));
+        return eb_next(&this);
     }
 
-    typeof ((&this)) prev_unique ( )
+    typeof(&this) prev_unique ( )
     {
-        return eb_prev_unique((&this));
+        return eb_prev_unique(&this);
     }
 
-    typeof ((&this)) next_unique ( )
+    typeof(&this) next_unique ( )
     {
-        return eb_next_unique((&this));
+        return eb_next_unique(&this);
     }
 
     void remove ( )
     {
-        eb_delete((&this));
+        eb_delete(&this);
     }
 };
 

--- a/src/ocean/util/container/ebtree/model/Node.d
+++ b/src/ocean/util/container/ebtree/model/Node.d
@@ -63,7 +63,7 @@ struct Node ( eb_node, Key, alias eb_getkey, alias eb_next, alias eb_prev,
         // TODO: Check if this works with signed keys.
 
 //        return this.node_.key_;
-        return eb_getkey(&(&this).node_);
+        return eb_getkey(&this.node_);
     }
 
     /**************************************************************************
@@ -75,9 +75,9 @@ struct Node ( eb_node, Key, alias eb_getkey, alias eb_next, alias eb_prev,
 
      **************************************************************************/
 
-    public typeof ((&this)) next ( )
+    public typeof(&this) next ( )
     {
-        return (&this).ebCall!(eb_next);
+        return this.ebCall!(eb_next);
     }
 
     /**************************************************************************
@@ -89,9 +89,9 @@ struct Node ( eb_node, Key, alias eb_getkey, alias eb_next, alias eb_prev,
 
      **************************************************************************/
 
-    public typeof ((&this)) prev ( )
+    public typeof(&this) prev ( )
     {
-        return (&this).ebCall!(eb_prev);
+        return this.ebCall!(eb_prev);
     }
 
     /**************************************************************************
@@ -104,9 +104,9 @@ struct Node ( eb_node, Key, alias eb_getkey, alias eb_next, alias eb_prev,
 
      **************************************************************************/
 
-    public typeof ((&this)) next_unique ( )
+    public typeof(&this) next_unique ( )
     {
-        return (&this).ebCall!(eb_next_unique);
+        return this.ebCall!(eb_next_unique);
     }
 
     /**************************************************************************
@@ -120,9 +120,9 @@ struct Node ( eb_node, Key, alias eb_getkey, alias eb_next, alias eb_prev,
 
      **************************************************************************/
 
-    public typeof ((&this)) prev_unique ( )
+    public typeof(&this) prev_unique ( )
     {
-        return (&this).ebCall!(eb_prev_unique);
+        return this.ebCall!(eb_prev_unique);
     }
 
     /**************************************************************************
@@ -134,11 +134,11 @@ struct Node ( eb_node, Key, alias eb_getkey, alias eb_next, alias eb_prev,
 
      **************************************************************************/
 
-    private typeof ((&this)) remove ( )
+    private typeof(&this) remove ( )
     {
-        eb_delete(&(&this).node_);
+        eb_delete(&this.node_);
 
-        return (&this);
+        return &this;
     }
 
     /**************************************************************************
@@ -154,11 +154,10 @@ struct Node ( eb_node, Key, alias eb_getkey, alias eb_next, alias eb_prev,
 
      **************************************************************************/
 
-    private typeof ((&this)) ebCall ( alias eb_func ) ( )
+    private typeof(&this) ebCall ( alias eb_func ) ( )
     {
-        static assert (is (typeof (eb_func(&(&this).node_)) == eb_node*));
+        static assert (is(typeof(eb_func(&this.node_)) == eb_node*));
 
-        return cast (typeof ((&this))) eb_func(&this.node_);
+        return cast(typeof(&this)) eb_func(&this.node_);
     }
 }
-

--- a/src/ocean/util/container/map/TreeMap.d
+++ b/src/ocean/util/container/map/TreeMap.d
@@ -85,7 +85,7 @@ struct TreeMap ( T )
 
     public bool is_empty ( ) // const
     {
-        return (&this).root.is_empty();
+        return this.root.is_empty();
     }
 
     /***************************************************************************
@@ -100,8 +100,8 @@ struct TreeMap ( T )
 
     public void reinit ( )
     {
-        (&this).root = eb_root.init;
-        (&this).root.unique = true;
+        this.root = eb_root.init;
+        this.root.unique = true;
     }
 
     /***************************************************************************
@@ -123,7 +123,7 @@ struct TreeMap ( T )
 
     public T* put ( ulong key, out bool added )
     {
-        return &((&this).put_(key, added).value);
+        return &(this.put_(key, added).value);
     }
 
     /***********************************************************************
@@ -140,7 +140,7 @@ struct TreeMap ( T )
 
     private T* opIn_r ( ulong key )
     {
-        return &((cast(Node*)eb64_lookup(&(&this).root, key)).value);
+        return &((cast(Node*)eb64_lookup(&this.root, key)).value);
     }
 
     /***********************************************************************
@@ -154,7 +154,7 @@ struct TreeMap ( T )
 
     public T* first ()
     {
-        return (&this).getBoundary!(true)();
+        return this.getBoundary!(true)();
     }
 
     /***********************************************************************
@@ -168,7 +168,7 @@ struct TreeMap ( T )
 
     public T* last ()
     {
-        return (&this).getBoundary!(false)();
+        return this.getBoundary!(false)();
     }
 
     /***********************************************************************
@@ -182,7 +182,7 @@ struct TreeMap ( T )
     {
         int stop = 0;
 
-        for (auto eb_node = eb64_first(&(&this).root); eb_node && !stop;)
+        for (auto eb_node = eb64_first(&this.root); eb_node && !stop;)
         {
             // Backup node.next here because dg() may change or delete node!
             auto next = eb_node.next;
@@ -214,9 +214,9 @@ struct TreeMap ( T )
 
     public bool remove ( ulong key )
     {
-        if (auto node = (&this).nodeForKey(key))
+        if (auto node = this.nodeForKey(key))
         {
-            (&this).remove_(*node);
+            this.remove_(*node);
             return true;
         }
         else
@@ -266,7 +266,7 @@ struct TreeMap ( T )
         else
             alias eb64_last eb64_function;
 
-        return &((cast(Node*)eb64_function(&(&this).root)).value);
+        return &((cast(Node*)eb64_function(&this.root)).value);
     }
 
     /***********************************************************************
@@ -283,7 +283,7 @@ struct TreeMap ( T )
 
     private Node* nodeForKey ( ulong key )
     {
-        return cast(Node*)eb64_lookup(&(&this).root, key);
+        return cast(Node*)eb64_lookup(&this.root, key);
     }
 
     /***************************************************************************
@@ -313,7 +313,7 @@ struct TreeMap ( T )
             eb64_node* ebnode = &node.tupleof[0];
 
         ebnode.key = key;
-        eb64_node* added_ebnode = eb64_insert(&(&this).root, ebnode);
+        eb64_node* added_ebnode = eb64_insert(&this.root, ebnode);
         added = added_ebnode is ebnode;
 
         if (!added)
@@ -359,9 +359,9 @@ struct TreeMap ( T )
 
         Node* allocate ( )
         {
-            if (auto node = (&this).spare)
+            if (auto node = this.spare)
             {
-                (&this).spare = null;
+                this.spare = null;
                 return node;
             }
 
@@ -392,10 +392,10 @@ struct TreeMap ( T )
 
         void deallocate ( Node* node )
         {
-            if ((&this).spare is null)
+            if (this.spare is null)
             {
                 *node = (*node).init;
-                (&this).spare = node;
+                this.spare = node;
             }
             else
             {

--- a/src/ocean/util/container/map/model/Bucket.d
+++ b/src/ocean/util/container/map/model/Bucket.d
@@ -160,7 +160,7 @@ public struct Bucket ( size_t V, K = hash_t )
 
     public bool has_element ( )
     {
-        return (&this).first !is null;
+        return this.first !is null;
     }
 
     /**************************************************************************
@@ -181,13 +181,13 @@ public struct Bucket ( size_t V, K = hash_t )
         debug (HostingArrayMapBucket) if (element)
         {
             assert (element.bucket, "bucket not set in found element");
-            assert (element.bucket is (&this),
+            assert (element.bucket is &this,
                     "element found is not from this bucket");
         }
     }
     body
     {
-        for (Element* element = (&this).first; element; element = element.next)
+        for (Element* element = this.first; element; element = element.next)
         {
             if (element.key == key)
             {
@@ -226,11 +226,11 @@ public struct Bucket ( size_t V, K = hash_t )
     }
     body
     {
-        Element* element = (&this).find(key);
+        Element* element = this.find(key);
 
         if (!element)
         {
-            element = (&this).add(new_element);
+            element = this.add(new_element);
 
             static if (isArrayType!(K) == ArrayKind.Static)
             {
@@ -263,7 +263,7 @@ public struct Bucket ( size_t V, K = hash_t )
     public Element* add ( Element* element )
     in
     {
-        debug (HostingArrayMapBucket) element.bucket = (&this);
+        debug (HostingArrayMapBucket) element.bucket = &this;
     }
     out
     {
@@ -271,7 +271,7 @@ public struct Bucket ( size_t V, K = hash_t )
         {
             // Check for cyclic links using 2 pointers, one which traverse
             // twice as fast as the first one
-            auto ptr1 = (&this).first;
+            auto ptr1 = this.first;
             auto ptr2 = ptr1;
 
             // Find meeting point
@@ -289,8 +289,8 @@ public struct Bucket ( size_t V, K = hash_t )
     }
     body
     {
-        element.next = (&this).first;
-        (&this).first   = element;
+        element.next = this.first;
+        this.first   = element;
 
         return element;
     }
@@ -319,7 +319,7 @@ public struct Bucket ( size_t V, K = hash_t )
 
             debug (HostingArrayMapBucket) if (removed)
             {
-                assert (removed.bucket is (&this),
+                assert (removed.bucket is &this,
                         "element to remove is not from this bucket");
 
                 removed.bucket = null;
@@ -328,22 +328,22 @@ public struct Bucket ( size_t V, K = hash_t )
     }
     body
     {
-        if ((&this).first !is null)
+        if (this.first !is null)
         {
-            if ((&this).first.key == key)
+            if (this.first.key == key)
             {
-                Element* removed = (&this).first;
+                Element* removed = this.first;
 
-                (&this).first   = (&this).first.next;
+                this.first   = this.first.next;
                 removed.next = null;
 
                 return removed;
             }
             else
             {
-                Element* element = (&this).first.next;
+                Element* element = this.first.next;
 
-                for (Element* prev = (&this).first; element;)
+                for (Element* prev = this.first; element;)
                 {
                     if (element.key == key)
                     {

--- a/src/ocean/util/container/map/model/BucketInfo.d
+++ b/src/ocean/util/container/map/model/BucketInfo.d
@@ -67,14 +67,14 @@ class BucketInfo
 
         public equals_t opEquals (Bucket rhs)
         {
-            return (&this).opCmp(rhs) == 0;
+            return this.opCmp(rhs) == 0;
         }
 
         /**********************************************************************/
 
         debug (BucketInfo) private void print ( )
         {
-            Stderr.format(" {,2}/{,2}", (&this).index, (&this).length);
+            Stderr.format(" {,2}/{,2}", this.index, this.length);
         }
     }
 

--- a/src/ocean/util/container/map/utils/MapSerializer.d
+++ b/src/ocean/util/container/map/utils/MapSerializer.d
@@ -1640,7 +1640,7 @@ unittest
 
         bool compare ( OldStruct* old )
         {
-            return old.old == (&this).old &&
+            return old.old == this.old &&
                    old.old+1 == a_bit_newer;
         }
     }
@@ -1759,7 +1759,7 @@ unittest
 
         bool compare ( StructPrevious* olds )
         {
-            return (&this).hello42 == (olds.hello + 42);
+            return this.hello42 == (olds.hello + 42);
         }
 
         static struct StructPrevious
@@ -1770,7 +1770,7 @@ unittest
 
             bool compare ( StructNext* news )
             {
-                return (&this).hello == (news.hello42 - 42);
+                return this.hello == (news.hello42 - 42);
             }
         }
     }

--- a/src/ocean/util/container/more/BitSet.d
+++ b/src/ocean/util/container/more/BitSet.d
@@ -128,7 +128,7 @@ struct BitSet (int Count=0)
         BitSet* clr ()
         {
                 bits[] = 0;
-                return (&this);
+                return &this;
         }
 
         /**********************************************************************
@@ -141,7 +141,7 @@ struct BitSet (int Count=0)
         {
                 BitSet x;
                 static if (Count == 0)
-                           x.bits.length = (&this).bits.length;
+                           x.bits.length = this.bits.length;
                 x.bits[] = bits[];
                 return x;
         }
@@ -168,6 +168,6 @@ struct BitSet (int Count=0)
                 i = i / width;
                 if (i >= bits.length)
                     bits.length = i + 1;
-                return (&this);
+                return &this;
         }
 }

--- a/src/ocean/util/container/more/HashFile.d
+++ b/src/ocean/util/container/more/HashFile.d
@@ -265,11 +265,11 @@ class HashFile(K, V)
 
                 void write (HashFile bucket, V data, BlockSize block)
                 {
-                        (&this).used = data.length;
+                        this.used = data.length;
 
                         // create new slot if we exceed capacity
-                        if ((&this).used > (&this).capacity)
-                            createBucket (bucket, (&this).used, block);
+                        if (this.used > this.capacity)
+                            createBucket (bucket, this.used, block);
 
                         bucket.heap [offset .. offset+used] = cast(ubyte[]) data;
                 }
@@ -280,10 +280,10 @@ class HashFile(K, V)
 
                 void createBucket (HashFile bucket, int bytes, BlockSize block)
                 {
-                        (&this).offset = bucket.waterLine;
-                        (&this).capacity = (bytes + block.capacity) & ~block.capacity;
+                        this.offset = bucket.waterLine;
+                        this.capacity = (bytes + block.capacity) & ~block.capacity;
 
-                        bucket.waterLine += (&this).capacity;
+                        bucket.waterLine += this.capacity;
                         if (bucket.waterLine > bucket.fileSize)
                            {
                            auto target = bucket.waterLine * 2;

--- a/src/ocean/util/container/more/Heap.d
+++ b/src/ocean/util/container/more/Heap.d
@@ -162,7 +162,7 @@ struct Heap (T, alias Compare = minHeapCompare!(T), alias Move = defaultHeapSwap
         /** reset this heap, and use the provided host for value elements */
         void clear (T[] host)
         {
-                (&this).heap = host;
+                this.heap = host;
                 clear;
         }
 
@@ -187,8 +187,8 @@ struct Heap (T, alias Compare = minHeapCompare!(T), alias Move = defaultHeapSwap
         Heap clone ()
         {
                 Heap other;
-                other.heap = (&this).heap.dup;
-                other.next = (&this).next;
+                other.heap = this.heap.dup;
+                other.next = this.next;
                 return other;
         }
 

--- a/src/ocean/util/container/more/Stack.d
+++ b/src/ocean/util/container/more/Stack.d
@@ -59,7 +59,7 @@ public struct Stack ( V, int Size = 0 )
     Stack* clear ( )
     {
         depth = 0;
-        return (&this);
+        return &this;
     }
 
     /***************************************************************************
@@ -140,7 +140,7 @@ public struct Stack ( V, int Size = 0 )
             enforce(.e_bounds, depth < stack.length);
             stack[depth++] = value;
         }
-        return (&this);
+        return &this;
     }
 
     /***************************************************************************
@@ -158,7 +158,7 @@ public struct Stack ( V, int Size = 0 )
     {
         foreach (v; value)
             push (v);
-        return (&this);
+        return &this;
     }
 
     /***************************************************************************
@@ -255,7 +255,7 @@ public struct Stack ( V, int Size = 0 )
             p++;
         }
         *p = t;
-        return (&this);
+        return &this;
     }
 
     /***************************************************************************
@@ -282,7 +282,7 @@ public struct Stack ( V, int Size = 0 )
             p--;
         }
         *p = t;
-        return (&this);
+        return &this;
     }
 
     /***************************************************************************

--- a/src/ocean/util/container/more/Vector.d
+++ b/src/ocean/util/container/more/Vector.d
@@ -54,7 +54,7 @@ struct Vector (V, int Size = 0)
         Vector* clear ()
         {
                 depth = 0;
-                return (&this);
+                return &this;
         }
 
         /***********************************************************************
@@ -158,7 +158,7 @@ struct Vector (V, int Size = 0)
         {
                 foreach (v; value)
                          add (v);
-                return (&this);
+                return &this;
         }
 
         /**********************************************************************

--- a/src/ocean/util/container/pool/AcquiredResources.d
+++ b/src/ocean/util/container/pool/AcquiredResources.d
@@ -112,8 +112,8 @@ public struct Acquired ( T )
 
     public void initialise ( FreeList!(ubyte[]) buffer_pool, FreeList!(T) t_pool )
     {
-        (&this).buffer_pool = buffer_pool;
-        (&this).t_pool = t_pool;
+        this.buffer_pool = buffer_pool;
+        this.t_pool = t_pool;
     }
 
     /***************************************************************************
@@ -130,19 +130,19 @@ public struct Acquired ( T )
 
     public Elem acquire ( lazy Elem new_t )
     {
-        verify((&this).buffer_pool !is null);
+        verify(this.buffer_pool !is null);
 
         // Acquire container buffer, if not already done.
-        if ( (&this).buffer is null )
+        if ( this.buffer is null )
         {
-            (&this).buffer = acquireBuffer((&this).buffer_pool, Elem.sizeof * 4);
-            (&this).acquired = VoidBufferAsArrayOf!(Elem)(&(&this).buffer);
+            this.buffer = acquireBuffer(this.buffer_pool, Elem.sizeof * 4);
+            this.acquired = VoidBufferAsArrayOf!(Elem)(&this.buffer);
         }
 
         // Acquire new element.
-        (&this).acquired ~= (&this).t_pool.get(new_t);
+        this.acquired ~= this.t_pool.get(new_t);
 
-        return (&this).acquired.array()[$-1];
+        return this.acquired.array()[$-1];
     }
 
     /***************************************************************************
@@ -153,16 +153,16 @@ public struct Acquired ( T )
 
     public void relinquishAll ( )
     {
-        verify((&this).buffer_pool !is null);
+        verify(this.buffer_pool !is null);
 
-        if ( (&this).buffer !is null )
+        if ( this.buffer !is null )
         {
             // Relinquish acquired Ts.
-            foreach ( ref inst; (&this).acquired.array() )
-                (&this).t_pool.recycle(inst);
+            foreach ( ref inst; this.acquired.array() )
+                this.t_pool.recycle(inst);
 
             // Relinquish container buffer.
-            (&this).buffer_pool.recycle(cast(ubyte[])(&this).buffer);
+            this.buffer_pool.recycle(cast(ubyte[])this.buffer);
         }
     }
 }
@@ -287,7 +287,7 @@ public struct AcquiredArraysOf ( T )
 
     public void initialise ( FreeList!(ubyte[]) buffer_pool )
     {
-        (&this).buffer_pool = buffer_pool;
+        this.buffer_pool = buffer_pool;
     }
 
     /***************************************************************************
@@ -313,7 +313,7 @@ public struct AcquiredArraysOf ( T )
 
         public void[]* acquire ( )
         {
-            return (&this).acquireNewBuffer();
+            return this.acquireNewBuffer();
         }
     }
     else
@@ -330,7 +330,7 @@ public struct AcquiredArraysOf ( T )
 
         public VoidBufferAsArrayOf!(T) acquire ( )
         {
-            auto new_buf = (&this).acquireNewBuffer();
+            auto new_buf = this.acquireNewBuffer();
             return VoidBufferAsArrayOf!(T)(new_buf);
         }
     }
@@ -343,16 +343,16 @@ public struct AcquiredArraysOf ( T )
 
     public void relinquishAll ( )
     {
-        verify((&this).buffer_pool !is null);
+        verify(this.buffer_pool !is null);
 
-        if ( (&this).buffer !is null )
+        if ( this.buffer !is null )
         {
             // Relinquish acquired buffers.
-            foreach ( ref inst; (&this).acquired.array() )
-                (&this).buffer_pool.recycle(cast(ubyte[])inst);
+            foreach ( ref inst; this.acquired.array() )
+                this.buffer_pool.recycle(cast(ubyte[])inst);
 
             // Relinquish container buffer.
-            (&this).buffer_pool.recycle(cast(ubyte[])(&this).buffer);
+            this.buffer_pool.recycle(cast(ubyte[])this.buffer);
         }
     }
 
@@ -368,24 +368,24 @@ public struct AcquiredArraysOf ( T )
 
     private void[]* acquireNewBuffer ( )
     {
-        verify((&this).buffer_pool !is null);
+        verify(this.buffer_pool !is null);
 
         enum initial_array_capacity = 4;
 
         // Acquire container buffer, if not already done.
-        if ( (&this).buffer is null )
+        if ( this.buffer is null )
         {
-            (&this).buffer = acquireBuffer((&this).buffer_pool,
+            this.buffer = acquireBuffer(this.buffer_pool,
                 (void[]).sizeof * initial_array_capacity);
-            (&this).acquired = VoidBufferAsArrayOf!(void[])(&(&this).buffer);
+            this.acquired = VoidBufferAsArrayOf!(void[])(&this.buffer);
         }
 
         // Acquire and re-initialise new buffer to return to the user. Store
         // it in the container buffer.
-        (&this).acquired ~= acquireBuffer((&this).buffer_pool,
+        this.acquired ~= acquireBuffer(this.buffer_pool,
             T.sizeof * initial_array_capacity);
 
-        return &((&this).acquired.array()[$-1]);
+        return &(this.acquired.array()[$-1]);
     }
 }
 
@@ -500,7 +500,7 @@ public struct AcquiredSingleton ( T )
 
     public void initialise ( FreeList!(T) t_pool )
     {
-        (&this).t_pool = t_pool;
+        this.t_pool = t_pool;
     }
 
     /***************************************************************************
@@ -517,14 +517,14 @@ public struct AcquiredSingleton ( T )
 
     public Elem acquire ( lazy Elem new_t )
     {
-        verify((&this).t_pool !is null);
+        verify(this.t_pool !is null);
 
-        if ( (&this).acquired is null )
-            (&this).acquired = (&this).t_pool.get(new_t);
+        if ( this.acquired is null )
+            this.acquired = this.t_pool.get(new_t);
 
-        verify((&this).acquired !is null);
+        verify(this.acquired !is null);
 
-        return (&this).acquired;
+        return this.acquired;
     }
 
     /***************************************************************************
@@ -544,17 +544,17 @@ public struct AcquiredSingleton ( T )
 
     public Elem acquire ( lazy Elem new_t, scope void delegate ( Elem ) reset )
     {
-        verify((&this).t_pool !is null);
+        verify(this.t_pool !is null);
 
-        if ( (&this).acquired is null )
+        if ( this.acquired is null )
         {
-            (&this).acquired = (&this).t_pool.get(new_t);
-            reset((&this).acquired);
+            this.acquired = this.t_pool.get(new_t);
+            reset(this.acquired);
         }
 
-        verify((&this).acquired !is null);
+        verify(this.acquired !is null);
 
-        return (&this).acquired;
+        return this.acquired;
     }
 
     /***************************************************************************
@@ -565,10 +565,10 @@ public struct AcquiredSingleton ( T )
 
     public void relinquish ( )
     {
-        verify((&this).t_pool !is null);
+        verify(this.t_pool !is null);
 
-        if ( (&this).acquired !is null )
-            (&this).t_pool.recycle((&this).acquired);
+        if ( this.acquired !is null )
+            this.t_pool.recycle(this.acquired);
     }
 }
 

--- a/src/ocean/util/container/queue/LinkedListQueue.d
+++ b/src/ocean/util/container/queue/LinkedListQueue.d
@@ -123,7 +123,7 @@ public class LinkedListQueue ( T, alias gc_tracking_policy = GCTrackingPolicy.re
 
         public QueueItem* find ( T find_value )
         {
-            for ( auto p = (&this); p; p = p.next )
+            for ( auto p = &this; p; p = p.next )
                  if ( find_value == p.value )
                      return p;
             return null;

--- a/src/ocean/util/log/Event.d
+++ b/src/ocean/util/log/Event.d
@@ -86,7 +86,7 @@ public struct LogEvent
     /// Return the logger level name of this event.
     cstring levelName ()
     {
-        return ILogger.convert((&this).level_);
+        return ILogger.convert(this.level_);
     }
 
     /// Convert a time value (in milliseconds) to ascii

--- a/src/ocean/util/log/Logger.d
+++ b/src/ocean/util/log/Logger.d
@@ -144,7 +144,7 @@ public struct Log
         {
             uint total;
 
-            foreach (field; (&this).tupleof)
+            foreach (field; this.tupleof)
             {
                 total += field;
             }
@@ -155,7 +155,7 @@ public struct Log
         /// Resets the counters
         private void reset ()
         {
-            foreach (ref field; (&this).tupleof)
+            foreach (ref field; this.tupleof)
             {
                 field = field.init;
             }
@@ -175,19 +175,19 @@ public struct Log
             with (Level) switch (event_level)
             {
             case Trace:
-                (&this).logged_trace++;
+                this.logged_trace++;
                 break;
             case Info:
-                (&this).logged_info++;
+                this.logged_info++;
                 break;
             case Warn:
-                (&this).logged_warn++;
+                this.logged_warn++;
                 break;
             case Error:
-                (&this).logged_error++;
+                this.logged_error++;
                 break;
             case Fatal:
-                (&this).logged_fatal++;
+                this.logged_fatal++;
                 break;
             case None:
                 break;

--- a/src/ocean/util/log/PeriodicTrace.d
+++ b/src/ocean/util/log/PeriodicTrace.d
@@ -173,22 +173,22 @@ struct PeriodicTracer
 
     ***************************************************************************/
 
-    public typeof((&this)) format (Args...) ( cstring fmt, Args args )
+    public typeof(&this) format (Args...) ( cstring fmt, Args args )
     {
-        if ((&this).timeToUpdate())
+        if (this.timeToUpdate())
         {
-            (&this).last_update_time = (&this).now;
+            this.last_update_time = this.now;
 
-            (&this).formatted.length = 0;
-            enableStomping((&this).formatted);
-            sformat((&this).formatted, fmt, args);
+            this.formatted.length = 0;
+            enableStomping(this.formatted);
+            sformat(this.formatted, fmt, args);
 
-            if ((&this).static_display)
-                StaticTrace.format("{}", (&this).formatted).flush;
+            if (this.static_display)
+                StaticTrace.format("{}", this.formatted).flush;
             else
-                Stderr.formatln("{}", (&this).formatted).flush;
+                Stderr.formatln("{}", this.formatted).flush;
         }
-        return (&this);
+        return &this;
     }
 
 
@@ -209,10 +209,10 @@ struct PeriodicTracer
 
     ***************************************************************************/
 
-    public typeof((&this)) format (Args...) ( ulong interval, cstring fmt, Args args )
+    public typeof(&this) format (Args...) ( ulong interval, cstring fmt, Args args )
     {
-        (&this).interval = interval;
-        return (&this).format(fmt, args);
+        this.interval = interval;
+        return this.format(fmt, args);
     }
 
 
@@ -236,8 +236,8 @@ struct PeriodicTracer
 
     public bool timeToUpdate ( )
     {
-        (&this).now = timer.microsec();
-        return (&this).now > (&this).last_update_time + (&this).interval;
+        this.now = timer.microsec();
+        return this.now > this.last_update_time + this.interval;
     }
 
 

--- a/src/ocean/util/log/StatsReader.d
+++ b/src/ocean/util/log/StatsReader.d
@@ -143,9 +143,9 @@ public struct StatsLine
     {
         StatsLine stats_line;
 
-        stats_line.line = (&this).line.dup;
-        stats_line.date = (&this).date.dup;
-        stats_line.time = (&this).time.dup;
+        stats_line.line = this.line.dup;
+        stats_line.date = this.date.dup;
+        stats_line.time = this.time.dup;
 
         return stats_line;
     }
@@ -245,7 +245,7 @@ public class StatsLogReader
         {
             int result;
 
-            foreach (line; (&this).lines)
+            foreach (line; this.lines)
             {
                 if (line.length == 0)
                 {

--- a/src/ocean/util/serialize/contiguous/Contiguous.d
+++ b/src/ocean/util/serialize/contiguous/Contiguous.d
@@ -79,12 +79,12 @@ struct Contiguous( S )
 
     public S* ptr ( )
     {
-        verify(((&this).data.length == 0) || ((&this).data.length >= S.sizeof));
+        verify((this.data.length == 0) || (this.data.length >= S.sizeof));
 
-        if ((&this).data.length == 0)
+        if (this.data.length == 0)
             return null;
 
-        return cast(S*) (&this).data.ptr;
+        return cast(S*) this.data.ptr;
     }
 
     /***************************************************************************
@@ -99,9 +99,9 @@ struct Contiguous( S )
 
     public void enforceIntegrity()
     {
-        if ((&this).data.ptr)
+        if (this.data.ptr)
         {
-            enforceContiguous(*cast(S*) (&this).data.ptr, (&this).data);
+            enforceContiguous(*cast(S*) this.data.ptr, this.data);
         }
     }
 
@@ -116,7 +116,7 @@ struct Contiguous( S )
 
     public size_t length()
     {
-        return (&this).data.length;
+        return this.data.length;
     }
 
     /***************************************************************************
@@ -140,9 +140,9 @@ struct Contiguous( S )
             // can't call this.enforceIntegrity because it will trigger
             // invariant recursively being a public method
 
-            if ((&this).data.length)
+            if (this.data.length)
             {
-                enforceContiguous(*cast(S*) (&this).data.ptr, (&this).data);
+                enforceContiguous(*cast(S*) this.data.ptr, this.data);
             }
         }
     }

--- a/src/ocean/util/serialize/contiguous/MultiVersionDecorator.d
+++ b/src/ocean/util/serialize/contiguous/MultiVersionDecorator.d
@@ -784,7 +784,7 @@ struct Test3
 
         void compare ( NamedTest t, Version0 other )
         {
-            foreach (index, ref element; (&this).tupleof)
+            foreach (index, ref element; this.tupleof)
             {
                 t.test!("==")(element, other.tupleof[index]);
             }
@@ -792,7 +792,7 @@ struct Test3
 
         void compare ( NamedTest t, Version1 other )
         {
-            foreach (index, ref element; (&this).tupleof)
+            foreach (index, ref element; this.tupleof)
             {
                 enum name = this.tupleof[index].stringof[
                     rfind(this.tupleof[index].stringof, "."[]) + 1 .. $
@@ -800,7 +800,7 @@ struct Test3
 
                 static if (name == "nested_arr")
                 {
-                    foreach (i, elem; (&this).nested_arr)
+                    foreach (i, elem; this.nested_arr)
                     {
                         t.test!("==")(elem.a, other.nested_arr[i].a);
                     }
@@ -851,7 +851,7 @@ struct Test3
 
         void compare ( NamedTest t, Version0 other )
         {
-            foreach (index, ref member; (&this).tupleof)
+            foreach (index, ref member; this.tupleof)
             {
                 enum name = this.tupleof[index].stringof[
                     rfind(this.tupleof[index].stringof, "."[]) + 1 .. $
@@ -859,7 +859,7 @@ struct Test3
 
                 static if (name == "nested_arr")
                 {
-                    foreach (i, ref nested; (&this).nested_arr)
+                    foreach (i, ref nested; this.nested_arr)
                     {
                         test!("==")(nested.a, other.nested_arr[i].a);
                         test!("==")(nested.b, other.nested_arr[i].a + 1);
@@ -867,7 +867,7 @@ struct Test3
                 }
                 else static if (name == "c")
                 {
-                    test!("==")((&this).c, other.b - other.a);
+                    test!("==")(this.c, other.b - other.a);
                 }
                 else
                 {
@@ -878,7 +878,7 @@ struct Test3
 
         void compare ( NamedTest t, Version1 other )
         {
-            foreach (index, ref element; (&this).tupleof)
+            foreach (index, ref element; this.tupleof)
             {
                 t.test!("==")(element, other.tupleof[index]);
             }
@@ -886,7 +886,7 @@ struct Test3
 
         void compare ( NamedTest t, Version2 other )
         {
-            foreach (index, ref member; (&this).tupleof)
+            foreach (index, ref member; this.tupleof)
             {
                 enum name = this.tupleof[index].stringof[
                     rfind(this.tupleof[index].stringof, "."[]) + 1 .. $
@@ -894,7 +894,7 @@ struct Test3
 
                 static if (name == "nested_arr")
                 {
-                    foreach (i, ref nested; (&this).nested_arr)
+                    foreach (i, ref nested; this.nested_arr)
                     {
                         test!("==")(nested.a, other.nested_arr[i].a);
                         test!("==")(nested.b, other.nested_arr[i].a / 2);
@@ -902,7 +902,7 @@ struct Test3
                 }
                 else static if (name == "c")
                 {
-                    test!("==")((&this).c, other.d);
+                    test!("==")(this.c, other.d);
                 }
                 else
                 {
@@ -948,7 +948,7 @@ struct Test3
 
         void compare ( NamedTest t, ref Version1 other )
         {
-            foreach (index, ref member; (&this).tupleof)
+            foreach (index, ref member; this.tupleof)
             {
                 enum name = this.tupleof[index].stringof[
                     rfind(this.tupleof[index].stringof, "."[]) + 1 .. $
@@ -956,14 +956,14 @@ struct Test3
 
                 static if (name == "nested_arr")
                 {
-                    foreach (i, ref nested; (&this).nested_arr)
+                    foreach (i, ref nested; this.nested_arr)
                     {
                         test!("==")(nested.a, other.nested_arr[i].b * 2);
                     }
                 }
                 else static if (name == "d")
                 {
-                    test!("==")((&this).d, other.c);
+                    test!("==")(this.d, other.c);
                 }
                 else
                 {
@@ -974,7 +974,7 @@ struct Test3
 
         void compare ( NamedTest t, ref Version2 other )
         {
-            foreach (index, member; (&this).tupleof)
+            foreach (index, member; this.tupleof)
             {
                 t.test!("==")(member, other.tupleof[index]);
             }

--- a/src/ocean/util/serialize/contiguous/package.d
+++ b/src/ocean/util/serialize/contiguous/package.d
@@ -215,18 +215,18 @@ struct S
 
     void testNullReferences ( ) const
     {
-        foreach (s2_static_array_element; (&this).s2_static_array)
+        foreach (s2_static_array_element; this.s2_static_array)
         {
             testArray!("is")(s2_static_array_element.a, null);
             testArray!("is")(s2_static_array_element.b, null);
         }
 
-        foreach (s3_a_element; (&this).s3.a)
+        foreach (s3_a_element; this.s3.a)
             testArray!("is")(s3_a_element, null);
 
-        testArray!("is")((&this).s4_dynamic_array, null);
+        testArray!("is")(this.s4_dynamic_array, null);
 
-        foreach (static_of_dynamic_element; (&this).static_of_dynamic)
+        foreach (static_of_dynamic_element; this.static_of_dynamic)
             testArray!("is")(static_of_dynamic_element, null);
     }
 
@@ -254,23 +254,23 @@ struct S
 
         size_t n = This.sizeof;
 
-        n += s2_length((&this).s2);
+        n += s2_length(this.s2);
 
-        foreach (s2_static_array_element; (&this).s2_static_array)
+        foreach (s2_static_array_element; this.s2_static_array)
             n += s2_length(s2_static_array_element);
 
-        foreach (s3_a_element; (&this).s3.a)
+        foreach (s3_a_element; this.s3.a)
             n += serialArrayLength(s3_a_element);
 
-        n += serialArrayLength((&this).s4_dynamic_array);
-        foreach (s4_dynamic_array_element; (&this).s4_dynamic_array)
+        n += serialArrayLength(this.s4_dynamic_array);
+        foreach (s4_dynamic_array_element; this.s4_dynamic_array)
             n += serialArrayLength(s4_dynamic_array_element.a);
 
-        foreach (static_of_dynamic_element; (&this).static_of_dynamic)
+        foreach (static_of_dynamic_element; this.static_of_dynamic)
             n += serialArrayLength(static_of_dynamic_element);
 
-        n += serialArrayLength((&this).dynamic_of_static_of_static_of_dynamic);
-        foreach (dynamic_element; (&this).dynamic_of_static_of_static_of_dynamic)
+        n += serialArrayLength(this.dynamic_of_static_of_static_of_dynamic);
+        foreach (dynamic_element; this.dynamic_of_static_of_static_of_dynamic)
             foreach (static_element; dynamic_element)
                 foreach (static_element2; static_element)
                     n += serialArrayLength(static_element2);


### PR DESCRIPTION
```
Those `(&this)` were automatically added by d1to2conv.
However, most of them are unnecessary, and can be trivially replaced by `this`.
This is due to the fact that, within a struct, this was a pointer to the type,
hence typeof(this) would be `Struct*`, while in D2, it is a reference to the type,
hence typeof(this) is `Struct`."

The following rules were following for this change:
1) If the `(&this)` did not matter, it was simply removed.
   This is the most frequent case, and applies to *any* member access.
   E.g. `(&this).foo` can always be converted to `this.foo` in Ocean
   (this is not necessarily true in other code bases, because UFCS).
2) The second most common use case was returning a pointer to the struct,
   e.g. `return (&this);`; this was converted to `return &this;`.
   It was mostly present in containers.
3) If within a typeof, and the pointer type is wanted, e.g. `typeof((&this))`,
   the second level of parenthesis was removed;
4) Likewise, some places used `auto x = (&this)` and `funcCall((&this))`,
   and the second level of parenthsesis was removed.
```

I can split it up by module / package if it's any easier to review.