### PR TITLE
Remove use of hacky genOpCmp and genOpEquals mixins

### DIFF
--- a/src/ocean/core/array/DefaultPredicates.d
+++ b/src/ocean/core/array/DefaultPredicates.d
@@ -21,7 +21,6 @@ module ocean.core.array.DefaultPredicates;
 version (unittest)
 {
     import ocean.core.Test;
-    import ocean.transition;
 }
 
 struct DefaultPredicates
@@ -59,23 +58,22 @@ unittest
     {
         int x;
 
-        mixin (genOpEquals(
-        `{
+        override equals_t opEquals(Object rhs)
+        {
             auto o = cast(typeof(this)) rhs;
             if (o is null) return false;
             return (this.x == o.x);
-        }`));
+        }
     }
 
     struct S
     {
         int x;
 
-        mixin (genOpEquals("
+        bool opEquals(const typeof(this) rhs) const
         {
             return this.x == rhs.x;
         }
-        "));
     }
 
     auto c1 = new C;

--- a/src/ocean/math/Range.d
+++ b/src/ocean/math/Range.d
@@ -19,8 +19,8 @@
 
 module ocean.math.Range;
 
-import ocean.transition;
 import ocean.core.Verify;
+import ocean.meta.types.Qualifiers;
 
 version (unittest)
 {
@@ -613,8 +613,8 @@ public struct Range ( T )
 
     ***************************************************************************/
 
-    mixin (genOpCmp(
-    `{
+    public int opCmp ( const typeof(this) rhs ) const
+    {
         auto _this = cast(Unqual!(typeof(this))) this;
         auto _rhs = cast(Unqual!(typeof(rhs))) rhs;
 
@@ -627,7 +627,7 @@ public struct Range ( T )
         if ( _this.max_ < _rhs.max_ ) return -1;
         if ( _rhs.max_ < _this.max_ ) return 1;
         return 0;
-    }`));
+    }
 
     unittest
     {

--- a/src/ocean/math/WideUInt.d
+++ b/src/ocean/math/WideUInt.d
@@ -297,7 +297,7 @@ public struct WideUInt ( size_t N )
 
     ***************************************************************************/
 
-    mixin(genOpCmp("
+    public int opCmp ( const typeof(this) rhs ) const
     {
         ptrdiff_t idx = N-1;
         while (idx > 0)
@@ -311,7 +311,6 @@ public struct WideUInt ( size_t N )
         auto b = rhs.payload[idx];
         return a < b ? -1 : (a > b ? 1 : 0);
     }
-    "));
 
     unittest
     {

--- a/src/ocean/time/Time.d
+++ b/src/ocean/time/Time.d
@@ -136,17 +136,16 @@ struct TimeSpan
         /**
          * Compares this object against another TimeSpan value.
          */
-        mixin(genOpCmp(`
-            {
-                    if (ticks_ < rhs.ticks_)
-                        return -1;
+        public int opCmp ( const typeof(this) rhs ) const
+        {
+            if (ticks_ < rhs.ticks_)
+                return -1;
 
-                    if (ticks_ > rhs.ticks_)
-                        return 1;
+            if (ticks_ > rhs.ticks_)
+                return 1;
 
-                    return 0;
-            }
-        `));
+            return 0;
+        }
 
         /**
          * Add or subtract the TimeSpan given to this TimeSpan returning a

--- a/src/ocean/util/container/ebtree/EBTree128.d
+++ b/src/ocean/util/container/ebtree/EBTree128.d
@@ -110,8 +110,8 @@ class EBTree128 ( bool signed = false ) : IEBTree
 
          **********************************************************************/
 
-        public mixin(genOpCmp(
-        `{
+        public int opCmp ( const typeof(this) rhs ) const
+        {
             static if (signed)
             {
                 return eb128i_cmp_264(this.lo, this.hi, rhs.lo, rhs.hi);
@@ -120,7 +120,7 @@ class EBTree128 ( bool signed = false ) : IEBTree
             {
                 return eb128_cmp_264(this.lo, this.hi, rhs.lo, rhs.hi);
             }
-        }`));
+        }
 
         public equals_t opEquals(Key rhs)
         {

--- a/src/ocean/util/container/ebtree/EBTree32.d
+++ b/src/ocean/util/container/ebtree/EBTree32.d
@@ -156,12 +156,12 @@ class EBTree32 ( bool signed = false ) : IEBTree
 
          **********************************************************************/
 
-        public mixin (genOpCmp(
-        `{
+        public int opCmp ( const typeof(this) rhs ) const
+        {
             return (this.hi > rhs.hi)? +1 :
                    (this.hi < rhs.hi)? -1 :
                    (this.lo >= rhs.lo)? (this.lo > rhs.lo) : -1;
-        }`));
+        }
 
         /**********************************************************************
 

--- a/src/ocean/util/container/ebtree/EBTree64.d
+++ b/src/ocean/util/container/ebtree/EBTree64.d
@@ -155,12 +155,12 @@ class EBTree64 ( bool signed = false ) : IEBTree
 
          **********************************************************************/
 
-        public mixin(genOpCmp(
-        `{
+        public int opCmp ( const typeof(this) rhs ) const
+        {
             return (this.hi > rhs.hi)? +1 :
                    (this.hi < rhs.hi)? -1 :
                    (this.lo >= rhs.lo)? (this.lo > rhs.lo) : -1;
-        }`));
+        }
 
         public equals_t opEquals(Dual32Key rhs)
         {

--- a/src/ocean/util/container/ebtree/c/eb128tree.d
+++ b/src/ocean/util/container/ebtree/c/eb128tree.d
@@ -71,10 +71,10 @@ struct UCent
 
      **************************************************************************/
 
-    public mixin (genOpCmp(
-    `{
+    public int opCmp ( const typeof(this) rhs ) const
+    {
         return eb128_cmp_264(this.tupleof, rhs.tupleof);
-    }`));
+    }
 
     public equals_t opEquals(UCent rhs)
     {
@@ -113,10 +113,10 @@ struct Cent
 
      **************************************************************************/
 
-    public mixin(genOpCmp(
-    `{
+    public int opCmp ( const typeof(this) rhs ) const
+    {
         return eb128i_cmp_264(this.tupleof, rhs.tupleof);
-    }`));
+    }
 
     public equals_t opEquals(Cent rhs)
     {

--- a/src/ocean/util/container/map/model/BucketInfo.d
+++ b/src/ocean/util/container/map/model/BucketInfo.d
@@ -60,10 +60,10 @@ class BucketInfo
 
          **********************************************************************/
 
-        public mixin (genOpCmp(
-        `{
+        public int opCmp ( const typeof(this) rhs ) const
+        {
             return (this.length >= rhs.length)? this.length > rhs.length : -1;
-        }`));
+        }
 
         public equals_t opEquals (Bucket rhs)
         {

--- a/src/ocean/util/container/pool/FreeList.d
+++ b/src/ocean/util/container/pool/FreeList.d
@@ -39,7 +39,6 @@ import ocean.core.Array : pop;
 import ocean.meta.traits.Basic;
 import ocean.meta.types.Typedef;
 
-import ocean.transition;
 import ocean.core.Buffer;
 import ocean.core.TypeConvert;
 
@@ -368,11 +367,11 @@ version (unittest)
 
     private class Class
     {
-        mixin(genOpEquals(`
+        override equals_t opEquals(Object rhs)
         {
             auto crhs = cast(typeof(this)) rhs;
             return this.i == crhs.i && this.s == crhs.s;
-        }`));
+        }
 
         size_t i;
         char[] s;

--- a/src/ocean/util/container/pool/ObjectPool.d
+++ b/src/ocean/util/container/pool/ObjectPool.d
@@ -44,7 +44,6 @@ module ocean.util.container.pool.ObjectPool;
 import ocean.util.container.pool.model.IAggregatePool;
 import ocean.util.container.pool.model.IResettable;
 
-import ocean.transition;
 
 /*******************************************************************************
 
@@ -196,11 +195,11 @@ version (unittest)
     {
         size_t object_pool_index;
 
-        mixin(genOpEquals(`
+        override equals_t opEquals(Object rhs)
         {
             auto crhs = cast(typeof(this)) rhs;
             return this.i == crhs.i && this.s == crhs.s;
-        }`));
+        }
 
         size_t i;
         char[] s;


### PR DESCRIPTION
These mixins were required for the D2 transition. They can now be replaced with the code which they generated.
In the case of `opEquals` they were only used inside unit tests.