### PR TITLE
Replace deprecated operator overloads in Map and container modules

### DIFF
--- a/src/ocean/core/BitArray.d
+++ b/src/ocean/core/BitArray.d
@@ -588,7 +588,7 @@ struct BitArray
      * Returns:
      *  A new array which is the complement of this array.
      */
-    BitArray opUnary ( string op )( ) if (op == "~")
+    BitArray opUnary ( string op : "~" )( )
     {
         auto dim = this.dim();
 
@@ -705,7 +705,7 @@ struct BitArray
      * Returns:
      *  A new array which is the result of this array minus the supplied array.
      */
-    BitArray opBinary ( string op )( BitArray rhs ) if (op == "-")
+    BitArray opBinary ( string op : "-" )( BitArray rhs )
     {
         verify(len == rhs.length);
 
@@ -745,7 +745,7 @@ struct BitArray
      *  A new array which is the result of this array concatenated with the
      *  supplied array.
      */
-    BitArray opBinary ( string op )( bool rhs ) if (op == "~")
+    BitArray opBinary ( string op : "~" )( bool rhs )
     {
         BitArray result;
 
@@ -757,7 +757,7 @@ struct BitArray
 
 
     /** ditto */
-    BitArray opBinaryRight ( string op )( bool lhs ) if (op == "~")
+    BitArray opBinaryRight ( string op : "~" )( bool lhs )
     {
         BitArray result;
 
@@ -770,7 +770,7 @@ struct BitArray
 
 
     /** ditto */
-    BitArray opBinary ( string op )( BitArray rhs ) if (op == "~")
+    BitArray opBinary ( string op : "~" )( BitArray rhs )
     {
         BitArray result;
 
@@ -949,7 +949,7 @@ struct BitArray
      * Returns:
      *  A shallow copy of this array.
      */
-    BitArray opOpAssign ( string op )( bool b ) if (op == "~")
+    BitArray opOpAssign ( string op : "~" )( bool b )
     {
         length = len + 1;
         this[len - 1] = b;
@@ -973,7 +973,7 @@ struct BitArray
     }
 
     /** ditto */
-    BitArray opOpAssign ( string op )( BitArray rhs ) if (op == "~")
+    BitArray opOpAssign ( string op : "~" )( BitArray rhs )
     {
         auto istart = len;
         length = len + rhs.length;

--- a/src/ocean/core/Enum.d
+++ b/src/ocean/core/Enum.d
@@ -769,12 +769,12 @@ version (unittest)
         test(E().max == max);
 
         // opApply 1
-        size_t i;
+        size_t outer_i;
         foreach ( n, v; E() )
         {
-            test(n == names[i]);
-            test(v == values[i]);
-            i++;
+            test(n == names[outer_i]);
+            test(v == values[outer_i]);
+            outer_i++;
         }
 
         // opApply 2

--- a/src/ocean/core/buffer/NoIndirections.d
+++ b/src/ocean/core/buffer/NoIndirections.d
@@ -122,7 +122,7 @@ template NoIndirectionsBufferImpl ( )
 
     ***************************************************************************/
 
-    void opOpAssign (string op) ( in T rhs ) if (op == "~")
+    void opOpAssign (string op : "~") ( in T rhs )
     {
         this.length = this.data.length + 1;
         this.data[$-1] = rhs;
@@ -134,7 +134,7 @@ template NoIndirectionsBufferImpl ( )
 
     ***************************************************************************/
 
-    void opOpAssign (string op) ( in T[] rhs ) if (op == "~")
+    void opOpAssign (string op : "~") ( in T[] rhs )
     {
         this.length = this.data.length + rhs.length;
         this.data[$-rhs.length .. $] = rhs[];

--- a/src/ocean/core/buffer/Void.d
+++ b/src/ocean/core/buffer/Void.d
@@ -101,7 +101,7 @@ template VoidBufferImpl ( )
 
     ***************************************************************************/
 
-    void opOpAssign (string op) ( in ubyte rhs ) if (op == "~")
+    void opOpAssign (string op : "~") ( in ubyte rhs )
     {
         this.length = this.data.length + 1;
         this.data[$-1] = rhs;
@@ -113,7 +113,7 @@ template VoidBufferImpl ( )
 
     ***************************************************************************/
 
-    void opOpAssign (string op) ( in ubyte[] rhs ) if (op == "~")
+    void opOpAssign (string op: "~") ( in ubyte[] rhs )
     {
         this.length = this.data.length + rhs.length;
         this.data[$-rhs.length .. $] = rhs[];

--- a/src/ocean/io/select/selector/RegisteredClients.d
+++ b/src/ocean/io/select/selector/RegisteredClients.d
@@ -49,7 +49,7 @@ public abstract class IRegisteredClients
 
     ***************************************************************************/
 
-    final public void opAddAssign ( ISelectClient client )
+    final public void opOpAssign ( string op : "+" ) ( ISelectClient client )
     {
         debug ( ISelectClient ) Stderr.formatln("{} :: Registered", client).flush();
         client.registered();
@@ -68,7 +68,7 @@ public abstract class IRegisteredClients
 
     ***************************************************************************/
 
-    final public void opSubAssign ( ISelectClient client )
+    final public void opOpAssign ( string op : "-" ) ( ISelectClient client )
     {
         debug ( ISelectClient ) Stderr.formatln("{} :: Unregistered", client).flush();
         client.unregistered();

--- a/src/ocean/net/http/consts/HttpVersion.d
+++ b/src/ocean/net/http/consts/HttpVersion.d
@@ -92,7 +92,7 @@ struct HttpVersionIds
 
      **************************************************************************/
 
-    static HttpVersion* opIn_r ( cstring id )
+    static HttpVersion* opBinaryRight (string op : "in") ( cstring id )
     {
         return id.length? id in codes : null;
     }
@@ -113,7 +113,7 @@ struct HttpVersionIds
 
     static HttpVersion opIndex ( cstring id )
     {
-        HttpVersion* code = opIn_r(id);
+        HttpVersion* code = opBinaryRight!("in")(id);
 
         return code? *code : (*code).Undefined;
     }

--- a/src/ocean/sys/stats/linux/ProcVFS.d
+++ b/src/ocean/sys/stats/linux/ProcVFS.d
@@ -317,7 +317,7 @@ public struct ProcUptime
 
         ***********************************************************************/
 
-        Time opSub(Time rhs)
+        Time opBinary ( string op : "-" ) (Time rhs)
         {
             Time res_time;
 

--- a/src/ocean/text/convert/DateTime_tango.d
+++ b/src/ocean/text/convert/DateTime_tango.d
@@ -908,7 +908,7 @@ private struct Result
 
      **********************************************************************/
 
-    private void opCatAssign (cstring rhs)
+    private void opOpAssign (string op : "~") (cstring rhs)
     {
         auto end = index + rhs.length;
         verify(end < target_.length);
@@ -921,7 +921,7 @@ private struct Result
 
      **********************************************************************/
 
-    private void opCatAssign (char rhs)
+    private void opOpAssign (string op : "~") (char rhs)
     {
         verify(index < target_.length);
         target_[index++] = rhs;

--- a/src/ocean/util/container/HashRangeMap.d
+++ b/src/ocean/util/container/HashRangeMap.d
@@ -45,12 +45,12 @@ public alias Range!(hash_t) HashRange;
 
     Provides a mapping from HashRange to the specified type
 
-    Note: Unittests for `put`, `remove` and `opIn_r` are not placed directly
-    in this struct as they depend on the assumption that type `Value`
-    (the template argument) has a meaningful equality operator (opEquals).
-    Instead, private external functions exist to test these methods. These are
-    then called on HashRangeMaps with various different types of Value,
-    in a unittest block outside the struct.
+    Note: Unittests for `put`, `remove` and `opopBinaryRight!"in"` are not
+    placed directly in this struct as they depend on the assumption that type
+    `Value` (the template argument) has a meaningful equality operator
+    (opEquals). Instead, private external functions exist to test these methods.
+    These are then called on HashRangeMaps with various different types of
+    Value, in a unittest block outside the struct.
 
     Params:
         Value = type to store in values of map
@@ -274,7 +274,7 @@ public struct HashRangeMap ( Value )
 
     ***************************************************************************/
 
-    public Value* opIn_r ( HashRange range )
+    public Value* opBinaryRight (string op : "in") ( HashRange range )
     {
         size_t insert_place;
         if (!bsearch(this.ranges, range, insert_place))
@@ -788,7 +788,7 @@ version (unittest)
         test!("==")(hrm.values, [v[0], v[1], v[3], v[4]][]);
     }
 
-    // Unittest function for opIn_r().
+    // Unittest function for opBinaryRight!"in".
     private void testOpInR ( Value ) ( Value[] v )
     {
         verify(v.length == 5, "You should provide an array of 5 different values");

--- a/src/ocean/util/container/VoidBufferAsArrayOf.d
+++ b/src/ocean/util/container/VoidBufferAsArrayOf.d
@@ -120,9 +120,6 @@ public struct VoidBufferAsArrayOf ( T )
         Note that mutable copies of appended elements are made internally, but
         to access them from the outside, the constness of T applies.
 
-        but
-        are inaccessible from the outside.
-
         Params:
             arr = elements to append
 

--- a/src/ocean/util/container/VoidBufferAsArrayOf.d
+++ b/src/ocean/util/container/VoidBufferAsArrayOf.d
@@ -61,7 +61,7 @@ import ocean.transition;
 public struct VoidBufferAsArrayOf ( T )
 {
     // T == void is not only pointless but is also invalid: it's illegal to pass
-    // a void argument to a function (e.g. opCatAssign).
+    // a void argument to a function (e.g. opOpAssign!("~")).
     static assert(!is(T == void));
 
     /// Pointer to the underlying void buffer. Must be set before use by struct
@@ -128,7 +128,7 @@ public struct VoidBufferAsArrayOf ( T )
 
     ***************************************************************************/
 
-    public T[] opCatAssign ( in T[] arr )
+    public T[] opOpAssign ( string op : "~" ) ( in T[] arr )
     {
         return cast(T[])((*this.buffer) ~= cast(void[])arr);
     }
@@ -148,9 +148,9 @@ public struct VoidBufferAsArrayOf ( T )
 
     ***************************************************************************/
 
-    public T[] opCatAssign ( in T element )
+    public T[] opOpAssign ( string op : "~" ) ( in T element )
     {
-        return this.opCatAssign((&element)[0 .. 1]);
+        return this.opOpAssign!("~")((&element)[0 .. 1]);
     }
 }
 

--- a/src/ocean/util/container/btree/BTreeMap.d
+++ b/src/ocean/util/container/btree/BTreeMap.d
@@ -247,7 +247,7 @@ struct BTreeMap(TreeKeyType, TreeValueType, int tree_degree)
 
     ***************************************************************************/
 
-    public ValueType* opIn_r (KeyType key)
+    public ValueType* opBinaryRight (string op : "in") (KeyType key)
     {
         return this.impl.get(key);
     }

--- a/src/ocean/util/container/map/Map.d
+++ b/src/ocean/util/container/map/Map.d
@@ -459,7 +459,7 @@ public abstract class Map ( V, K ) : BucketSet!(V.sizeof, K)
 
     ***************************************************************************/
 
-    public V* opIn_r ( in K key )
+    public V* opBinaryRight (string op : "in") ( in K key )
     {
         auto element = this.get_(key);
 
@@ -473,7 +473,7 @@ public abstract class Map ( V, K ) : BucketSet!(V.sizeof, K)
 
         Note: Use this method if it is sure that a value for key is in the map,
         in other words, it would be a bug if it isn't. To look up a mapping that
-        may or may not exist, use the 'in' operator (opIn_r() above).
+        may or may not exist, use the 'in' operator (opBinaryRight!"in" above).
 
         Params:
             key = key to obtain the value for
@@ -503,7 +503,7 @@ public abstract class Map ( V, K ) : BucketSet!(V.sizeof, K)
 
         Note: Use this method if it is sure that a value for key is in the map,
         in other words, it would be a bug if it isn't. To look up a mapping that
-        may or may not exist, use the 'in' operator (opIn_r() above).
+        may or may not exist, use the 'in' operator (opBinaryRight!"in" above).
 
         Params:
             key = key to obtain the value for
@@ -859,7 +859,7 @@ public abstract class Map ( size_t V, K ) : BucketSet!(V, K)
 
      ***************************************************************************/
 
-    public void[] opIn_r ( in K key )
+    public void[] opBinaryRight (string op : "in") ( in K key )
     out (val)
     {
         if (val)
@@ -879,7 +879,7 @@ public abstract class Map ( size_t V, K ) : BucketSet!(V, K)
 
         Note: Use this method if it is sure that a value for key is in the map,
         in other words, it would be a bug if it isn't. To look up a mapping that
-        may or may not exist, use the 'in' operator (opIn_r() above).
+        may or may not exist, use the 'in' operator (opBinaryRight!"in"above).
 
         Params:
             key = key to obtain the value for
@@ -909,7 +909,7 @@ public abstract class Map ( size_t V, K ) : BucketSet!(V, K)
 
         Note: Use this method if it is sure that a value for key is in the map,
         in other words, it would be a bug if it isn't. To look up a mapping that
-        may or may not exist, use the 'in' operator (opIn_r() above).
+        may or may not exist, use the 'in' operator (opBinaryRight"in" above).
 
         Params:
             key = key to obtain the value for

--- a/src/ocean/util/container/map/TreeMap.d
+++ b/src/ocean/util/container/map/TreeMap.d
@@ -138,7 +138,7 @@ struct TreeMap ( T )
 
     ***********************************************************************/
 
-    private T* opIn_r ( ulong key )
+    private T* opBinaryRight (string op : "in") ( ulong key )
     {
         return &((cast(Node*)eb64_lookup(&this.root, key)).value);
     }

--- a/src/ocean/util/container/more/Heap.d
+++ b/src/ocean/util/container/more/Heap.d
@@ -50,7 +50,11 @@ struct Heap (T, alias Compare = minHeapCompare!(T), alias Move = defaultHeapSwap
         import ocean.core.Verify;
 
         alias pop       remove;
-        alias push      opCatAssign;
+
+        public template opOpAssign ( string op : "~" )
+        {
+            alias opOpAssign = push;
+        }
 
         // The actual data.
         private T[]     heap;

--- a/src/ocean/util/container/more/Stack.d
+++ b/src/ocean/util/container/more/Stack.d
@@ -399,6 +399,18 @@ unittest
     test!("==")(stack.unused(), 0);
 }
 
+unittest
+{
+    // Check overloaded operators
+    Stack!(int) stack;
+    stack ~= 4;
+    stack ~= 5;
+    stack >>= 2;
+    test!("==")(stack.pop(), 4);
+    stack <<= 1;
+    test!("==")(stack.pop(), 5);
+}
+
 /*******************************************************************************
 
     Exception that indicates any kind of out of bound access in stack, for

--- a/src/ocean/util/container/more/Stack.d
+++ b/src/ocean/util/container/more/Stack.d
@@ -33,9 +33,21 @@ public struct Stack ( V, int Size = 0 )
 {
     public alias nth         opIndex;
     public alias slice       opSlice;
-    public alias rotateRight opShrAssign;
-    public alias rotateLeft  opShlAssign;
-    public alias push        opCatAssign;
+
+    public template opOpAssign ( string op : ">>" )
+    {
+        alias opOpAssign = rotateRight;
+    }
+
+    public template opOpAssign ( string op : "<<" )
+    {
+        alias opOpAssign = rotateLeft;
+    }
+
+    public template opOpAssign ( string op : "~" )
+    {
+        alias opOpAssign = push;
+    }
 
     static if (Size == 0)
     {

--- a/src/ocean/util/container/more/Vector.d
+++ b/src/ocean/util/container/more/Vector.d
@@ -32,7 +32,11 @@ struct Vector (V, int Size = 0)
 {
         alias add       push;
         alias slice     opSlice;
-        alias push      opCatAssign;
+
+        public template opOpAssign ( string op : "~" )
+        {
+            alias opOpAssign = push;
+        }
 
         static if (Size == 0)
                   {


### PR DESCRIPTION
In dmd 2.088, the D1 operator overloads are deprecated. This causes almost 2000 deprecation warnings when compiling most apps using our libraries.

This PR deals with the straightforward cases, where the operator is a member of a struct. In this case it is a simple substitution, that won't break any existing code.

(The cases where the operator is a member of a class are far more difficult, because the D1 operator overloads are virtual, whereas the D2 overloads are static. Those cases are not dealt with in this PR).

Additionally in this PR I have fixed one 'shadowing' warning in a unit test, and cleaned up a broken doc comment.
