### PR TITLE
Deprecate trivial function ocean.text.Util : layout

### DIFF
--- a/relnotes/text-util-layout.deprecation.md
+++ b/relnotes/text-util-layout.deprecation.md
@@ -1,0 +1,11 @@
+### Function `ocean.text.Util : layout` has been deprecated
+
+`ocean.text.Util`
+
+This function was duplicating the functionality of `Formatter`.
+Additionally, the speed advantage does not apply anymore,
+as the overhead of the old Tango `Layout` was due to the usage of `TypeInfo`,
+and performances should be equivalent nowadays.
+Lastly, most usage in Ocean were to format temporaries into buffer,
+and later pass them to a delegate,
+something that can be done without temporary using `sformat`.

--- a/src/ocean/text/Util.d
+++ b/src/ocean/text/Util.d
@@ -73,7 +73,6 @@
         matching (s1*, s2*, length)                 // low-level compare
         isSpace (match)                             // is whitespace?
         unescape(source, output)                    // convert '\' prefixes
-        layout (destination, format ...)            // featherweight printf
         lines (str)                                 // foreach lines
         quotes (str, set)                           // foreach quotes
         delimiters (str, set)                       // foreach delimiters
@@ -999,6 +998,7 @@ QuoteFruct!T quotes(T) (T[] src, cstring set)
 
 *******************************************************************************/
 
+deprecated("Use `ocean.text.convert.Formatter : snformat` instead")
 cstring layout(mstring output, cstring format, const(char[])[] arguments ...)
 {
     return layout_(output, format, arguments);
@@ -1522,8 +1522,6 @@ unittest
     foreach (element; quotes ("1 'avcc   cc ' 3", " "))
         q ~= element;
     test (q.length is 3 && q[0] == "1" && q[1] == "'avcc   cc '" && q[2] == "3");
-
-    test (layout (tmp, "%1,%%%c %0", "abc", "efg") == "efg,%c abc");
 
     x = split ("one, two, three", ",");
     test (x.length is 3 && x[0] == "one" && x[1] == " two" && x[2] == " three");

--- a/src/ocean/text/convert/TimeStamp.d
+++ b/src/ocean/text/convert/TimeStamp.d
@@ -35,19 +35,12 @@
 
 module ocean.text.convert.TimeStamp;
 
-import ocean.transition;
-
-import ocean.time.Time;
-
 import ocean.core.ExceptionDefinitions;
-
-import Util = ocean.text.Util;
-
-import ocean.time.chrono.Gregorian;
-
-import Integer = ocean.text.convert.Integer_tango;
-
 import ocean.core.Verify;
+import ocean.transition;
+import ocean.time.Time;
+import ocean.text.convert.Formatter;
+import ocean.time.chrono.Gregorian;
 
 version (unittest) import ocean.core.Test;
 
@@ -102,34 +95,21 @@ Const!(T)[] format(T, U=Time) (T[] output, U t)
 
 Const!(T)[] format(T) (T[] output, Time t)
 {
-    static Const!(T)[][] Months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    static immutable T[][] Months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
         "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-    static Const!(T)[][] Days   = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+    static immutable T[][] Days   = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
-    Const!(T)[] convert (T[] tmp, long i)
-    {
-        return Integer.formatter!(T) (tmp, i, 'u', 0, 8);
-    }
-
-    verify (output.length >= 29);
+    verify(output.length >= 29);
     if (t is t.max)
-        throw new IllegalArgumentException ("TimeStamp.format :: invalid Time argument");
+        throw new IllegalArgumentException("TimeStamp.format :: invalid Time argument");
 
     // convert time to field values
-    auto time = t.time;
-    auto date = Gregorian.generic.toDate (t);
+    const time = t.time;
+    const date = Gregorian.generic.toDate(t);
 
-    // use the featherweight formatter ...
-    T[14] tmp = void;
-    return Util.layout (output, cast(Const!(T)[])"%0, %1 %2 %3 %4:%5:%6 GMT",
-            Days[date.dow],
-            convert (tmp[0..2], date.day),
-            Months[date.month-1],
-            convert (tmp[2..6], date.year),
-            convert (tmp[6..8], time.hours),
-            convert (tmp[8..10], time.minutes),
-            convert (tmp[10..12], time.seconds)
-            );
+    return snformat(output, "{}, {u2} {} {u4} {u2}:{u2}:{u2} GMT",
+                    Days[date.dow], date.day, Months[date.month-1], date.year,
+                    time.hours, time.minutes, time.seconds);
 }
 
 unittest
@@ -155,30 +135,17 @@ Const!(T)[] format8601(T, U=Time) (T[] output, U t)
 
 Const!(T)[] format8601(T) (T[] output, Time t)
 {
-    Const!(T)[] convert (T[] tmp, long i)
-    {
-        return Integer.formatter!(T) (tmp, i, 'u', 0, 8);
-    }
-
-
-    verify (output.length >= 29);
+    verify(output.length >= 29);
     if (t is t.max)
-        throw new IllegalArgumentException ("TimeStamp.format :: invalid Time argument");
+        throw new IllegalArgumentException("TimeStamp.format :: invalid Time argument");
 
     // convert time to field values
-    auto time = t.time;
-    auto date = Gregorian.generic.toDate (t);
+    const time = t.time;
+    const date = Gregorian.generic.toDate(t);
 
-    // use the featherweight formatter ...
-    T[20] tmp = void;
-    return Util.layout (output, cast(T[]) "%0-%1-%2T%3%:%4:%5Z",
-            convert (tmp[0..4], date.year),
-            convert (tmp[4..6], date.month),
-            convert (tmp[6..8], date.day),
-            convert (tmp[8..10], time.hours),
-            convert (tmp[10..12], time.minutes),
-            convert (tmp[12..14], time.seconds)
-            );
+    return snformat(output, "{u4}-{u2}-{u2}T{u2}:{u2}:{u2}Z",
+                    date.year, date.month, date.day,
+                    time.hours, time.minutes, time.seconds);
 }
 
 unittest

--- a/src/ocean/util/log/layout/LayoutStatsLog.d
+++ b/src/ocean/util/log/layout/LayoutStatsLog.d
@@ -21,8 +21,7 @@
 module ocean.util.log.layout.LayoutStatsLog;
 
 import ocean.transition;
-import Integer = ocean.text.convert.Integer_tango;
-import ocean.text.Util;
+import ocean.text.convert.Formatter;
 import ocean.time.Clock;
 import ocean.time.WallClock;
 import ocean.util.log.Appender;
@@ -64,35 +63,15 @@ public class LayoutStatsLog : Appender.Layout
 
     public override void format (LogEvent event, scope void delegate(cstring) dg)
     {
-        auto level = event.levelName;
-
         // convert time to field values
-        auto tm = event.time;
-        auto dt = (localTime) ? WallClock.toDate(tm) : Clock.toDate(tm);
+        const tm = event.time;
+        const dt = (localTime) ? WallClock.toDate(tm) : Clock.toDate(tm);
 
         // format date according to ISO-8601 (lightweight formatter)
-        char[20] tmp = void;
-        char[256] tmp2 = void;
-        dg(layout(tmp2, "%0-%1-%2 %3:%4:%5,%6 ",
-                  convert(tmp[0..4],   dt.date.year),
-                  convert(tmp[4..6],   dt.date.month),
-                  convert(tmp[6..8],   dt.date.day),
-                  convert(tmp[8..10],  dt.time.hours),
-                  convert(tmp[10..12], dt.time.minutes),
-                  convert(tmp[12..14], dt.time.seconds),
-                  convert(tmp[14..17], dt.time.millis)));
-        dg(event.toString);
-    }
-
-    /***************************************************************************
-
-        Convert an integer to a zero prefixed text representation
-
-    ***************************************************************************/
-
-    private cstring convert (mstring tmp, long i)
-    {
-        return Integer.formatter(tmp, i, 'u', '?', 8);
+        sformat(dg, "{u4}-{u2}-{u2} {u2}:{u2}:{u2},{u2} {}",
+            dt.date.year, dt.date.month, dt.date.day,
+            dt.time.hours, dt.time.minutes, dt.time.seconds, dt.time.millis,
+            event);
     }
 }
 

