### PR TITLE
Rename BitArray.init to BitArray.initialize

### DIFF
--- a/relnotes/bitarray-init.migration.md
+++ b/relnotes/bitarray-init.migration.md
@@ -1,0 +1,5 @@
+### Removed the deprecated `init` method
+
+`ocean.core.BitArray`
+
+Use the `initialize` method instead.

--- a/src/ocean/core/BitArray.d
+++ b/src/ocean/core/BitArray.d
@@ -194,12 +194,6 @@ struct BitArray
         return this;
     }
 
-    deprecated("Please use initialize instead")
-    void init( void[] target, size_t numbits )
-    {
-        this.initialize(target, numbits);
-    }
-
     /**
      * Map BitArray onto target, with numbits being the number of bits in the
      * array. Does not copy the data.  This is the inverse of opCast.


### PR DESCRIPTION
I targeted v6.x.x since this is technically a breaking change. But I don't see this used anywhere right now - at least not in other parts of ocean and swarm. For the closed-source stuff, I don't know. ^_^

Fixes #781