### PR TITLE
Replace opCatAssign with opOpAssign in Buffer

### DIFF
--- a/src/ocean/core/buffer/NoIndirections.d
+++ b/src/ocean/core/buffer/NoIndirections.d
@@ -117,11 +117,12 @@ template NoIndirectionsBufferImpl ( )
         Appends to current buffer
 
         Params:
+            op = operation to perform
             rhs = array or element to append
 
     ***************************************************************************/
 
-    void opCatAssign ( in T rhs )
+    void opOpAssign (string op) ( in T rhs ) if (op == "~")
     {
         this.length = this.data.length + 1;
         this.data[$-1] = rhs;
@@ -133,7 +134,7 @@ template NoIndirectionsBufferImpl ( )
 
     ***************************************************************************/
 
-    void opCatAssign ( in T[] rhs )
+    void opOpAssign (string op) ( in T[] rhs ) if (op == "~")
     {
         this.length = this.data.length + rhs.length;
         this.data[$-rhs.length .. $] = rhs[];

--- a/src/ocean/core/buffer/Void.d
+++ b/src/ocean/core/buffer/Void.d
@@ -96,11 +96,12 @@ template VoidBufferImpl ( )
         Appends to current buffer
 
         Params:
+            op = operation to perform
             rhs = array or element to append
 
     ***************************************************************************/
 
-    void opCatAssign ( in ubyte rhs )
+    void opOpAssign (string op) ( in ubyte rhs ) if (op == "~")
     {
         this.length = this.data.length + 1;
         this.data[$-1] = rhs;
@@ -112,7 +113,7 @@ template VoidBufferImpl ( )
 
     ***************************************************************************/
 
-    void opCatAssign ( in ubyte[] rhs )
+    void opOpAssign (string op) ( in ubyte[] rhs ) if (op == "~")
     {
         this.length = this.data.length + rhs.length;
         this.data[$-rhs.length .. $] = rhs[];

--- a/src/ocean/core/buffer/WithIndirections.d
+++ b/src/ocean/core/buffer/WithIndirections.d
@@ -98,11 +98,12 @@ template WithIndirectionsBufferImpl ( )
         Appends to current buffer
 
         Params:
+            op = operation to perform
             rhs = array or element to append
 
     ***************************************************************************/
 
-    void opCatAssign ( T rhs )
+    void opOpAssign (string op) ( T rhs ) if (op == "~")
     {
         this.length = this.data.length + 1;
         this.data[$-1] = rhs;
@@ -114,7 +115,7 @@ template WithIndirectionsBufferImpl ( )
 
     ***************************************************************************/
 
-    void opCatAssign ( T[] rhs )
+    void opOpAssign (string op) ( T[] rhs ) if (op == "~")
     {
         this.length = this.data.length + rhs.length;
         this.data[$-rhs.length .. $] = rhs[];


### PR DESCRIPTION
Since Buffer is a struct, there is no concern with making this function a template.
Additionally, since Buffer is widely used in Ocean,
it is one of the main source of deprecations.