--- a/src/ocean/util/log/layout/LayoutStatsLog.d
+++ b/src/ocean/util/log/layout/LayoutStatsLog.d
@@ -28,6 +28,11 @@ import ocean.time.WallClock;
 import ocean.util.log.Appender;
 import ocean.util.log.Event;
 
+version (unittest)
+{
+    import ocean.core.Test;
+    import ocean.util.log.ILogger;
+}
 
 /*******************************************************************************
 
@@ -89,4 +94,24 @@ public class LayoutStatsLog : Appender.Layout
     {
         return Integer.formatter(tmp, i, 'u', '?', 8);
     }
+}
+
+unittest
+{
+    mstring result = new mstring(2048);
+    result.length = 0;
+    enableStomping(result);
+
+    scope dg = (cstring v) { result ~= v; };
+    scope layout = new LayoutStatsLog(false);
+    LogEvent event = {
+        msg_: "Baguette: 420, Radler: +Inf",
+        name_: "Irrelevant",
+        time_: Time.fromUnixTime(1525048962) + TimeSpan.fromMillis(420),
+        level_: ILogger.Level.Warn,
+        host_: null,
+    };
+
+    testNoAlloc(layout.format(event, dg));
+    test!("==")(result, "2018-04-30 00:42:42,420 Baguette: 420, Radler: +Inf");
 }


### PR DESCRIPTION
And a bunch of other fixes that arose from this.
As I was fixing the Logger's `Layout` classes, I realized this function was useless, and mostly a relic of the time when the Tango `Layout` class was extremely expensive.