### PR TITLE
Fix function to check for UTF-8 string type

### DIFF
--- a/relnotes/fix-is-string-type.bug.md
+++ b/relnotes/fix-is-string-type.bug.md
@@ -1,0 +1,10 @@
+### Fix function to check for UTF-8 string type
+
+`ocean.meta.traits.Arrays`
+
+The function `ocean.meta.traits.Arrays.isUTF8StringType()` is suggested to
+replace the deprecated `ocean.core.Traits.isStringType()` but it failed to
+check for static arrays and now it is fixed to support both basic kind of
+arrays.
+
+Fixes #778

--- a/src/ocean/meta/traits/Arrays.d
+++ b/src/ocean/meta/traits/Arrays.d
@@ -35,13 +35,13 @@ import ocean.meta.types.Qualifiers;
 template isUTF8StringType ( T )
 {
     static immutable isUTF8StringType =
-           isArrayType!(T) == ArrayKind.Dynamic
-        && is(Unqual!(ElementTypeOf!(T)) == char);
+        isBasicArrayType!(T) && is(Unqual!(ElementTypeOf!(T)) == char);
 }
 
 ///
 unittest
 {
+    static assert (isUTF8StringType!(char[1]));
     static assert (isUTF8StringType!(char[]));
     static assert (isUTF8StringType!(Immut!(char)[]));
     static assert (!isUTF8StringType!(wchar[]));


### PR DESCRIPTION
The function `ocean.meta.traits.Arrays.isUTF8StringType()` is suggested to
replace the deprecated `ocean.core.Traits.isStringType()` but it failed to
check for static arrays and now it is fixed to support both basic kind of
arrays.

Fixes #778