### PR TITLE
Replace 'import ocean.transition' inside ocean.core modules

### DIFF
--- a/integrationtest/unixsockext/main.d
+++ b/integrationtest/unixsockext/main.d
@@ -15,7 +15,7 @@
 
 module integrationtest.unixsockext.main;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import core.sys.posix.sys.stat;
 import ocean.core.Test;
@@ -44,6 +44,8 @@ class UnixSockListeningApp : DaemonApp
     // Called after arguments and config file parsing.
     override protected int run ( Arguments args, ConfigParser config )
     {
+        import ocean.transition : Octal;
+
         this.startEventHandling(theScheduler.epoll);
         auto errnoexception = new ErrnoException;
 

--- a/src/ocean/core/Test.d
+++ b/src/ocean/core/Test.d
@@ -28,10 +28,10 @@
 module ocean.core.Test;
 
 
-import ocean.transition;
-
 import core.memory;
 import ocean.core.Enforce;
+import ocean.meta.types.Qualifiers;
+
 import ocean.text.convert.Formatter;
 
 /******************************************************************************
@@ -321,6 +321,8 @@ unittest
 public void testNoAlloc ( lazy void expr, istring file = __FILE__,
     int line = __LINE__ )
 {
+    import ocean.transition;
+
     size_t used1, free1;
     ocean.transition.gc_usage(used1, free1);
 
@@ -368,6 +370,8 @@ unittest
 
 unittest
 {
+    import ocean.meta.types.Typedef;
+
     auto t = new NamedTest("typedef");
 
     mixin(Typedef!(int, "MyInt"));

--- a/src/ocean/core/UnitTestRunner.d
+++ b/src/ocean/core/UnitTestRunner.d
@@ -49,10 +49,8 @@
 
 module ocean.core.UnitTestRunner;
 
-import ocean.transition;
-
-
 import ocean.core.Verify;
+import ocean.meta.types.Qualifiers;
 import ocean.stdc.string: strdup, strlen, strncmp;
 import core.sys.posix.unistd: unlink;
 import core.sys.posix.sys.time: gettimeofday, timeval;
@@ -186,6 +184,8 @@ private class UnitTestRunner
 
     private int run ( )
     {
+        import ocean.transition;
+
         verify(prog.length > 0);
 
         timeval start_time = this.now();

--- a/src/ocean/io/FilePath.d
+++ b/src/ocean/io/FilePath.d
@@ -17,10 +17,12 @@
 
 module ocean.io.FilePath;
 
-import ocean.transition;
+import ocean.transition : Octal;
 import ocean.core.Verify;
+import ocean.core.TypeConvert: assumeUnique;
 import ocean.io.Path;
 import ocean.io.model.IFile : FileConst, FileInfo;
+import ocean.meta.types.Qualifiers;
 
 import core.sys.posix.unistd : link;
 import ocean.stdc.string : memmove;

--- a/src/ocean/io/Path.d
+++ b/src/ocean/io/Path.d
@@ -62,7 +62,8 @@ import ocean.core.Verify;
 import ocean.io.model.IFile : FileConst, FileInfo;
 import ocean.sys.Common;
 public import ocean.time.Time : Time, TimeSpan;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
+import ocean.transition : Octal;
 
 import core.stdc.string : memmove;
 

--- a/src/ocean/io/console/AppStatus.d
+++ b/src/ocean/io/console/AppStatus.d
@@ -66,9 +66,9 @@ import ocean.io.Console;
 import ocean.io.Stdout;
 import ocean.io.Terminal;
 import ocean.io.model.IConduit;
+import ocean.meta.types.Qualifiers;
 import ocean.text.convert.Formatter;
 import ocean.time.MicrosecondsClock;
-import ocean.transition;
 import ocean.util.container.AppendBuffer;
 import ocean.text.convert.Integer;
 
@@ -907,6 +907,8 @@ public class AppStatus
 
     public bool getMemoryUsage ( out float mem_allocated, out float mem_free )
     {
+        import ocean.transition;
+
         static immutable float Mb = 1024 * 1024;
         size_t used, free;
         ocean.transition.gc_usage(used, free);

--- a/src/ocean/io/device/TempFile.d
+++ b/src/ocean/io/device/TempFile.d
@@ -23,8 +23,9 @@
 
 module ocean.io.device.TempFile;
 
-import ocean.transition;
 import ocean.core.Verify;
+import ocean.core.TypeConvert: assumeUnique;
+import ocean.meta.types.Qualifiers;
 
 import Path = ocean.io.Path;
 import ocean.math.random.Kiss : Kiss;
@@ -210,6 +211,8 @@ class TempFile : File
      */
     private bool openTempFile(cstring path, TempStyle style)
     {
+        import ocean.transition : Octal;
+
         // Check suitability
         {
             mstring path_mut = Path.parse(path.dup).path;

--- a/src/ocean/net/server/unix/UnixListener.d
+++ b/src/ocean/net/server/unix/UnixListener.d
@@ -20,7 +20,7 @@ import ocean.net.server.unix.UnixConnectionHandler;
 import ocean.net.server.SelectListener;
 import ocean.io.select.EpollSelectDispatcher;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /// Provides default functionality for handling unix socket commands.
 public class UnixListener : UnixSocketListener!( BasicCommandHandler )
@@ -178,6 +178,8 @@ public class UnixSocketListener ( CommandHandlerType ) : SelectListener!(
             address.sun_family = AF_UNIX;
             address.sun_path[0 .. this.address_pathnul.length] =
                 this.address_pathnul;
+
+            import ocean.transition : Octal;
 
             // The socket should be opened with rw-rw-r-- permissions,
             // so the owner and group could connect to it by default.

--- a/src/ocean/sys/Environment.d
+++ b/src/ocean/sys/Environment.d
@@ -17,7 +17,8 @@
 
 module ocean.sys.Environment;
 
-import ocean.transition;
+import ocean.core.TypeConvert: assumeUnique;
+import ocean.meta.types.Qualifiers;
 
 import ocean.sys.Common;
 
@@ -103,6 +104,8 @@ struct Environment
 
                     if (bin.path(pe).exists)
                     {
+                        import ocean.transition : Octal;
+
                         stat_t stats;
                         stat(bin.cString.ptr, &stats);
                         if (stats.st_mode & Octal!("100"))


### PR DESCRIPTION
The `ocean.transition` module was used during D2 transition. Some of the aliases which it defined (`istring`, `cstring`, `mstring`) turned out to be useful, and were moved to another module.  This PR updates the imports to point to the new module. A couple of modules used `gc_stats` which doesn't have a replacement, but in those cases I made the transition import into a local import in a single function.

This PR cleans up all the modules in the `ocean.core.*` package. The rest of ocean will have to be updated at some time in the future.