### PR TITLE
Only lazy-initialize SanityException when throwing

### DIFF
--- a/relnotes/lazy_verify.bug.md
+++ b/relnotes/lazy_verify.bug.md
@@ -1,0 +1,11 @@
+### `verify` now lazily allocates on `throw`, not on call
+
+`ocean.core.Verify`
+
+`verify` used to lazily initialize a `static` exception on the first call.
+However, this means that `testNoAlloc(verify(true))` could randomly fail,
+depending on the order unittests are executed,
+and this transitively affected all users of `verify` (that is, everything).
+`verify` will now lazily allocates only on `throw`,
+so `testNoAlloc(verify(true))` will always pass,
+but `testNoAlloc(verify(false))` could still potentially fail.

--- a/src/ocean/core/Verify.d
+++ b/src/ocean/core/Verify.d
@@ -39,11 +39,11 @@ public void verify ( bool ok, lazy istring msg = "",
 {
     static SanityException exc;
 
-    if (exc is null)
-        exc = new SanityException("");
-
     if (!ok)
     {
+        if (exc is null)
+            exc = new SanityException("");
+
         exc.file = file;
         exc.line = line;
         exc.msg = msg;


### PR DESCRIPTION
```
This caused problems for the first call to 'testNoAlloc',
as even a non-throwing call could result in an allocation.
```

It was failing with LDC, and it took me a good afternoon to trace it to this from `LayoutSimple`'s tests.