### PR TITLE
Deprecate empty modules `ocean.stdc.posix.{net.if_,stdlib}`

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -43,6 +43,7 @@ $O/%unittests: override LDFLAGS += -lglib-2.0 -lpcre -lxml2 -lxslt -lebtree \
 
 # Remove deprecated modules from testing:
 TEST_FILTER_OUT += \
+	$C/src/ocean/stdc/posix/net/if_.d \
 	$C/src/ocean/stdc/posix/netinet/in_.d \
 	$C/src/ocean/stdc/posix/sys/types.d   \
 	$C/src/ocean/util/log/model/ILogger.d

--- a/Build.mak
+++ b/Build.mak
@@ -45,5 +45,6 @@ $O/%unittests: override LDFLAGS += -lglib-2.0 -lpcre -lxml2 -lxslt -lebtree \
 TEST_FILTER_OUT += \
 	$C/src/ocean/stdc/posix/net/if_.d \
 	$C/src/ocean/stdc/posix/netinet/in_.d \
+	$C/src/ocean/stdc/posix/stdlib.d \
 	$C/src/ocean/stdc/posix/sys/types.d   \
 	$C/src/ocean/util/log/model/ILogger.d

--- a/integrationtest/signalext/main.d
+++ b/integrationtest/signalext/main.d
@@ -8,13 +8,19 @@
 
 module integrationtest.signalext.main;
 
-import ocean.transition;
-
-import core.sys.posix.signal;
 import ocean.core.Test;
 import ocean.sys.ErrnoException;
+import ocean.text.util.StringC;
+import ocean.transition;
 import ocean.util.app.DaemonApp;
+import ocean.io.device.File;
+import Path = ocean.io.Path;
 import ocean.io.select.client.TimerEvent;
+import ocean.io.select.EpollSelectDispatcher;
+
+import core.sys.posix.signal;
+import core.sys.posix.stdlib : mkdtemp;
+import core.sys.posix.unistd;
 
 /// Counters incremented from original and application's
 /// signal handler
@@ -23,8 +29,6 @@ private int app_counter;
 
 class MyApp : DaemonApp
 {
-    import ocean.io.select.EpollSelectDispatcher;
-
     private EpollSelectDispatcher epoll;
 
     this ( )
@@ -67,12 +71,6 @@ class MyApp : DaemonApp
         this.epoll.shutdown();
     }
 }
-
-import ocean.io.device.File;
-import Path = ocean.io.Path;
-import ocean.text.util.StringC;
-import core.sys.posix.unistd;
-import ocean.stdc.posix.stdlib : mkdtemp;
 
 version(UnitTest) {} else
 void main(istring[] args)

--- a/integrationtest/unixsocket/main.d
+++ b/integrationtest/unixsocket/main.d
@@ -24,22 +24,21 @@ module integrationtest.unixsocket.main;
 
 import ocean.core.Enforce;
 import ocean.core.Test;
-import ocean.sys.socket.UnixSocket;
-
-import ocean.transition;
+import ocean.core.Time;
+import ocean.math.Math;
 import ocean.stdc.posix.sys.socket;
 import ocean.stdc.posix.sys.un;
 import ocean.stdc.posix.sys.wait;
-import core.sys.posix.unistd;
-import ocean.stdc.posix.stdlib : mkdtemp;
-import core.stdc.stdio;
-import ocean.math.Math;
-import ocean.core.Time;
 import ocean.stdc.string;
+import ocean.sys.socket.UnixSocket;
+import ocean.text.util.StringC;
+import ocean.transition;
+
+import core.stdc.stdio;
+import core.sys.posix.stdlib : mkdtemp;
+import core.sys.posix.unistd;
 import core.stdc.errno;
 import core.thread;
-
-import ocean.text.util.StringC;
 
 static immutable istring CLIENT_STRING = "Hello from the client";
 

--- a/relnotes/net-if.deprecation.md
+++ b/relnotes/net-if.deprecation.md
@@ -1,0 +1,6 @@
+### Module `ocean.stdc.posix.net.if_` has been deprecated
+
+`ocean.stdc.posix.net.if_`
+
+This module was just publicly importing `core.sys.posix.net.if_`.
+Prefer this import instead.

--- a/relnotes/posix-stdlib.deprecation.md
+++ b/relnotes/posix-stdlib.deprecation.md
@@ -1,0 +1,8 @@
+### Module `ocean.stdc.posix.stdlib` has been deprecated
+
+`ocean.stdc.posix.stdlib`
+
+This module was just publicly importing two other modules.
+Most uses can be replaced with an import to `core.sys.posix.stdlib`.
+Users of `mkstemp`, `mkostemp`, or `mkostemps` should import
+`ocean.stdc.posix.gnu.stdlib`.

--- a/src/ocean/stdc/posix/net/if_.d
+++ b/src/ocean/stdc/posix/net/if_.d
@@ -11,7 +11,7 @@
 
 *******************************************************************************/
 
-
+deprecated("Import `core.sys.posix.net.if_` directly")
 module ocean.stdc.posix.net.if_;
 
 public import core.sys.posix.net.if_;

--- a/src/ocean/stdc/posix/stdlib.d
+++ b/src/ocean/stdc/posix/stdlib.d
@@ -11,11 +11,9 @@
 
 *******************************************************************************/
 
-
+deprecated("Import `core.sys.posix.stdlib` or `ocean.stdc.posix.gnu.stdlib` directly")
 module ocean.stdc.posix.stdlib;
 
 public import core.sys.posix.stdlib;
 
 public import ocean.stdc.posix.gnu.stdlib;
-
-extern (C) char* mkdtemp(char*);

--- a/src/ocean/util/test/DirectorySandbox.d
+++ b/src/ocean/util/test/DirectorySandbox.d
@@ -27,9 +27,10 @@ class DirectorySandbox
     import ocean.io.device.File;
     import Path = ocean.io.Path;
     import ocean.text.util.StringC;
-    import core.sys.posix.unistd: getcwd, chdir;
-    import ocean.stdc.posix.stdlib : mkdtemp;
     import core.stdc.string: strlen;
+    import core.sys.posix.stdlib : mkdtemp;
+    import core.sys.posix.unistd: getcwd, chdir;
+
 
     /// reusable ErrnoException instance
     private ErrnoException exception;


### PR DESCRIPTION
See individual commits.
Commit introducing mkdtemp: https://github.com/dlang/druntime/commit/c59ecbe27b4da4366c7cb8bce4adf0fefe48c9fb