### PR TITLE
Replace D1 unary operator overloads in ocean.math

### DIFF
--- a/relnotes/d1-ops.migration.md
+++ b/relnotes/d1-ops.migration.md
@@ -1,6 +1,9 @@
 ### Replace D1 operator overloads with D2 operator overloads
 
 `ocean.io.model.SuspendableThrottlerCount`
+`ocean.math.Distribution`
+`ocean.math.SlidingAverage`
+`ocean.math.WideUInt`
 
 DMD 2.088.0 has deprecated D1 operator overloads, which are expected to
 be replaced with the newer D2 `op{Unary,Binary,BinaryRight,OpAssign}`

--- a/src/ocean/math/Distribution.d
+++ b/src/ocean/math/Distribution.d
@@ -121,7 +121,7 @@ public class Distribution ( T )
 {
     /***************************************************************************
 
-        List of values, appended to by the opAddAssign method.
+        List of values, appended to by the opOpAssign!"~" method.
 
     ***************************************************************************/
 
@@ -132,7 +132,7 @@ public class Distribution ( T )
 
         Indicates whether the list of values has been sorted (which is required
         by the methods: lessThanCount, greaterThanCount, percentValue).
-        opAddAssign() and clear() reset the sorted flag to false.
+        opOpAssign() and clear() reset the sorted flag to false.
 
         TODO: it might be better to always maintain the list in sorted order?
 
@@ -161,11 +161,12 @@ public class Distribution ( T )
         Adds a value to the list.
 
         Params:
+            op = operation to perform
             value = value to add
 
     ***************************************************************************/
 
-    public void opCatAssign ( T value )
+    public void opOpAssign ( string op ) ( T value ) if (op == "~")
     {
         this.values.append(value);
         this.sorted = false;

--- a/src/ocean/math/SlidingAverage.d
+++ b/src/ocean/math/SlidingAverage.d
@@ -491,4 +491,13 @@ public class SlidingAverageTime ( T ) : SlidingAverage!(T)
 unittest
 {
     auto avg_stats = new SlidingAverageTime!(size_t)(100, 50, 1000);
+
+    test!("==")(avg_stats.current, 0, "Failed SlidingAverageTime initial value");
+
+    avg_stats++;
+    test!("==")(avg_stats.current, 1, "Failed SlidingAverageTime increment value");
+
+    avg_stats += 3;
+    test!("==")(avg_stats.current, 4, "Failed SlidingAverageTime add value");
+
 }

--- a/src/ocean/math/SlidingAverage.d
+++ b/src/ocean/math/SlidingAverage.d
@@ -393,8 +393,8 @@ public class SlidingAverageTime ( T ) : SlidingAverage!(T)
         Adds current value to the time window history.
         Calculates the new average and returns it
 
-        This pushes the data accumulated using opPostInc, opAddAssign and
-        opAssign to the list of values used to calculate the average.
+        This pushes the data accumulated using opUnary!"++", opOpAssign!"+"
+        and opAssign to the list of values used to calculate the average.
 
         Note: This should be called by a timer periodically according to the
               resolution given in the constructor
@@ -455,12 +455,15 @@ public class SlidingAverageTime ( T ) : SlidingAverage!(T)
 
         Increments the current value by one
 
+        Params:
+            op = operation to perform
+
         Returns:
             new current value
 
     ***************************************************************************/
 
-    public T opPostInc ( )
+    public T opUnary ( string op ) ( ) if (op == "++")
     {
         return this.current++;
     }
@@ -471,6 +474,7 @@ public class SlidingAverageTime ( T ) : SlidingAverage!(T)
         Adds the given value to the current value
 
         Params:
+            op = operation to perform
             val = value to add to the current value
 
         Returns:
@@ -478,7 +482,7 @@ public class SlidingAverageTime ( T ) : SlidingAverage!(T)
 
     ***************************************************************************/
 
-    public T opAddAssign ( T val )
+    public T opOpAssign ( string op ) ( T val ) if (op == "+")
     {
         return this.current += val;
     }

--- a/src/ocean/math/WideUInt.d
+++ b/src/ocean/math/WideUInt.d
@@ -327,6 +327,7 @@ public struct WideUInt ( size_t N )
         Increment current value by one fitting in uint
 
         Params:
+            op = operation to perform
             rhs = value to increment with. Limited to `uint` for now to simplify
                 internal arithmetic.
 
@@ -336,7 +337,7 @@ public struct WideUInt ( size_t N )
 
     ***************************************************************************/
 
-    public void opAddAssign ( uint rhs )
+    public void opOpAssign ( string op ) ( uint rhs ) if (op == "+")
     {
         if (add(this.payload[0], rhs))
             enforce(.wideint_exception, this.checkAndInc(1));


### PR DESCRIPTION
DMD 2.088.0 has deprecated D1 operator overloads, which are expected to be replaced with the newer D2 `op{Unary,Binary,BinaryRight,OpAssign}` templated methods: https://dlang.org/changelog/2.088.0.html#dep_d1_ops

`ocean.math` contains surprisingly few such operators, and they are easy to replace.  For `WideUInt` there should be no resulting problems, as it is a struct, but `Distribution` and `SlidingAverageTime` are classes, so there is a risk this will be a breaking change for downstream subclasses if any attempt to override the older D1 methods.