### PR TITLE
Replace version (UnitTest) with version (unittest) in integration tests

### DIFF
--- a/integrationtest/asyncio/main.d
+++ b/integrationtest/asyncio/main.d
@@ -115,7 +115,7 @@ class AsyncIOUsingApp: DaemonApp
     }
 }
 
-version(UnitTest) {} else
+version (unittest) {} else
 void main(istring[] args)
 {
 

--- a/integrationtest/buffered/main.d
+++ b/integrationtest/buffered/main.d
@@ -5,7 +5,7 @@ import ocean.util.test.DirectorySandbox;
 import ocean.io.device.File;
 import ocean.core.Test;
 
-version(UnitTest) {} else
+version (unittest) {} else
 void main ()
 {
     auto sandbox = DirectorySandbox.create();

--- a/integrationtest/filesystemevent/main.d
+++ b/integrationtest/filesystemevent/main.d
@@ -281,7 +281,7 @@ class FileCreationTestTask: Task
 
 *******************************************************************************/
 
-version(UnitTest) {} else
+version (unittest) {} else
 void main ( )
 {
     initScheduler(SchedulerConfiguration.init);

--- a/integrationtest/flexiblefilequeue/main.d
+++ b/integrationtest/flexiblefilequeue/main.d
@@ -18,7 +18,7 @@ import ocean.text.util.StringC;
 import ocean.util.container.queue.FlexibleFileQueue;
 import ocean.util.test.DirectorySandbox;
 
-version(UnitTest) {} else
+version (unittest) {} else
 public void main ()
 {
     // Create will cd us into the sandbox

--- a/integrationtest/httpserver/main.d
+++ b/integrationtest/httpserver/main.d
@@ -139,7 +139,7 @@ class ClientTask: Task
 
 *******************************************************************************/
 
-version(UnitTest) {} else
+version (unittest) {} else
 int main ( )
 {
     initScheduler(SchedulerConfiguration.init);

--- a/integrationtest/loggerstats/main.d
+++ b/integrationtest/loggerstats/main.d
@@ -25,7 +25,7 @@ import ocean.io.device.File;
 
 *******************************************************************************/
 
-version(UnitTest) {} else
+version (unittest) {} else
 void main ( )
 {
     auto dev_null = new File("/dev/null", File.WriteAppending);

--- a/integrationtest/pathutils/main.d
+++ b/integrationtest/pathutils/main.d
@@ -32,7 +32,7 @@ import ocean.util.test.DirectorySandbox;
 import core.sys.posix.sys.stat;
 
 /// Test method
-version(UnitTest) {} else
+version (unittest) {} else
 void main ( )
 {
     auto sandbox = DirectorySandbox.create();

--- a/integrationtest/prometheusstats/main.d
+++ b/integrationtest/prometheusstats/main.d
@@ -154,7 +154,7 @@ class ClientTask: Task
 
 *******************************************************************************/
 
-version(UnitTest) {} else
+version (unittest) {} else
 int main ( )
 {
     initScheduler(SchedulerConfiguration.init);

--- a/integrationtest/reopenfiles/main.d
+++ b/integrationtest/reopenfiles/main.d
@@ -162,7 +162,7 @@ class ReopenableFilesApp : DaemonApp
 
 }
 
-version(UnitTest) {} else
+version (unittest) {} else
 void main(istring[] args)
 {
     auto sandbox = DirectorySandbox.create(["etc", "log"]);

--- a/integrationtest/scheduler/main.d
+++ b/integrationtest/scheduler/main.d
@@ -81,7 +81,7 @@ class RegularTask : Task
     void copyArguments ( ) { }
 }
 
-version(UnitTest) {} else
+version (unittest) {} else
 void main ( )
 {
     SchedulerConfiguration config;

--- a/integrationtest/selectlistener/main.d
+++ b/integrationtest/selectlistener/main.d
@@ -145,7 +145,7 @@ void run_test ( istring socket_path )
 
 *******************************************************************************/
 
-version(UnitTest) {} else
+version (unittest) {} else
 int main ( )
 {
     run_test("/tmp/ocean_socket_test");

--- a/integrationtest/signalext/main.d
+++ b/integrationtest/signalext/main.d
@@ -72,7 +72,7 @@ class MyApp : DaemonApp
     }
 }
 
-version(UnitTest) {} else
+version (unittest) {} else
 void main(istring[] args)
 {
     static extern(C) void sighandler (int sig)

--- a/integrationtest/signalfd/main.d
+++ b/integrationtest/signalfd/main.d
@@ -490,7 +490,7 @@ private class SignalFDTest
 
 *******************************************************************************/
 
-version(UnitTest) {} else
+version (unittest) {} else
 void main ( )
 {
     // Test a single signal handled by a signalfd

--- a/integrationtest/sysstats/main.d
+++ b/integrationtest/sysstats/main.d
@@ -97,7 +97,7 @@ class MyApp : DaemonApp
 import ocean.io.device.File;
 import ocean.util.test.DirectorySandbox;
 
-version(UnitTest) {} else
+version (unittest) {} else
 void main(istring[] args)
 {
     auto sandbox = DirectorySandbox.create(["etc", "log"]);

--- a/integrationtest/taskext_cli/main.d
+++ b/integrationtest/taskext_cli/main.d
@@ -59,7 +59,7 @@ class TestApp : CliApp
 }
 
 
-version(UnitTest) {} else
+version (unittest) {} else
 int main ( istring[] cl_args )
 {
     auto app = new TestApp;

--- a/integrationtest/taskext_daemon/main.d
+++ b/integrationtest/taskext_daemon/main.d
@@ -70,7 +70,7 @@ class TestApp : DaemonApp
     }
 }
 
-version(UnitTest) {} else
+version (unittest) {} else
 int main ( istring[] cl_args )
 {
     with (DirectorySandbox.create(["etc", "log"]))

--- a/integrationtest/timerext/main.d
+++ b/integrationtest/timerext/main.d
@@ -77,7 +77,7 @@ class App : Application
     }
 }
 
-version(UnitTest) {} else
+version (unittest) {} else
 void main (istring[] args)
 {
     auto sandbox = DirectorySandbox.create(["etc", "log"]);

--- a/integrationtest/unixlistener/main.d
+++ b/integrationtest/unixlistener/main.d
@@ -156,7 +156,7 @@ void client_process (cstring socket_path)
 
 *******************************************************************************/
 
-version(UnitTest) {} else
+version (unittest) {} else
 int main ( )
 {
     // Since this is a one-off test, we will not care about destroying

--- a/integrationtest/unixsocket/main.d
+++ b/integrationtest/unixsocket/main.d
@@ -80,7 +80,7 @@ int runClient ( sockaddr_un* socket_address )
     return 0;
 }
 
-version(UnitTest) {} else
+version (unittest) {} else
 int main ( )
 {
     bool in_child = false;

--- a/integrationtest/unixsockext/main.d
+++ b/integrationtest/unixsockext/main.d
@@ -60,7 +60,7 @@ class UnixSockListeningApp : DaemonApp
 import ocean.io.device.File;
 import ocean.util.test.DirectorySandbox;
 
-version(UnitTest) {} else
+version (unittest) {} else
 void main(istring[] args)
 {
     auto sandbox = DirectorySandbox.create(["etc", "log"]);

--- a/integrationtest/unregisterclient/main.d
+++ b/integrationtest/unregisterclient/main.d
@@ -43,7 +43,7 @@ private void corruptEventObject (SelectEvent client)
     ptr[0..initializer.length] = 0;
 }
 
-version(UnitTest) {} else
+version (unittest) {} else
 void main(istring[] args)
 {
     bool handler1()


### PR DESCRIPTION
This is a follow-up to b20cc5c8b30c86e1ef7213b622e90f07b2d2632c, which already replaced most of the old `version (UnitTest)` statements, but did not touch code in `integrationtest`.