### PR TITLE
Add DUB unittest configuration to specify library dependencies

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -7,3 +7,9 @@ copyright "Copyright (c) 2004 dunnhumby Germany GmbH and Tango contributors. All
 systemDependencies "Depending on the component used you might need one of the following libraries (check the used modules for details): -lglib-2.0 -lpcre -lxml2 -lxslt -lreadline -lhistory -llzo2 -lbz2 -lz -ldl -lgcrypt -lgpg-error -lrt -lebtree (version from https://github.com/sociomantic-tsunami/ebtree)"
 importPaths "src"
 targetType "sourceLibrary"
+
+configuration "unittest" {
+    excludedSourceFiles "src/ocean/core/UnitTestRunner.d"
+    libs "glib-2.0" "pcre" "ebtree" "readline" "lzo2" "gcrypt" "gpg-error"
+    lflags "-l:libcrypto.so.1.0.0" "-l:libssl.so.1.0.0"
+}


### PR DESCRIPTION
This should help avoid linker errors when running `dub test`.  Note that `libssl` (and hence `libcrypto`) have to be set to v1.0.0 instead of the default v1.1.0, as ocean requires symbols that are not available via the latter, specifically:

  - `SSL_library_init`
  - `SSL_load_error_strings`
  - `SSLv23_method`

Placing these settings inside the unittest configuration should ensure that downstreams can avoid linking against library dependencies they do not need: however, it comes at the cost that downstreams have to specify their library dependencies manually.

Some libraries specified in `Build.mak` appear to be unnecessary and are therefore not included in the DUB config:

  - bz2
  - history
  - rt
  - xml2
  - zlib (`-lz`) [probably because `zlib` is already in phobos]

The `ocean.core.UnitTestRunner` module is excluded from unittest builds, as its `main` would clash with the DUB auto-created `main`.  A different option would be to explicitly use the ocean unittest runner, but this is left for a later decision.

Finally, note that this setup will only run unittests, not integration tests: addressing this is left for future work.

As written, it is possible to run `dub test` successfully with upstream DMD.  `Using --compiler=dmd-transitional` fails with an error message:

```
Error: module typetuple is in file 'std/typetuple.d' which cannot be read
```

while using `--compiler=ldc2` or `--compiler=ldmd2` fails because of https://github.com/sociomantic-tsunami/ocean/issues/730.