### PR TITLE
Remove workarounds used during D2 transition

### DIFF
--- a/integrationtest/unixlistener/main.d
+++ b/integrationtest/unixlistener/main.d
@@ -94,7 +94,7 @@ void client_process (cstring socket_path)
     cstring readData ()
     {
         read_buffer.length = 100;
-        enableStomping(read_buffer);
+        assumeSafeAppend(read_buffer);
 
         auto buff = cast(void[])read_buffer;
 
@@ -110,7 +110,7 @@ void client_process (cstring socket_path)
         enforce(read_bytes > 0);
 
         read_buffer.length = read_bytes;
-        enableStomping(read_buffer);
+        assumeSafeAppend(read_buffer);
         return read_buffer;
     }
 

--- a/src/ocean/math/Range.d
+++ b/src/ocean/math/Range.d
@@ -50,8 +50,8 @@ public struct Range ( T )
 
     ***************************************************************************/
 
-    import ocean.transition: TypeofThis, assumeUnique;
-    mixin TypeofThis!();
+    alias typeof(this) This;
+
 
     /***************************************************************************
 
@@ -215,6 +215,8 @@ public struct Range ( T )
     {
         public istring toString()
         {
+            import ocean.core.TypeConvert: assumeUnique;
+
             auto msg = format("{}({}, {}", This.stringof, this.min_, this.max_);
 
             if (this.is_empty)

--- a/src/ocean/text/formatter/SmartUnion.d
+++ b/src/ocean/text/formatter/SmartUnion.d
@@ -76,7 +76,7 @@ private struct SmartUnionFormatter ( SU )
 
     static assert(is(TemplateInstanceArgs!(SmartUnion, SU)));
 
-    mixin TypeofThis;
+    alias typeof(this) This;
 
     /// Smart union to format.
     private SU smart_union;

--- a/src/ocean/util/Convert.d
+++ b/src/ocean/util/Convert.d
@@ -916,7 +916,8 @@ D toStringFromString(D,S)(S value)
     static if (is(S : D))
         return value;
 
-    else static if (!isMutable!(DElem) || !isMutable!(SElem))
+    else static if ( is(DElem == const) || is(DElem == immutable)
+        || is(SElem == const) || is(SElem == immutable) )
         // both cases require creating new string which makes
         // blindly casting result of transcoding to D inherently const correct
         return cast(D) toStringFromString!(Unqual!(DElem)[])(value.dup);

--- a/src/ocean/util/serialize/contiguous/package.d
+++ b/src/ocean/util/serialize/contiguous/package.d
@@ -203,7 +203,7 @@ struct S
         int union_b;
     }
 
-    mixin TypeofThis!();
+    alias typeof(this) This;
 
     /***************************************************************************
 


### PR DESCRIPTION
This PR cleans up the main workarounds used during D2 transition.
These are the code changes required before `import ocean.transition` can be removed (the remaining required changes only involve changes to import statements).
None of the changes in this PR actually affect any generated code.