### PR TITLE
Use non-deprecated import in LayoutSimple test

### DIFF
--- a/src/ocean/util/log/layout/LayoutSimple.d
+++ b/src/ocean/util/log/layout/LayoutSimple.d
@@ -23,7 +23,7 @@ import ocean.util.log.Event;
 version (unittest)
 {
     import ocean.core.Test;
-    import ocean.util.log.model.ILogger;
+    import ocean.util.log.ILogger;
 }
 
 /*******************************************************************************


### PR DESCRIPTION
This new import was introduced at the same time
the import was deprecated, leading to v5.x.x being broken
on the commit that precede this one.