### PR TITLE
Add support for Ubuntu bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,20 +33,20 @@ jobs:
     include:
         # Test matrix
         - <<: *test-matrix-d2
-          env: DMD=2.071.2.s* F=production
+          env: DIST=xenial DMD=2.071.2.s* F=production
         - <<: *test-matrix-d2
-          env: DMD=2.071.2.s* F=devel
+          env: DIST=xenial DMD=2.071.2.s* F=devel
         - <<: *test-matrix-d2
-          env: DMD=2.078.3.s* F=production
+          env: DIST=xenial DMD=2.078.3.s* F=production
         - <<: *test-matrix-d2
-          env: DMD=2.078.3.s* F=devel
+          env: DIST=xenial DMD=2.078.3.s* F=devel
         - <<: *test-matrix-d2
-          env: DMD=2.078.3.s* F=devel DFLAGS=-debug=ISelectClient
+          env: DIST=xenial DMD=2.078.3.s* F=devel DFLAGS=-debug=ISelectClient
           script: 2>/dev/null beaver dlang make
         - <<: *test-matrix-d2
-          env: DMD=2.085.* F=production
+          env: DIST=xenial DMD=2.085.* F=production
         - <<: *test-matrix-d2
-          env: DMD=2.085.* F=devel
+          env: DIST=xenial DMD=2.085.* F=devel
 
         # Additional stages
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,17 @@ jobs:
           env: DIST=xenial DMD=2.085.* F=production
         - <<: *test-matrix-d2
           env: DIST=xenial DMD=2.085.* F=devel
+        - <<: *test-matrix-d2
+          env: DIST=bionic DMD=2.078.3.s* F=production
+        - <<: *test-matrix-d2
+          env: DIST=bionic DMD=2.078.3.s* F=devel
+        - <<: *test-matrix-d2
+          env: DIST=bionic DMD=2.078.3.s* F=devel DFLAGS=-debug=ISelectClient
+          script: 2>/dev/null beaver dlang make
+        - <<: *test-matrix-d2
+          env: DIST=bionic DMD=2.091.* F=production
+        - <<: *test-matrix-d2
+          env: DIST=bionic DMD=2.091.* F=devel
 
         # Additional stages
 

--- a/Build.mak
+++ b/Build.mak
@@ -13,11 +13,7 @@ override DFLAGS += -w -version=GLIBC
 # symbols internally. Disable it on explicit flag to make possible regression
 # testing in D upstream.
 ifneq ($(ALLOW_DEPRECATIONS),1)
-	ifeq ($(DVER),2)
 	override DFLAGS += -de
-	else
-	override DFLAGS := $(filter-out -di,$(DFLAGS))
-	endif
 endif
 
 # Remove coverage files

--- a/Build.mak
+++ b/Build.mak
@@ -33,9 +33,12 @@ $O/test-taskext_daemon: override LDFLAGS += -lglib-2.0
 $O/test-unixsockext: override LDFLAGS += -lglib-2.0
 
 # Link unittests to all used libraries
+# TODO: Remove the specific version of libssl and libcrypto once the support
+# for Ubuntu xenial is dropped and the bindings for libssl have been updated
+# to v1.1.x
 $O/%unittests: override LDFLAGS += -lglib-2.0 -lpcre -lxml2 -lxslt -lebtree \
 		-lreadline -lhistory -llzo2 -lbz2 -lz -ldl -lgcrypt -lgpg-error -lrt \
-		-lssl -lcrypto
+		-l:libssl.so.1.0.0 -l:libcrypto.so.1.0.0
 
 # Remove deprecated modules from testing:
 TEST_FILTER_OUT += \

--- a/beaver.Dockerfile
+++ b/beaver.Dockerfile
@@ -1,1 +1,1 @@
-FROM sociomantictsunami/dlang:v4
+FROM sociomantictsunami/develdlang:v8

--- a/docker/build
+++ b/docker/build
@@ -3,7 +3,6 @@ set -xeu
 
 # Install dependencies
 apt-get install -y \
-    d1to2fix=0.10.* \
     libglib2.0-dev \
     libpcre3-dev \
     libxml2-dev \


### PR DESCRIPTION
- Remove D1 flags which are no longer needed as the code base is only D2.
- Set libssl and libcrypto to version 1.0.0 supported in Ubuntu xenial and bionic.
- The dmd-transitional compiler is available for Ubuntu bionic only in vesion 2.078.3.s*.
- Update beaver build image to support Ubuntu xenial and bionic distributions.
- Remove package d1to2fix that is no longer required as the code base is only D2.