### PR TITLE
Replace ocean.transition imports where trivially possible

### DIFF
--- a/example/collectd/main.d
+++ b/example/collectd/main.d
@@ -20,7 +20,7 @@
 
 module example.collectd.main;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Test;
 import ocean.net.collectd.Collectd;
 

--- a/integrationtest/asyncio/main.d
+++ b/integrationtest/asyncio/main.d
@@ -15,7 +15,7 @@
 
 module integrationtest.asyncio.main;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import core.sys.posix.sys.stat;
 import core.sys.posix.pthread;

--- a/integrationtest/filesystemevent/main.d
+++ b/integrationtest/filesystemevent/main.d
@@ -15,7 +15,7 @@
 
 module integrationtest.filesystemevent.main;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Enforce;
 

--- a/integrationtest/flexiblefilequeue/main.d
+++ b/integrationtest/flexiblefilequeue/main.d
@@ -12,7 +12,7 @@
 
 module integrationtest.flexiblefilequeue.main;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.io.Stdout;
 import ocean.text.util.StringC;
 import ocean.util.container.queue.FlexibleFileQueue;

--- a/integrationtest/httpserver/main.d
+++ b/integrationtest/httpserver/main.d
@@ -19,7 +19,7 @@
 
 module integrationtest.httpserver.main;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.net.http.TaskHttpConnectionHandler;
 import ocean.net.http.HttpConst : HttpResponseCode;

--- a/integrationtest/pathutils/main.d
+++ b/integrationtest/pathutils/main.d
@@ -15,7 +15,7 @@
 
 module integrationtest.pathutils.main;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Enforce;
 

--- a/integrationtest/prometheusstats/main.d
+++ b/integrationtest/prometheusstats/main.d
@@ -15,7 +15,7 @@
 
 module integrationtest.prometheusstats.main;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.io.select.EpollSelectDispatcher;
 import ocean.task.Task;

--- a/integrationtest/reopenfiles/main.d
+++ b/integrationtest/reopenfiles/main.d
@@ -15,7 +15,7 @@
 
 module integrationtest.reopenfiles.main;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import core.sys.posix.sys.stat;
 import core.sys.linux.fcntl;

--- a/integrationtest/scheduler/main.d
+++ b/integrationtest/scheduler/main.d
@@ -23,7 +23,7 @@ import ocean.task.Task;
 import ocean.task.TaskPool;
 import ocean.task.util.Timer;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Test;
 import ocean.io.Stdout;
 

--- a/integrationtest/selectlistener/main.d
+++ b/integrationtest/selectlistener/main.d
@@ -21,7 +21,7 @@
 
 module integrationtest.selectlistener.main;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Enforce: enforce;
 import Ocean = ocean.core.Test;

--- a/integrationtest/signalext/main.d
+++ b/integrationtest/signalext/main.d
@@ -11,7 +11,7 @@ module integrationtest.signalext.main;
 import ocean.core.Test;
 import ocean.sys.ErrnoException;
 import ocean.text.util.StringC;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.util.app.DaemonApp;
 import ocean.io.device.File;
 import Path = ocean.io.Path;

--- a/integrationtest/signalfd/main.d
+++ b/integrationtest/signalfd/main.d
@@ -28,7 +28,7 @@ import ocean.sys.SignalFD;
 import ocean.sys.Epoll;
 import ocean.sys.SignalMask;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Array : contains;
 import ocean.core.Enforce;
 import ocean.core.Test;

--- a/integrationtest/sysstats/main.d
+++ b/integrationtest/sysstats/main.d
@@ -15,7 +15,7 @@
 
 module integrationtest.sysstats.main;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Test;
 import ocean.sys.ErrnoException;

--- a/integrationtest/taskext_cli/main.d
+++ b/integrationtest/taskext_cli/main.d
@@ -15,7 +15,7 @@
 
 module integrationtest.taskext_cli.main;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.util.app.CliApp;
 import ocean.text.Arguments;
 import ocean.task.Task;

--- a/integrationtest/taskext_daemon/main.d
+++ b/integrationtest/taskext_daemon/main.d
@@ -15,7 +15,7 @@
 
 module integrationtest.taskext_daemon.main;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.util.app.DaemonApp;
 import ocean.util.test.DirectorySandbox;
 import ocean.task.Task;

--- a/integrationtest/timerext/main.d
+++ b/integrationtest/timerext/main.d
@@ -16,8 +16,8 @@
 
 module integrationtest.timerext.main;
 
-import ocean.transition;
 import ocean.core.Test;
+import ocean.meta.types.Qualifiers;
 import ocean.util.app.Application;
 import ocean.util.app.ext.TimerExt;
 import ocean.util.test.DirectorySandbox;
@@ -26,7 +26,7 @@ import ocean.io.device.File;
 class App : Application
 {
     import ocean.io.select.EpollSelectDispatcher;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     private EpollSelectDispatcher epoll;
     private TimerExt timers;

--- a/integrationtest/unixlistener/main.d
+++ b/integrationtest/unixlistener/main.d
@@ -15,7 +15,7 @@
 
 module integrationtest.unixlistener.main;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import core.thread;
 import core.stdc.errno;

--- a/integrationtest/unixsocket/main.d
+++ b/integrationtest/unixsocket/main.d
@@ -32,7 +32,7 @@ import ocean.stdc.posix.sys.wait;
 import ocean.stdc.string;
 import ocean.sys.socket.UnixSocket;
 import ocean.text.util.StringC;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import core.stdc.stdio;
 import core.sys.posix.stdlib : mkdtemp;

--- a/integrationtest/unregisterclient/main.d
+++ b/integrationtest/unregisterclient/main.d
@@ -15,7 +15,7 @@
 
 module integrationtest.unregisterclient.main;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.io.select.EpollSelectDispatcher;
 import ocean.io.select.client.SelectEvent;

--- a/src/ocean/application/components/ConfigOverrides.d
+++ b/src/ocean/application/components/ConfigOverrides.d
@@ -15,8 +15,9 @@
 
 module ocean.application.components.ConfigOverrides;
 
-import ocean.transition;
+import ocean.core.TypeConvert: assumeUnique;
 import ocean.core.Verify;
+import ocean.meta.types.Qualifiers;
 import ocean.text.Arguments;
 import ocean.text.Util : join, locate, locatePrior, trim;
 import ocean.util.config.ConfigParser;

--- a/src/ocean/application/components/OpenFiles.d
+++ b/src/ocean/application/components/OpenFiles.d
@@ -15,7 +15,7 @@
 
 module ocean.application.components.OpenFiles;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /// ditto
 public class OpenFiles

--- a/src/ocean/application/components/PidLock.d
+++ b/src/ocean/application/components/PidLock.d
@@ -15,7 +15,7 @@
 
 module ocean.application.components.PidLock;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /// ditto
 public struct PidLock

--- a/src/ocean/application/components/Signals.d
+++ b/src/ocean/application/components/Signals.d
@@ -22,7 +22,7 @@
 
 module ocean.application.components.Signals;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /// ditto
 public class Signals

--- a/src/ocean/application/components/TaskScheduler.d
+++ b/src/ocean/application/components/TaskScheduler.d
@@ -15,7 +15,7 @@
 
 module ocean.application.components.TaskScheduler;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.array.Search : find;
 import ocean.core.Enforce;
 import ocean.meta.codegen.Identifier;

--- a/src/ocean/application/components/UnixSocketCommands.d
+++ b/src/ocean/application/components/UnixSocketCommands.d
@@ -18,7 +18,7 @@ module ocean.application.components.UnixSocketCommands;
 /// ditto
 public class UnixSocketCommands
 {
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
     import ocean.core.Enforce;
     import ocean.io.select.EpollSelectDispatcher;
     import ocean.text.convert.Integer;

--- a/src/ocean/application/components/Version.d
+++ b/src/ocean/application/components/Version.d
@@ -15,7 +15,7 @@
 
 module ocean.application.components.Version;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Array: startsWith, map;
 import ocean.core.array.Mutation /* : moveToEnd, sort */;
 import ocean.text.Util;

--- a/src/ocean/core/Array.d
+++ b/src/ocean/core/Array.d
@@ -33,7 +33,7 @@
 module ocean.core.Array;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Test;
 import ocean.core.Buffer;

--- a/src/ocean/core/BitArray.d
+++ b/src/ocean/core/BitArray.d
@@ -16,8 +16,6 @@
  */
 module ocean.core.BitArray;
 
-import ocean.transition;
-
 import ocean.core.BitManip;
 import ocean.core.Verify;
 

--- a/src/ocean/core/Buffer.d
+++ b/src/ocean/core/Buffer.d
@@ -27,7 +27,7 @@
 module ocean.core.Buffer;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.meta.traits.Basic;
 import ocean.meta.types.Arrays;

--- a/src/ocean/core/DeepCompare.d
+++ b/src/ocean/core/DeepCompare.d
@@ -24,7 +24,7 @@ module ocean.core.DeepCompare;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 version (unittest) import ocean.core.Test;
 

--- a/src/ocean/core/Enum.d
+++ b/src/ocean/core/Enum.d
@@ -129,7 +129,7 @@ module ocean.core.Enum;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Test;
 
 /*******************************************************************************
@@ -367,7 +367,7 @@ public template SuperClassIndex ( size_t i, T ... )
 
 public template EnumBase ( T ... )
 {
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     alias IEnum.Name Name;
     alias IEnum.Value Value;

--- a/src/ocean/core/Exception.d
+++ b/src/ocean/core/Exception.d
@@ -92,7 +92,7 @@ unittest
 
 public template ReusableExceptionImplementation()
 {
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
     import ocean.core.Buffer;
     static import ocean.core.array.Mutation;
     static import ocean.text.convert.Formatter;
@@ -333,7 +333,7 @@ version (unittest)
 
 public template DefaultExceptionCtor()
 {
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     public this (istring msg, istring file = __FILE__,
                  typeof(__LINE__) line = __LINE__)

--- a/src/ocean/core/ExceptionDefinitions.d
+++ b/src/ocean/core/ExceptionDefinitions.d
@@ -16,7 +16,7 @@
  */
 module ocean.core.ExceptionDefinitions;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 ////////////////////////////////////////////////////////////////////////////////
 /*

--- a/src/ocean/core/MessageFiber.d
+++ b/src/ocean/core/MessageFiber.d
@@ -56,7 +56,7 @@
 
 module ocean.core.MessageFiber;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 import ocean.core.Array: copy;
 import ocean.core.SmartUnion;

--- a/src/ocean/core/SmartEnum.d
+++ b/src/ocean/core/SmartEnum.d
@@ -113,7 +113,7 @@ module ocean.core.SmartEnum;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 public import ocean.core.Enforce;
 
@@ -179,7 +179,7 @@ unittest
 
 public template SmartEnumCore ( BaseType )
 {
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     /***************************************************************************
 

--- a/src/ocean/core/SmartUnion.d
+++ b/src/ocean/core/SmartUnion.d
@@ -20,7 +20,7 @@
 
 module ocean.core.SmartUnion;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.ExceptionDefinitions;
 import ocean.core.Test;
 import ocean.core.Verify;

--- a/src/ocean/core/StructConverter.d
+++ b/src/ocean/core/StructConverter.d
@@ -20,7 +20,7 @@ module ocean.core.StructConverter;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.meta.codegen.Identifier;
 import ocean.meta.traits.Basic;
 import ocean.meta.types.Arrays : StripAllArrays;

--- a/src/ocean/core/Traits.d
+++ b/src/ocean/core/Traits.d
@@ -20,7 +20,7 @@
 module ocean.core.Traits;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Tuple: Tuple;
 

--- a/src/ocean/core/VersionCheck.d
+++ b/src/ocean/core/VersionCheck.d
@@ -19,7 +19,7 @@
 
 module ocean.core.VersionCheck;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.meta.codegen.CTFE;
 
 /// ditto

--- a/src/ocean/core/array/Mutation.d
+++ b/src/ocean/core/array/Mutation.d
@@ -21,8 +21,6 @@
 module ocean.core.array.Mutation;
 
 
-import ocean.transition;
-
 import core.stdc.string; // memmove, memset
 import core.stdc.math; // fabs;
 
@@ -36,6 +34,7 @@ import ocean.core.Verify;
 version (unittest)
 {
     import ocean.core.Test;
+    import ocean.meta.types.Qualifiers;
     import ocean.text.convert.Formatter;
 }
 

--- a/src/ocean/core/array/Search.d
+++ b/src/ocean/core/array/Search.d
@@ -22,16 +22,17 @@
 
 module ocean.core.array.Search;
 
-import ocean.transition;
 import ocean.core.Buffer;
 import ocean.core.array.DefaultPredicates;
 import ocean.core.Verify;
 import ocean.meta.traits.Basic;
+import ocean.meta.types.Qualifiers;
 
 import core.sys.posix.sys.types; // ssize_t;
 
 version (unittest)
 {
+    import ocean.meta.types.Typedef;
     import ocean.core.Test;
 }
 

--- a/src/ocean/core/array/Transformation.d
+++ b/src/ocean/core/array/Transformation.d
@@ -22,7 +22,6 @@
 module ocean.core.array.Transformation;
 
 
-import ocean.transition;
 import ocean.meta.traits.Basic;
 import ocean.meta.types.Function;
 
@@ -34,6 +33,7 @@ import ocean.core.array.Search;
 version (unittest)
 {
     import ocean.core.Test;
+    import ocean.meta.types.Qualifiers;
 }
 
 /*******************************************************************************

--- a/src/ocean/io/Console.d
+++ b/src/ocean/io/Console.d
@@ -20,7 +20,7 @@
 
 module ocean.io.Console;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.sys.Common;
 

--- a/src/ocean/io/FileException.d
+++ b/src/ocean/io/FileException.d
@@ -16,7 +16,7 @@
 module ocean.io.FileException;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.sys.ErrnoException;
 import core.stdc.errno;

--- a/src/ocean/io/FileSystem.d
+++ b/src/ocean/io/FileSystem.d
@@ -19,7 +19,7 @@
 
 module ocean.io.FileSystem;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.sys.Common;
 

--- a/src/ocean/io/Stdout.d
+++ b/src/ocean/io/Stdout.d
@@ -25,7 +25,7 @@ module ocean.io.Stdout;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.io.Terminal;
 

--- a/src/ocean/io/Terminal.d
+++ b/src/ocean/io/Terminal.d
@@ -22,7 +22,7 @@ module ocean.io.Terminal;
 
 ******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import core.sys.posix.signal;
 

--- a/src/ocean/io/compress/Lzo.d
+++ b/src/ocean/io/compress/Lzo.d
@@ -27,7 +27,7 @@ import ocean.io.compress.CompressException;
 
 import ocean.core.Enforce: enforce;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/ocean/io/compress/lzo/LzoCrc.d
+++ b/src/ocean/io/compress/lzo/LzoCrc.d
@@ -18,7 +18,7 @@ module ocean.io.compress.lzo.LzoCrc;
 
 import ocean.io.compress.lzo.c.lzoconf: lzo_crc32, lzo_crc32_init;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.TypeConvert;
 
 /******************************************************************************

--- a/src/ocean/io/console/StructTable.d
+++ b/src/ocean/io/console/StructTable.d
@@ -107,7 +107,7 @@ module ocean.io.console.StructTable;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.meta.codegen.Identifier /* : fieldIdentifier */;
 

--- a/src/ocean/io/console/Tables.d
+++ b/src/ocean/io/console/Tables.d
@@ -118,7 +118,7 @@ module ocean.io.console.Tables;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Array : copy, appendCopy, concat;
 import ocean.core.Verify;

--- a/src/ocean/io/console/readline/History.d
+++ b/src/ocean/io/console/readline/History.d
@@ -31,7 +31,7 @@ module ocean.io.console.readline.History;
 
 import C = ocean.io.console.readline.c.history;
 import ocean.text.util.StringC;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 static this()
 {

--- a/src/ocean/io/console/readline/Readline.d
+++ b/src/ocean/io/console/readline/Readline.d
@@ -45,7 +45,7 @@ import ocean.text.util.StringC;
 import core.stdc.string: strlen;
 import core.stdc.stdlib : free;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/ocean/io/console/readline/c/readline.d
+++ b/src/ocean/io/console/readline/c/readline.d
@@ -26,7 +26,7 @@ module ocean.io.console.readline.c.readline;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 public extern (C)

--- a/src/ocean/io/device/Array.d
+++ b/src/ocean/io/device/Array.d
@@ -19,7 +19,7 @@
 
 module ocean.io.device.Array;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/ocean/io/device/BitBucket.d
+++ b/src/ocean/io/device/BitBucket.d
@@ -19,7 +19,7 @@
 
 module ocean.io.device.BitBucket;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.io.device.Conduit;
 

--- a/src/ocean/io/device/Conduit.d
+++ b/src/ocean/io/device/Conduit.d
@@ -18,7 +18,7 @@
 module ocean.io.device.Conduit;
 
 import ocean.core.ExceptionDefinitions;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 public import ocean.io.model.IConduit;
 
 import core.thread;

--- a/src/ocean/io/device/Device.d
+++ b/src/ocean/io/device/Device.d
@@ -17,7 +17,7 @@
 
 module ocean.io.device.Device;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.sys.Common;
 

--- a/src/ocean/io/device/DirectIO.d
+++ b/src/ocean/io/device/DirectIO.d
@@ -62,7 +62,7 @@ module ocean.io.device.DirectIO;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 import core.memory;

--- a/src/ocean/io/device/File.d
+++ b/src/ocean/io/device/File.d
@@ -25,7 +25,7 @@
 module ocean.io.device.File;
 
 import ArrayMut = ocean.core.array.Mutation;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 import ocean.sys.Common;

--- a/src/ocean/io/device/FileMap.d
+++ b/src/ocean/io/device/FileMap.d
@@ -17,7 +17,7 @@
 
 module ocean.io.device.FileMap;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.stdc.posix.sys.mman;
 import ocean.sys.Common;
 

--- a/src/ocean/io/device/IODevice.d
+++ b/src/ocean/io/device/IODevice.d
@@ -21,7 +21,7 @@
 module ocean.io.device.IODevice;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.io.model.IConduit: ISelectable;
 

--- a/src/ocean/io/device/MemoryDevice.d
+++ b/src/ocean/io/device/MemoryDevice.d
@@ -21,7 +21,7 @@
 module ocean.io.device.MemoryDevice;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.io.model.IConduit;
 import ocean.stdc.string : memmove;
 

--- a/src/ocean/io/digest/FirstName.d
+++ b/src/ocean/io/digest/FirstName.d
@@ -17,7 +17,7 @@ module ocean.io.digest.FirstName;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.io.digest.Fnv1;
 

--- a/src/ocean/io/digest/Fnv1.d
+++ b/src/ocean/io/digest/Fnv1.d
@@ -17,7 +17,7 @@ module  ocean.io.digest.Fnv1;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.util.digest.Digest;
 
 import ocean.core.ByteSwap;

--- a/src/ocean/io/model/IConduit.d
+++ b/src/ocean/io/model/IConduit.d
@@ -19,7 +19,8 @@
 
 module ocean.io.model.IConduit;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
+import ocean.meta.types.Typedef;
 
 /*******************************************************************************
 

--- a/src/ocean/io/model/IFile.d
+++ b/src/ocean/io/model/IFile.d
@@ -17,7 +17,7 @@
 
 module ocean.io.model.IFile;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/ocean/io/model/ISuspendableThrottler.d
+++ b/src/ocean/io/model/ISuspendableThrottler.d
@@ -18,7 +18,7 @@
 
 module ocean.io.model.ISuspendableThrottler;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /*******************************************************************************

--- a/src/ocean/io/model/SuspendableThrottlerCount.d
+++ b/src/ocean/io/model/SuspendableThrottlerCount.d
@@ -27,7 +27,7 @@ module ocean.io.model.SuspendableThrottlerCount;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 import ocean.io.model.ISuspendable,

--- a/src/ocean/io/select/EpollSelectDispatcher.d
+++ b/src/ocean/io/select/EpollSelectDispatcher.d
@@ -29,7 +29,7 @@
 module ocean.io.select.EpollSelectDispatcher;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/ocean/io/select/client/EpollProcess.d
+++ b/src/ocean/io/select/client/EpollProcess.d
@@ -94,7 +94,7 @@ module ocean.io.select.client.EpollProcess;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/ocean/io/select/client/FiberTimerEvent.d
+++ b/src/ocean/io/select/client/FiberTimerEvent.d
@@ -27,7 +27,7 @@ import ocean.sys.TimerFD;
 
 import ocean.io.select.client.model.IFiberSelectClient;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import core.stdc.math: modf;
 
 

--- a/src/ocean/io/select/client/FileSystemEvent.d
+++ b/src/ocean/io/select/client/FileSystemEvent.d
@@ -32,7 +32,7 @@ import ocean.io.select.EpollSelectDispatcher;
 import ocean.io.select.client.model.ISelectClient: ISelectClient;
 import ocean.core.Buffer;
 import ocean.core.SmartUnion;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /*******************************************************************************

--- a/src/ocean/io/select/client/TimerEvent.d
+++ b/src/ocean/io/select/client/TimerEvent.d
@@ -23,7 +23,7 @@ import ocean.io.select.client.model.ISelectClient: ISelectClient;
 import ocean.sys.TimerFD;
 import ocean.core.Verify;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.io.model.IConduit: ISelectable;
 
 import core.sys.posix.time: time_t, timespec, itimerspec;

--- a/src/ocean/io/select/client/TimerSet.d
+++ b/src/ocean/io/select/client/TimerSet.d
@@ -41,7 +41,7 @@ import ocean.io.select.timeout.TimerEventTimeoutManager;
 
 import ocean.time.timeout.model.ITimeoutClient;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.util.container.map.model.IAllocator;
 debug import ocean.text.convert.Formatter;
 

--- a/src/ocean/io/select/client/model/ISelectClient.d
+++ b/src/ocean/io/select/client/model/ISelectClient.d
@@ -27,7 +27,7 @@ module ocean.io.select.client.model.ISelectClient;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 
@@ -398,6 +398,7 @@ public abstract class ISelectClient : ITimeoutClient, ISelectable, ISelectClient
 
     debug public override istring toString ( )
     {
+        import ocean.core.TypeConvert: assumeUnique;
         mstring to_string_buf;
         this.fmtInfo((cstring chunk) {to_string_buf ~= chunk;});
         return assumeUnique(to_string_buf);

--- a/src/ocean/io/select/client/model/ISelectClientInfo.d
+++ b/src/ocean/io/select/client/model/ISelectClientInfo.d
@@ -18,7 +18,7 @@ module ocean.io.select.client.model.ISelectClientInfo;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.io.model.IConduit: ISelectable;
 

--- a/src/ocean/io/select/protocol/fiber/BufferedFiberSelectWriter.d
+++ b/src/ocean/io/select/protocol/fiber/BufferedFiberSelectWriter.d
@@ -15,7 +15,7 @@
 
 module ocean.io.select.protocol.fiber.BufferedFiberSelectWriter;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/ocean/io/select/protocol/fiber/FiberSelectReader.d
+++ b/src/ocean/io/select/protocol/fiber/FiberSelectReader.d
@@ -545,7 +545,7 @@ version (unittest)
     import ocean.io.select.fiber.SelectFiber;
     import core.sys.posix.stdlib;
     import ocean.core.Test;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 }
 
 unittest

--- a/src/ocean/io/select/protocol/fiber/FiberSelectWriter.d
+++ b/src/ocean/io/select/protocol/fiber/FiberSelectWriter.d
@@ -25,7 +25,7 @@
 
 module ocean.io.select.protocol.fiber.FiberSelectWriter;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 import ocean.io.select.protocol.fiber.model.IFiberSelectProtocol;
 import ocean.io.select.client.model.ISelectClient;

--- a/src/ocean/io/select/protocol/fiber/FiberSocketConnection.d
+++ b/src/ocean/io/select/protocol/fiber/FiberSocketConnection.d
@@ -21,7 +21,7 @@ module ocean.io.select.protocol.fiber.FiberSocketConnection;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/ocean/io/select/protocol/fiber/model/IFiberSelectProtocol.d
+++ b/src/ocean/io/select/protocol/fiber/model/IFiberSelectProtocol.d
@@ -29,7 +29,7 @@ import ocean.io.select.fiber.SelectFiber;
 
 import ocean.io.select.protocol.generic.ErrnoIOException: IOError, IOWarning;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 debug ( SelectFiber ) import ocean.io.Stdout : Stderr;
 

--- a/src/ocean/io/select/protocol/generic/ErrnoIOException.d
+++ b/src/ocean/io/select/protocol/generic/ErrnoIOException.d
@@ -16,7 +16,7 @@
 module ocean.io.select.protocol.generic.ErrnoIOException;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.sys.ErrnoException;
 

--- a/src/ocean/io/select/protocol/task/TaskSelectClient.d
+++ b/src/ocean/io/select/protocol/task/TaskSelectClient.d
@@ -28,7 +28,7 @@ class TaskSelectClient: ISelectClient
     import ocean.task.IScheduler: theScheduler;
     import ocean.io.select.protocol.task.TimeoutException;
     import ocean.util.log.Logger;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     debug (SelectFiber) import ocean.io.Stdout: Stdout;
 

--- a/src/ocean/io/select/protocol/task/TaskSelectTransceiver.d
+++ b/src/ocean/io/select/protocol/task/TaskSelectTransceiver.d
@@ -52,7 +52,7 @@ class TaskSelectTransceiver
     debug (Raw) import ocean.io.Stdout: Stdout;
 
     import ocean.core.Enforce: enforce;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     /***************************************************************************
 
@@ -725,7 +725,7 @@ version (unittest)
 {
     import ocean.io.select.protocol.generic.ErrnoIOException;
     import ocean.task.Task;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 }
 
 /// Example of sending and receiving data with the `TaskSelectTransceiver`.

--- a/src/ocean/io/select/protocol/task/TaskSelectTransceiver_test.d
+++ b/src/ocean/io/select/protocol/task/TaskSelectTransceiver_test.d
@@ -15,7 +15,7 @@ module ocean.io.select.protocol.task.TaskSelectTransceiver_test;
 
 import ocean.io.select.protocol.task.TaskSelectTransceiver;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.stdc.posix.fcntl: O_NONBLOCK;
 import core.sys.posix.unistd: write, close;
 import ocean.sys.ErrnoException;

--- a/src/ocean/io/select/protocol/task/TimeoutException.d
+++ b/src/ocean/io/select/protocol/task/TimeoutException.d
@@ -17,7 +17,7 @@ module ocean.io.select.protocol.task.TimeoutException;
 
 class TimeoutException: Exception
 {
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     this ( istring file = __FILE__, int line = __LINE__ )
     {

--- a/src/ocean/io/select/selector/SelectedKeysHandler.d
+++ b/src/ocean/io/select/selector/SelectedKeysHandler.d
@@ -18,7 +18,7 @@
 module ocean.io.select.selector.SelectedKeysHandler;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.io.select.selector.model.ISelectedKeysHandler;
 

--- a/src/ocean/io/select/selector/TimeoutSelectedKeysHandler.d
+++ b/src/ocean/io/select/selector/TimeoutSelectedKeysHandler.d
@@ -28,7 +28,7 @@ import ocean.io.select.client.model.ISelectClient;
 
 import ocean.time.timeout.model.ITimeoutManager,
                ocean.time.timeout.model.ITimeoutClient;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.container.AppendBuffer: AppendBuffer;
 

--- a/src/ocean/io/select/timeout/TimerEventTimeoutManager.d
+++ b/src/ocean/io/select/timeout/TimerEventTimeoutManager.d
@@ -35,7 +35,7 @@
 module ocean.io.select.timeout.TimerEventTimeoutManager;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.time.timeout.TimeoutManager;
 

--- a/src/ocean/io/serialize/SimpleStreamSerializer.d
+++ b/src/ocean/io/serialize/SimpleStreamSerializer.d
@@ -50,7 +50,7 @@ module ocean.io.serialize.SimpleStreamSerializer;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Enforce: enforce;
 

--- a/src/ocean/io/serialize/StringStructSerializer.d
+++ b/src/ocean/io/serialize/StringStructSerializer.d
@@ -53,7 +53,7 @@ module ocean.io.serialize.StringStructSerializer;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Array;
 
@@ -556,6 +556,7 @@ public class StringStructSerializer ( Char )
 version (unittest)
 {
     import ocean.core.Test;
+    import ocean.meta.types.Typedef;
     import core.stdc.time;
 }
 

--- a/src/ocean/io/serialize/StructSerializer.d
+++ b/src/ocean/io/serialize/StructSerializer.d
@@ -19,7 +19,7 @@
 module ocean.io.serialize.StructSerializer;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.io.serialize.SimpleStreamSerializer;
 

--- a/src/ocean/io/stream/Buffered.d
+++ b/src/ocean/io/stream/Buffered.d
@@ -21,7 +21,7 @@ module ocean.io.stream.Buffered;
 
 import core.stdc.string;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 version (unittest)  import ocean.core.Test;
 import ocean.core.Verify;
 

--- a/src/ocean/io/stream/Data.d
+++ b/src/ocean/io/stream/Data.d
@@ -26,7 +26,7 @@
 
 module ocean.io.stream.Data;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/ocean/io/stream/Delimiters.d
+++ b/src/ocean/io/stream/Delimiters.d
@@ -17,7 +17,7 @@
 
 module ocean.io.stream.Delimiters;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.io.stream.Iterator;
 

--- a/src/ocean/io/stream/Format.d
+++ b/src/ocean/io/stream/Format.d
@@ -17,7 +17,7 @@
 
 module ocean.io.stream.Format;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/ocean/io/stream/Iterator.d
+++ b/src/ocean/io/stream/Iterator.d
@@ -17,7 +17,7 @@
 
 module ocean.io.stream.Iterator;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/ocean/io/stream/Lines.d
+++ b/src/ocean/io/stream/Lines.d
@@ -17,7 +17,7 @@
 
 module ocean.io.stream.Lines;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.io.stream.Iterator;
 

--- a/src/ocean/io/stream/Quotes.d
+++ b/src/ocean/io/stream/Quotes.d
@@ -17,7 +17,7 @@
 
 module ocean.io.stream.Quotes;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.io.stream.Iterator;
 

--- a/src/ocean/io/stream/TextFile.d
+++ b/src/ocean/io/stream/TextFile.d
@@ -17,7 +17,7 @@
 
 module ocean.io.stream.TextFile;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 public  import ocean.io.device.File;
 

--- a/src/ocean/io/stream/Zlib_internal.d
+++ b/src/ocean/io/stream/Zlib_internal.d
@@ -29,7 +29,7 @@ module ocean.io.stream.Zlib_internal;
 
 // package(ocean):
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/ocean/io/vfs/FileFolder.d
+++ b/src/ocean/io/vfs/FileFolder.d
@@ -17,7 +17,8 @@
 
 module ocean.io.vfs.FileFolder;
 
-import ocean.transition;
+import ocean.core.TypeConvert: assumeUnique;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/ocean/io/vfs/LinkedFolder.d
+++ b/src/ocean/io/vfs/LinkedFolder.d
@@ -17,7 +17,7 @@
 
 module ocean.io.vfs.LinkedFolder;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.io.vfs.model.Vfs;
 

--- a/src/ocean/io/vfs/VirtualFolder.d
+++ b/src/ocean/io/vfs/VirtualFolder.d
@@ -17,7 +17,7 @@
 
 module ocean.io.vfs.VirtualFolder;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/ocean/io/vfs/model/Vfs.d
+++ b/src/ocean/io/vfs/model/Vfs.d
@@ -17,7 +17,7 @@
 
 module ocean.io.vfs.model.Vfs;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.time.Time : Time;
 

--- a/src/ocean/math/BinaryHistogram.d
+++ b/src/ocean/math/BinaryHistogram.d
@@ -20,7 +20,7 @@
 
 module ocean.math.BinaryHistogram;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 /*******************************************************************************

--- a/src/ocean/math/Bracket.d
+++ b/src/ocean/math/Bracket.d
@@ -14,7 +14,7 @@
  *
  */
 module ocean.math.Bracket;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 static import tsm = core.stdc.math;
 import ocean.math.Math;

--- a/src/ocean/math/Distribution.d
+++ b/src/ocean/math/Distribution.d
@@ -98,7 +98,7 @@ module ocean.math.Distribution;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Enforce;
 import ocean.core.Array : bsearch, sort;

--- a/src/ocean/math/GammaFunction.d
+++ b/src/ocean/math/GammaFunction.d
@@ -25,7 +25,7 @@
  *  NAN = $(RED NAN)
  */
 module ocean.math.GammaFunction;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.math.Math;
 import ocean.math.IEEE;
 import ocean.math.ErrorFunction;

--- a/src/ocean/math/IEEE.d
+++ b/src/ocean/math/IEEE.d
@@ -35,7 +35,7 @@
  */
 module ocean.math.IEEE;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 version (unittest) import ocean.core.Test;

--- a/src/ocean/math/Math.d
+++ b/src/ocean/math/Math.d
@@ -45,7 +45,7 @@
 
 module ocean.math.Math;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 static import core.stdc.math;
 import ocean.math.IEEE;

--- a/src/ocean/math/SlidingAverage.d
+++ b/src/ocean/math/SlidingAverage.d
@@ -206,7 +206,7 @@ version (unittest)
 {
     import ocean.util.Convert: to;
     import ocean.core.Test;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     /*******************************************************************************
 

--- a/src/ocean/math/TimeHistogram.d
+++ b/src/ocean/math/TimeHistogram.d
@@ -19,12 +19,12 @@
 
 module ocean.math.TimeHistogram;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /// ditto
 struct TimeHistogram
 {
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
     import ocean.core.Traits : FieldName;
 
     /***************************************************************************

--- a/src/ocean/math/WideUInt.d
+++ b/src/ocean/math/WideUInt.d
@@ -17,8 +17,9 @@
 
 module ocean.math.WideUInt;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Test;
+import ocean.core.TypeConvert: assumeUnique;
 import ocean.core.Enforce;
 import ocean.core.Verify;
 

--- a/src/ocean/math/random/Random.d
+++ b/src/ocean/math/random/Random.d
@@ -178,7 +178,7 @@
 *******************************************************************************/
 module ocean.math.random.Random;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.math.random.engines.URandom;
 import ocean.math.random.engines.KissCmwc;

--- a/src/ocean/math/random/engines/CMWC.d
+++ b/src/ocean/math/random/engines/CMWC.d
@@ -15,7 +15,8 @@
 
 *******************************************************************************/
 module ocean.math.random.engines.CMWC;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
+import ocean.core.TypeConvert: assumeUnique;
 import Integer=ocean.text.convert.Integer_tango;
 import ocean.core.Verify;
 

--- a/src/ocean/math/random/engines/KISS.d
+++ b/src/ocean/math/random/engines/KISS.d
@@ -15,7 +15,8 @@
 
 *******************************************************************************/
 module ocean.math.random.engines.KISS;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
+import ocean.core.TypeConvert: assumeUnique;
 import Integer = ocean.text.convert.Integer_tango;
 import ocean.core.Verify;
 

--- a/src/ocean/math/random/engines/KissCmwc.d
+++ b/src/ocean/math/random/engines/KissCmwc.d
@@ -16,7 +16,8 @@
 *******************************************************************************/
 
 module ocean.math.random.engines.KissCmwc;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
+import ocean.core.TypeConvert: assumeUnique;
 import Integer = ocean.text.convert.Integer_tango;
 import ocean.core.Verify;
 

--- a/src/ocean/math/random/engines/Twister.d
+++ b/src/ocean/math/random/engines/Twister.d
@@ -19,7 +19,8 @@
 *******************************************************************************/
 
 module ocean.math.random.engines.Twister;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
+import ocean.core.TypeConvert: assumeUnique;
 import Integer = ocean.text.convert.Integer_tango;
 import ocean.core.Verify;
 

--- a/src/ocean/math/random/engines/URandom.d
+++ b/src/ocean/math/random/engines/URandom.d
@@ -16,7 +16,7 @@
 *******************************************************************************/
 module ocean.math.random.engines.URandom;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import Integer = ocean.text.convert.Integer_tango;
 import ocean.io.device.File; // use stdc read/write?
 import ocean.core.Verify;

--- a/src/ocean/meta/types/ReduceType_test.d
+++ b/src/ocean/meta/types/ReduceType_test.d
@@ -13,7 +13,8 @@
 
 module ocean.meta.types.ReduceType_test;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
+import ocean.meta.types.Typedef;
 import ocean.meta.traits.Basic;
 import ocean.meta.types.ReduceType;
 

--- a/src/ocean/meta/values/Reset.d
+++ b/src/ocean/meta/values/Reset.d
@@ -17,7 +17,7 @@
 
 module ocean.meta.values.Reset;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.meta.values.VisitValue;
 import ocean.meta.traits.Basic;

--- a/src/ocean/net/Uri.d
+++ b/src/ocean/net/Uri.d
@@ -15,7 +15,7 @@ module ocean.net.Uri;
 
 public import ocean.net.model.UriView;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Exception;
 import ocean.core.Buffer;
 import ocean.stdc.string : memchr;

--- a/src/ocean/net/collectd/Collectd.d
+++ b/src/ocean/net/collectd/Collectd.d
@@ -86,7 +86,7 @@ unittest
 }
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Enforce;
 import ocean.core.Verify;
 import ocean.core.Exception;

--- a/src/ocean/net/collectd/Identifier.d
+++ b/src/ocean/net/collectd/Identifier.d
@@ -30,7 +30,7 @@ module ocean.net.collectd.Identifier;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.ExceptionDefinitions; // IllegalArgumentException
 import ocean.text.convert.Formatter;
 import ocean.text.util.StringSearch; // locateChar

--- a/src/ocean/net/collectd/SocketReader.d
+++ b/src/ocean/net/collectd/SocketReader.d
@@ -20,7 +20,7 @@
 module ocean.net.collectd.SocketReader;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 import ocean.sys.ErrnoException;
 import ocean.sys.socket.model.ISocket;

--- a/src/ocean/net/email/EmailSender.d
+++ b/src/ocean/net/email/EmailSender.d
@@ -20,7 +20,7 @@ module ocean.net.email.EmailSender;
 
 import ocean.core.Array : append;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.io.Stdout;
 import ocean.sys.Process;
 import ocean.core.ExceptionDefinitions : ProcessException;

--- a/src/ocean/net/http/HttpConnectionHandler.d
+++ b/src/ocean/net/http/HttpConnectionHandler.d
@@ -22,7 +22,7 @@
 module ocean.net.http.HttpConnectionHandler;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.net.http.HttpRequest,
        ocean.net.http.HttpResponse,
        ocean.net.http.HttpException;

--- a/src/ocean/net/http/HttpConst.d
+++ b/src/ocean/net/http/HttpConst.d
@@ -17,7 +17,7 @@
 
 module ocean.net.http.HttpConst;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/ocean/net/http/HttpCookies.d
+++ b/src/ocean/net/http/HttpCookies.d
@@ -17,7 +17,7 @@
 
 module ocean.net.http.HttpCookies;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import core.stdc.ctype;
 

--- a/src/ocean/net/http/HttpException.d
+++ b/src/ocean/net/http/HttpException.d
@@ -25,7 +25,7 @@
 module ocean.net.http.HttpException;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Array: copy, concat;
 import ocean.core.Enforce;

--- a/src/ocean/net/http/HttpHeaders.d
+++ b/src/ocean/net/http/HttpHeaders.d
@@ -17,7 +17,7 @@
 
 module ocean.net.http.HttpHeaders;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.time.Time;
 

--- a/src/ocean/net/http/HttpParams.d
+++ b/src/ocean/net/http/HttpParams.d
@@ -17,7 +17,7 @@
 
 module ocean.net.http.HttpParams;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.time.Time;
 

--- a/src/ocean/net/http/HttpRequest.d
+++ b/src/ocean/net/http/HttpRequest.d
@@ -42,7 +42,7 @@
 module ocean.net.http.HttpRequest;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.net.http.message.HttpHeader;
 

--- a/src/ocean/net/http/HttpResponse.d
+++ b/src/ocean/net/http/HttpResponse.d
@@ -41,7 +41,7 @@
 module ocean.net.http.HttpResponse;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/ocean/net/http/HttpStack.d
+++ b/src/ocean/net/http/HttpStack.d
@@ -19,7 +19,7 @@ module ocean.net.http.HttpStack;
 
 import ocean.core.ExceptionDefinitions;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /******************************************************************************
 

--- a/src/ocean/net/http/HttpTokens.d
+++ b/src/ocean/net/http/HttpTokens.d
@@ -17,7 +17,7 @@
 
 module ocean.net.http.HttpTokens;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.time.Time;
 

--- a/src/ocean/net/http/HttpTriplet.d
+++ b/src/ocean/net/http/HttpTriplet.d
@@ -17,7 +17,7 @@
 
 module ocean.net.http.HttpTriplet;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /******************************************************************************
 

--- a/src/ocean/net/http/TaskHttpConnectionHandler.d
+++ b/src/ocean/net/http/TaskHttpConnectionHandler.d
@@ -20,7 +20,7 @@
 
 module ocean.net.http.TaskHttpConnectionHandler;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.net.server.connection.TaskConnectionHandler;
 

--- a/src/ocean/net/http/consts/CookieAttributeNames.d
+++ b/src/ocean/net/http/consts/CookieAttributeNames.d
@@ -24,7 +24,7 @@ module ocean.net.http.consts.CookieAttributeNames;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 version (unittest) import ocean.core.Test;
 

--- a/src/ocean/net/http/consts/HeaderFieldNames.d
+++ b/src/ocean/net/http/consts/HeaderFieldNames.d
@@ -16,7 +16,7 @@
 module ocean.net.http.consts.HeaderFieldNames;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /******************************************************************************/

--- a/src/ocean/net/http/consts/HttpMethod.d
+++ b/src/ocean/net/http/consts/HttpMethod.d
@@ -18,7 +18,7 @@
 module ocean.net.http.consts.HttpMethod;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 version (unittest) import ocean.core.Test;
 

--- a/src/ocean/net/http/consts/HttpVersion.d
+++ b/src/ocean/net/http/consts/HttpVersion.d
@@ -16,7 +16,7 @@
 module ocean.net.http.consts.HttpVersion;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 import core.stdc.ctype: isdigit;
 

--- a/src/ocean/net/http/consts/StatusCodes.d
+++ b/src/ocean/net/http/consts/StatusCodes.d
@@ -18,7 +18,7 @@
 module ocean.net.http.consts.StatusCodes;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.net.http.HttpConst: HttpHeader, HttpResponseCode;
 

--- a/src/ocean/net/http/consts/UriDelim.d
+++ b/src/ocean/net/http/consts/UriDelim.d
@@ -17,7 +17,7 @@
 module ocean.net.http.consts.UriDelim;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /*******************************************************************************

--- a/src/ocean/net/http/cookie/HttpCookieGenerator.d
+++ b/src/ocean/net/http/cookie/HttpCookieGenerator.d
@@ -21,7 +21,7 @@
 module ocean.net.http.cookie.HttpCookieGenerator;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/ocean/net/http/cookie/HttpCookieParser.d
+++ b/src/ocean/net/http/cookie/HttpCookieParser.d
@@ -21,7 +21,7 @@
 module ocean.net.http.cookie.HttpCookieParser;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.net.util.QueryParams: QueryParamSet;
 
 version (unittest) import ocean.core.Test;

--- a/src/ocean/net/http/message/HttpHeader.d
+++ b/src/ocean/net/http/message/HttpHeader.d
@@ -21,7 +21,7 @@
 module ocean.net.http.message.HttpHeader;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.TypeConvert;
 import ocean.core.Verify;

--- a/src/ocean/net/http/message/HttpHeaderParser.d
+++ b/src/ocean/net/http/message/HttpHeaderParser.d
@@ -22,7 +22,7 @@
 module ocean.net.http.message.HttpHeaderParser;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Enforce;
 import ocean.core.Verify;
 import ocean.text.util.SplitIterator: ChrSplitIterator, ISplitIterator;

--- a/src/ocean/net/http/model/HttpParamsView.d
+++ b/src/ocean/net/http/model/HttpParamsView.d
@@ -17,7 +17,7 @@
 
 module ocean.net.http.model.HttpParamsView;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.time.Time;
 

--- a/src/ocean/net/http/time/HttpTimeFormatter.d
+++ b/src/ocean/net/http/time/HttpTimeFormatter.d
@@ -20,7 +20,7 @@
 module ocean.net.http.time.HttpTimeFormatter;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 import core.stdc.time:       time_t, tm, time;
 import core.sys.posix.time: gmtime_r, localtime_r;

--- a/src/ocean/net/http/time/HttpTimeParser.d
+++ b/src/ocean/net/http/time/HttpTimeParser.d
@@ -17,7 +17,7 @@
 module ocean.net.http.time.HttpTimeParser;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import TimeStamp = ocean.text.convert.TimeStamp: rfc1123, rfc850, asctime;
 

--- a/src/ocean/net/model/UriView.d
+++ b/src/ocean/net/model/UriView.d
@@ -17,7 +17,7 @@
 
 module ocean.net.model.UriView;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/ocean/net/server/SelectListener.d
+++ b/src/ocean/net/server/SelectListener.d
@@ -24,7 +24,7 @@
 module ocean.net.server.SelectListener;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 import ocean.io.select.client.model.ISelectClient;
 import ocean.net.server.connection.IConnectionHandler;

--- a/src/ocean/net/server/SelectListener_slowtest.d
+++ b/src/ocean/net/server/SelectListener_slowtest.d
@@ -16,7 +16,7 @@
 module ocean.net.server.SelectListener_slowtest;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.net.server.SelectListener;
 import ocean.net.server.connection.IConnectionHandler;

--- a/src/ocean/net/server/connection/TaskConnectionHandler.d
+++ b/src/ocean/net/server/connection/TaskConnectionHandler.d
@@ -29,7 +29,7 @@ abstract class TaskConnectionHandler : IConnectionHandler, Resettable
     import ocean.task.Task: Task;
     import ocean.task.IScheduler: theScheduler;
 
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     /***************************************************************************
 

--- a/src/ocean/net/server/unix/CommandRegistry.d
+++ b/src/ocean/net/server/unix/CommandRegistry.d
@@ -19,7 +19,7 @@
 
 module ocean.net.server.unix.CommandRegistry;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /// ditto
 public class CommandsRegistry

--- a/src/ocean/net/server/unix/UnixConnectionHandler.d
+++ b/src/ocean/net/server/unix/UnixConnectionHandler.d
@@ -45,7 +45,7 @@ module ocean.net.server.unix.UnixConnectionHandler;
 
 import ocean.net.server.connection.IFiberConnectionHandler;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.array.Mutation;
 
 import ocean.io.select.EpollSelectDispatcher;

--- a/src/ocean/net/ssl/SslClientConnection.d
+++ b/src/ocean/net/ssl/SslClientConnection.d
@@ -13,7 +13,7 @@ module ocean.net.ssl.SslClientConnection;
 
 import ocean.net.ssl.openssl.OpenSsl;
 import ocean.text.util.StringC;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 

--- a/src/ocean/net/ssl/openssl/OpenSsl.d
+++ b/src/ocean/net/ssl/openssl/OpenSsl.d
@@ -13,7 +13,7 @@ module ocean.net.ssl.openssl.OpenSsl;
 
 
 import core.stdc.config : c_ulong, c_long;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 extern (C):

--- a/src/ocean/net/util/GetSocketAddress.d
+++ b/src/ocean/net/util/GetSocketAddress.d
@@ -26,7 +26,7 @@
 
 module ocean.net.util.GetSocketAddress;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.io.model.IConduit: ISelectable;
 import ocean.stdc.posix.sys.socket: getsockname, getpeername, socklen_t, sockaddr;
 import ocean.sys.ErrnoException;

--- a/src/ocean/net/util/ParamSet.d
+++ b/src/ocean/net/util/ParamSet.d
@@ -32,7 +32,7 @@
 module ocean.net.util.ParamSet;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.TypeConvert;
 

--- a/src/ocean/net/util/QueryParams.d
+++ b/src/ocean/net/util/QueryParams.d
@@ -22,7 +22,7 @@
 module ocean.net.util.QueryParams;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/ocean/net/util/UrlDecoder.d
+++ b/src/ocean/net/util/UrlDecoder.d
@@ -22,7 +22,7 @@
 module ocean.net.util.UrlDecoder;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/ocean/net/util/UrlEncoder.d
+++ b/src/ocean/net/util/UrlEncoder.d
@@ -17,7 +17,7 @@
 module ocean.net.util.UrlEncoder;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 import core.stdc.ctype: isgraph;
 

--- a/src/ocean/stdc/gnu/string.d
+++ b/src/ocean/stdc/gnu/string.d
@@ -15,7 +15,7 @@
 
 module ocean.stdc.gnu.string;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import core.stdc.stddef: wchar_t;
 
 

--- a/src/ocean/stdc/posix/sys/un.d
+++ b/src/ocean/stdc/posix/sys/un.d
@@ -14,7 +14,7 @@
 
 module ocean.stdc.posix.sys.un;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 public import core.sys.posix.sys.un;
 import core.sys.posix.sys.socket;

--- a/src/ocean/sys/CloseOnExec.d
+++ b/src/ocean/sys/CloseOnExec.d
@@ -84,7 +84,7 @@
 
 module ocean.sys.CloseOnExec;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/ocean/sys/CmdPath.d
+++ b/src/ocean/sys/CmdPath.d
@@ -16,7 +16,7 @@
 module ocean.sys.CmdPath;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.sys.Environment;
 

--- a/src/ocean/sys/Common.d
+++ b/src/ocean/sys/Common.d
@@ -17,7 +17,8 @@
 
 module ocean.sys.Common;
 
-import ocean.transition;
+import ocean.core.TypeConvert : assumeUnique;
+import ocean.meta.types.Qualifiers;
 
 public import ocean.sys.linux.linux;
 alias ocean.sys.linux.linux posix;

--- a/src/ocean/sys/CpuAffinity.d
+++ b/src/ocean/sys/CpuAffinity.d
@@ -19,7 +19,8 @@
 
 module ocean.sys.CpuAffinity;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
+import ocean.meta.types.Typedef;
 
 import core.sys.posix.sys.types : pid_t;
 

--- a/src/ocean/sys/Epoll.d
+++ b/src/ocean/sys/Epoll.d
@@ -16,7 +16,7 @@
 module ocean.sys.Epoll;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 import core.sys.posix.unistd: close;
 

--- a/src/ocean/sys/ErrnoException.d
+++ b/src/ocean/sys/ErrnoException.d
@@ -16,7 +16,7 @@
 module ocean.sys.ErrnoException;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import core.stdc.errno;
 
 version (unittest)

--- a/src/ocean/sys/GetIfAddrs.d
+++ b/src/ocean/sys/GetIfAddrs.d
@@ -16,7 +16,7 @@
 module ocean.sys.GetIfAddrs;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import core.stdc.errno;
 import core.stdc.string;

--- a/src/ocean/sys/HomeFolder.d
+++ b/src/ocean/sys/HomeFolder.d
@@ -22,7 +22,7 @@
 
 module ocean.sys.HomeFolder;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 import TextUtil = ocean.text.Util;
 import Path = ocean.io.Path;

--- a/src/ocean/sys/Pipe.d
+++ b/src/ocean/sys/Pipe.d
@@ -15,7 +15,7 @@
 
 module ocean.sys.Pipe;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.sys.Common;
 import ocean.io.device.Device;

--- a/src/ocean/sys/Process.d
+++ b/src/ocean/sys/Process.d
@@ -15,7 +15,7 @@
 
 module ocean.sys.Process;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 import ocean.core.Array : copy;
 import ocean.io.model.IFile;

--- a/src/ocean/sys/SignalFD.d
+++ b/src/ocean/sys/SignalFD.d
@@ -101,7 +101,7 @@ import core.stdc.errno : EAGAIN, EWOULDBLOCK, errno;
 
 import ocean.core.Array : contains;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 debug import ocean.io.Stdout;
 

--- a/src/ocean/sys/Stats.d
+++ b/src/ocean/sys/Stats.d
@@ -15,7 +15,7 @@
 
 module ocean.sys.Stats;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Enforce;
 import ocean.core.array.Mutation;
 import core.sys.posix.sys.resource;

--- a/src/ocean/sys/socket/AddrInfo.d
+++ b/src/ocean/sys/socket/AddrInfo.d
@@ -18,7 +18,7 @@ module ocean.sys.socket.AddrInfo;
 import ocean.core.Array: concat;
 import ocean.core.TypeConvert;
 import ocean.core.Verify;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import core.stdc.errno: errno, EAFNOSUPPORT;
 import core.stdc.string: strlen;

--- a/src/ocean/sys/socket/AddressIPSocket.d
+++ b/src/ocean/sys/socket/AddressIPSocket.d
@@ -23,7 +23,7 @@ import ocean.sys.socket.IPSocket,
        ocean.sys.socket.InetAddress,
        ocean.sys.socket.AddrInfo;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.io.device.Conduit: ISelectable;
 

--- a/src/ocean/sys/socket/IPSocket.d
+++ b/src/ocean/sys/socket/IPSocket.d
@@ -22,7 +22,7 @@ import ocean.stdc.posix.sys.socket;
 import ocean.sys.socket.InetAddress;
 import ocean.sys.socket.model.ISocket;
 import ocean.text.convert.Formatter;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import core.sys.posix.netinet.in_: AF_INET, AF_INET6;
 import core.sys.posix.sys.types: ssize_t;

--- a/src/ocean/sys/socket/InetAddress.d
+++ b/src/ocean/sys/socket/InetAddress.d
@@ -43,7 +43,7 @@ module ocean.sys.socket.InetAddress;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.stdc.posix.sys.socket: sockaddr;
 

--- a/src/ocean/sys/socket/UnixSocket.d
+++ b/src/ocean/sys/socket/UnixSocket.d
@@ -17,7 +17,7 @@ module ocean.sys.socket.UnixSocket;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Enforce;
 import ocean.sys.socket.model.ISocket;

--- a/src/ocean/sys/socket/model/IAddressIPSocketInfo.d
+++ b/src/ocean/sys/socket/model/IAddressIPSocketInfo.d
@@ -18,7 +18,7 @@ module ocean.sys.socket.model.IAddressIPSocketInfo;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.io.device.Conduit: ISelectable;
 
 

--- a/src/ocean/sys/socket/model/ISocket.d
+++ b/src/ocean/sys/socket/model/ISocket.d
@@ -15,7 +15,7 @@
 
 module ocean.sys.socket.model.ISocket;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.stdc.posix.sys.socket;
 import ocean.io.device.Conduit: ISelectable;
 import ocean.io.device.IODevice: IODevice;

--- a/src/ocean/sys/stats/linux/ProcVFS.d
+++ b/src/ocean/sys/stats/linux/ProcVFS.d
@@ -16,7 +16,7 @@
 
 module ocean.sys.stats.linux.ProcVFS;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import Path = ocean.io.Path;
 import ocean.sys.ErrnoException;
 import core.sys.posix.stdio;

--- a/src/ocean/sys/stats/linux/Queriable.d
+++ b/src/ocean/sys/stats/linux/Queriable.d
@@ -16,7 +16,7 @@
 
 module ocean.sys.stats.linux.Queriable;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.sys.ErrnoException;
 import core.sys.posix.sys.resource;
 import core.stdc.errno;

--- a/src/ocean/task/Scheduler.d
+++ b/src/ocean/task/Scheduler.d
@@ -23,7 +23,7 @@ module ocean.task.Scheduler;
 
 import core.thread;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Enforce;
 import ocean.core.Verify;
 import ocean.core.TypeConvert;

--- a/src/ocean/task/Task.d
+++ b/src/ocean/task/Task.d
@@ -26,7 +26,7 @@ module ocean.task.Task;
 
 static import core.thread;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.array.Mutation : moveToEnd, reverse;
 import ocean.core.Buffer;
 import ocean.core.Verify;

--- a/src/ocean/task/TaskPool.d
+++ b/src/ocean/task/TaskPool.d
@@ -23,7 +23,7 @@
 module ocean.task.TaskPool;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.task.Task;
 import ocean.task.IScheduler;

--- a/src/ocean/task/ThrottledTaskPool.d
+++ b/src/ocean/task/ThrottledTaskPool.d
@@ -28,7 +28,7 @@ import ocean.util.container.pool.model.ILimitable;
 import ocean.meta.traits.Aggregates /* : hasMethod */;
 import ocean.meta.types.Function /* ParametersOf */;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 debug (TaskScheduler)

--- a/src/ocean/task/internal/TaskExtensionMixins.d
+++ b/src/ocean/task/internal/TaskExtensionMixins.d
@@ -17,7 +17,7 @@
 module ocean.task.internal.TaskExtensionMixins;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 version (unittest)
 {

--- a/src/ocean/task/util/Event.d
+++ b/src/ocean/task/util/Event.d
@@ -16,7 +16,7 @@
 
 module ocean.task.util.Event;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.task.Task;
 
 debug (TaskScheduler)

--- a/src/ocean/task/util/StreamProcessor.d
+++ b/src/ocean/task/util/StreamProcessor.d
@@ -24,7 +24,7 @@
 module ocean.task.util.StreamProcessor;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.task.Task;
 import ocean.task.ThrottledTaskPool;

--- a/src/ocean/task/util/TaskPoolSerializer.d
+++ b/src/ocean/task/util/TaskPoolSerializer.d
@@ -34,7 +34,7 @@ module ocean.task.util.TaskPoolSerializer;
 
 public class TaskPoolSerializer
 {
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     import ocean.core.Array: concat;
     import ocean.core.Enforce;

--- a/src/ocean/task/util/Timer.d
+++ b/src/ocean/task/util/Timer.d
@@ -22,7 +22,7 @@
 
 module ocean.task.util.Timer;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.io.select.client.TimerSet;
 import ocean.util.container.pool.ObjectPool;
 import ocean.task.Task;

--- a/src/ocean/text/Arguments.d
+++ b/src/ocean/text/Arguments.d
@@ -604,7 +604,7 @@ module ocean.text.Arguments;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.io.Stdout;
 import ocean.io.stream.Format : FormatOutput;
@@ -614,7 +614,9 @@ import ocean.text.convert.Formatter;
 import ocean.text.convert.Integer;
 import ocean.util.container.SortedMap;
 import ocean.util.container.more.Stack;
+import ocean.core.TypeConvert: assumeUnique;
 import ocean.core.Verify;
+
 
 version (unittest) import ocean.core.Test;
 

--- a/src/ocean/text/Ascii.d
+++ b/src/ocean/text/Ascii.d
@@ -20,7 +20,7 @@
 
 module ocean.text.Ascii;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Array;
 

--- a/src/ocean/text/Unicode.d
+++ b/src/ocean/text/Unicode.d
@@ -33,7 +33,7 @@
 
 module ocean.text.Unicode;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.text.UnicodeData;
 import ocean.text.convert.Utf;
 import ocean.core.Verify;

--- a/src/ocean/text/Util.d
+++ b/src/ocean/text/Util.d
@@ -103,7 +103,7 @@
 module ocean.text.Util;
 
 //import ocean.meta.types.Qualifiers : cstring, mstring;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 version (unittest) import ocean.core.Test;

--- a/src/ocean/text/arguments/TimeIntervalArgs.d
+++ b/src/ocean/text/arguments/TimeIntervalArgs.d
@@ -50,7 +50,7 @@ import ocean.core.Enforce;
 import ocean.text.Arguments;
 import ocean.text.convert.DateTime;
 import ocean.text.convert.Integer;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 version (unittest)
 {

--- a/src/ocean/text/convert/DateTime.d
+++ b/src/ocean/text/convert/DateTime.d
@@ -18,7 +18,7 @@ module ocean.text.convert.DateTime;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import core.stdc.stdio : sscanf;
 

--- a/src/ocean/text/convert/DateTime_tango.d
+++ b/src/ocean/text/convert/DateTime_tango.d
@@ -30,7 +30,7 @@
 
 module ocean.text.convert.DateTime_tango;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.ExceptionDefinitions;
 import ocean.stdc.posix.langinfo;
@@ -40,7 +40,7 @@ import ocean.text.convert.Formatter;
 import ocean.text.util.StringC;
 import ocean.time.chrono.Calendar;
 import ocean.time.chrono.Gregorian;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 import core.sys.posix.time; // timezone

--- a/src/ocean/text/convert/Float.d
+++ b/src/ocean/text/convert/Float.d
@@ -30,7 +30,7 @@
 
 module ocean.text.convert.Float;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.ExceptionDefinitions;
 import ocean.math.IEEE;

--- a/src/ocean/text/convert/Float_test.d
+++ b/src/ocean/text/convert/Float_test.d
@@ -12,7 +12,7 @@
 
 module ocean.text.convert.Float_test;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.text.convert.Float;
 import ocean.core.Test;
 

--- a/src/ocean/text/convert/Formatter.d
+++ b/src/ocean/text/convert/Formatter.d
@@ -74,7 +74,7 @@
 
 module ocean.text.convert.Formatter;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Buffer;
 import Integer = ocean.text.convert.Integer_tango;
 import Float = ocean.text.convert.Float;
@@ -125,6 +125,8 @@ private alias void delegate(cstring, ref const(FormatInfo)) ElemSink;
 
 public istring format (Args...) (cstring fmt, Args args)
 {
+    import ocean.core.TypeConvert : assumeUnique;
+
     mstring buffer;
 
     scope FormatterSink sink = (cstring s)

--- a/src/ocean/text/convert/Formatter_test.d
+++ b/src/ocean/text/convert/Formatter_test.d
@@ -18,7 +18,7 @@ module ocean.text.convert.Formatter_test;
 import ocean.core.Test;
 import ocean.core.Buffer;
 import ocean.text.convert.Formatter;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 unittest
 {
@@ -333,6 +333,12 @@ unittest
     Additional unit tests
 
 *******************************************************************************/
+
+version (unittest)
+{
+    import ocean.meta.types.Typedef;
+}
+
 
 unittest
 {

--- a/src/ocean/text/convert/Hash.d
+++ b/src/ocean/text/convert/Hash.d
@@ -25,7 +25,7 @@ module ocean.text.convert.Hash;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import Integer = ocean.text.convert.Integer;
 

--- a/src/ocean/text/convert/Hex.d
+++ b/src/ocean/text/convert/Hex.d
@@ -18,7 +18,7 @@ module ocean.text.convert.Hex;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import Integer = ocean.text.convert.Integer_tango;
 

--- a/src/ocean/text/convert/Integer.d
+++ b/src/ocean/text/convert/Integer.d
@@ -26,7 +26,7 @@
 
 module ocean.text.convert.Integer;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.meta.traits.Basic;
 

--- a/src/ocean/text/convert/Integer_tango.d
+++ b/src/ocean/text/convert/Integer_tango.d
@@ -28,7 +28,7 @@
 
 module ocean.text.convert.Integer_tango;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.ExceptionDefinitions;
 import ocean.core.Verify;
 import ocean.meta.traits.Basic;

--- a/src/ocean/text/convert/Integer_tango_test.d
+++ b/src/ocean/text/convert/Integer_tango_test.d
@@ -12,7 +12,7 @@
 
 module ocean.text.convert.Integer_tango_test;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.text.convert.Integer_tango;
 import ocean.core.Test;
 

--- a/src/ocean/text/convert/TimeStamp.d
+++ b/src/ocean/text/convert/TimeStamp.d
@@ -37,7 +37,7 @@ module ocean.text.convert.TimeStamp;
 
 import ocean.core.ExceptionDefinitions;
 import ocean.core.Verify;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.time.Time;
 import ocean.text.convert.Formatter;
 import ocean.time.chrono.Gregorian;

--- a/src/ocean/text/convert/UnicodeBom.d
+++ b/src/ocean/text/convert/UnicodeBom.d
@@ -19,7 +19,7 @@ module ocean.text.convert.UnicodeBom;
 
 import core.exception : onUnicodeError;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.ByteSwap;
 
 import  Utf = ocean.text.convert.Utf;

--- a/src/ocean/text/convert/Utf.d
+++ b/src/ocean/text/convert/Utf.d
@@ -57,7 +57,7 @@ module ocean.text.convert.Utf;
 
 static import core.exception;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/ocean/text/convert/Utf_test.d
+++ b/src/ocean/text/convert/Utf_test.d
@@ -12,7 +12,7 @@
 
 module ocean.text.convert.Utf_test;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.text.convert.Utf;
 import ocean.core.Test;
 

--- a/src/ocean/text/csv/CSV.d
+++ b/src/ocean/text/csv/CSV.d
@@ -46,7 +46,7 @@ module ocean.text.csv.CSV;
 
 import ocean.core.Enforce;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.container.AppendBuffer;
 

--- a/src/ocean/text/csv/HeadingsCSV.d
+++ b/src/ocean/text/csv/HeadingsCSV.d
@@ -55,7 +55,7 @@ module ocean.text.csv.HeadingsCSV;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.text.csv.CSV;
 

--- a/src/ocean/text/entities/HtmlEntitySet.d
+++ b/src/ocean/text/entities/HtmlEntitySet.d
@@ -21,7 +21,7 @@ import ocean.text.entities.model.IEntitySet;
 
 import ocean.text.entities.XmlEntitySet;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/ocean/text/entities/XmlEntityCodec.d
+++ b/src/ocean/text/entities/XmlEntityCodec.d
@@ -40,7 +40,7 @@ import ocean.text.entities.model.MarkupEntityCodec;
 
 import ocean.text.entities.XmlEntitySet;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/ocean/text/entities/XmlEntitySet.d
+++ b/src/ocean/text/entities/XmlEntitySet.d
@@ -21,7 +21,7 @@ import ocean.core.Array;
 
 import ocean.text.entities.model.IEntitySet;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/ocean/text/entities/model/IEntityCodec.d
+++ b/src/ocean/text/entities/model/IEntityCodec.d
@@ -26,7 +26,7 @@ import ocean.text.entities.model.IEntitySet;
 
 import Utf = ocean.text.convert.Utf;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/ocean/text/entities/model/IEntitySet.d
+++ b/src/ocean/text/entities/model/IEntitySet.d
@@ -27,7 +27,7 @@ module ocean.text.entities.model.IEntitySet;
 
 import ocean.text.utf.UtfString : InvalidUnicode, utf_match;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/ocean/text/entities/model/MarkupEntityCodec.d
+++ b/src/ocean/text/entities/model/MarkupEntityCodec.d
@@ -42,7 +42,7 @@ module ocean.text.entities.model.MarkupEntityCodec;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Array;
 

--- a/src/ocean/text/formatter/SmartUnion.d
+++ b/src/ocean/text/formatter/SmartUnion.d
@@ -19,7 +19,7 @@
 
 module ocean.text.formatter.SmartUnion;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.SmartUnion;
 import ocean.core.Verify;
 import ocean.text.convert.Formatter;

--- a/src/ocean/text/json/Json.d
+++ b/src/ocean/text/json/Json.d
@@ -17,7 +17,7 @@
 
 module ocean.text.json.Json;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import core.stdc.stdarg;
 

--- a/src/ocean/text/json/JsonEscape.d
+++ b/src/ocean/text/json/JsonEscape.d
@@ -17,7 +17,7 @@
 
 module ocean.text.json.JsonEscape;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.text.json.JsonParser;
 

--- a/src/ocean/text/json/JsonExtractor.d
+++ b/src/ocean/text/json/JsonExtractor.d
@@ -157,7 +157,7 @@
 module ocean.text.json.JsonExtractor;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.text.json.JsonParserIter;
 import ocean.core.Array;

--- a/src/ocean/text/json/JsonParser.d
+++ b/src/ocean/text/json/JsonParser.d
@@ -17,7 +17,7 @@
 
 module ocean.text.json.JsonParser;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Exception;
 import ocean.util.container.more.Stack;
 

--- a/src/ocean/text/json/JsonParserIter.d
+++ b/src/ocean/text/json/JsonParserIter.d
@@ -23,7 +23,7 @@
 module ocean.text.json.JsonParserIter;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.text.json.JsonParser;
 

--- a/src/ocean/text/regex/PCRE.d
+++ b/src/ocean/text/regex/PCRE.d
@@ -49,7 +49,8 @@ module ocean.text.regex.PCRE;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
+import ocean.core.TypeConvert: assumeUnique;
 
 import ocean.core.Array : copy, concat;
 import ocean.text.util.StringC;

--- a/src/ocean/text/regex/c/pcre.d
+++ b/src/ocean/text/regex/c/pcre.d
@@ -21,7 +21,7 @@
 
 module ocean.text.regex.c.pcre;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 extern (C):
 

--- a/src/ocean/text/utf/UtfString.d
+++ b/src/ocean/text/utf/UtfString.d
@@ -64,7 +64,7 @@ module ocean.text.utf.UtfString;
 
 import Utf = ocean.text.convert.Utf;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/ocean/text/utf/UtfUtil.d
+++ b/src/ocean/text/utf/UtfUtil.d
@@ -36,7 +36,7 @@ module ocean.text.utf.UtfUtil;
 
 import core.exception: onUnicodeError;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.stdc.string: memrchr;
 

--- a/src/ocean/text/utf/c/glib_unicode.d
+++ b/src/ocean/text/utf/c/glib_unicode.d
@@ -25,7 +25,7 @@
 
 module ocean.text.utf.c.glib_unicode;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 enum GUnicodeType
 {

--- a/src/ocean/text/util/ClassName.d
+++ b/src/ocean/text/util/ClassName.d
@@ -15,7 +15,7 @@
 module ocean.text.util.ClassName;
 
 import ocean.stdc.gnu.string;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 istring classname ( const(Object) o )
 {

--- a/src/ocean/text/util/DigitGrouping.d
+++ b/src/ocean/text/util/DigitGrouping.d
@@ -39,7 +39,7 @@ module ocean.text.util.DigitGrouping;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.TypeConvert;
 

--- a/src/ocean/text/util/EscapeChars.d
+++ b/src/ocean/text/util/EscapeChars.d
@@ -16,7 +16,7 @@
 module ocean.text.util.EscapeChars;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Array: concat;
 import ocean.core.Verify;

--- a/src/ocean/text/util/SplitIterator.d
+++ b/src/ocean/text/util/SplitIterator.d
@@ -19,7 +19,7 @@
 
 module ocean.text.util.SplitIterator;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Array: concat, copy;
 import ocean.core.Verify;
 import ocean.io.Stdout;

--- a/src/ocean/text/util/StringC.d
+++ b/src/ocean/text/util/StringC.d
@@ -32,7 +32,7 @@ module ocean.text.util.StringC;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Buffer;
 import ocean.stdc.string: strlen, wcslen;

--- a/src/ocean/text/util/StringEncode.d
+++ b/src/ocean/text/util/StringEncode.d
@@ -43,7 +43,7 @@ module ocean.text.util.StringEncode;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 version (unittest) import ocean.core.Test;
 

--- a/src/ocean/text/util/StringSearch.d
+++ b/src/ocean/text/util/StringSearch.d
@@ -18,7 +18,7 @@
 module ocean.text.util.StringSearch;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 import c_stddef = core.stdc.stddef: wchar_t;

--- a/src/ocean/text/util/Time.d
+++ b/src/ocean/text/util/Time.d
@@ -20,7 +20,7 @@ module ocean.text.util.Time;
 
 import core.sys.posix.time : gmtime_r;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Enforce;
 

--- a/src/ocean/text/xml/DocPrinter.d
+++ b/src/ocean/text/xml/DocPrinter.d
@@ -17,7 +17,7 @@
 
 module ocean.text.xml.DocPrinter;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.io.model.IConduit;
 

--- a/src/ocean/text/xml/Document.d
+++ b/src/ocean/text/xml/Document.d
@@ -18,7 +18,7 @@
 module ocean.text.xml.Document;
 
 import Array = ocean.core.Array;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 package import ocean.text.xml.PullParser;

--- a/src/ocean/text/xml/PullParser.d
+++ b/src/ocean/text/xml/PullParser.d
@@ -15,7 +15,7 @@
 
 module ocean.text.xml.PullParser;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.text.Util : indexOf;
 

--- a/src/ocean/text/xml/SaxParser.d
+++ b/src/ocean/text/xml/SaxParser.d
@@ -25,7 +25,7 @@
 
 module ocean.text.xml.SaxParser;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.io.model.IConduit;
 import ocean.text.xml.PullParser;

--- a/src/ocean/time/ISO8601.d
+++ b/src/ocean/time/ISO8601.d
@@ -36,7 +36,7 @@
 
 module ocean.time.ISO8601;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 public import ocean.time.Time;
 public import ocean.time.chrono.Gregorian;

--- a/src/ocean/time/Time.d
+++ b/src/ocean/time/Time.d
@@ -20,7 +20,7 @@
 
 module ocean.time.Time;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import core.stdc.time: time_t;
 

--- a/src/ocean/time/chrono/Gregorian.d
+++ b/src/ocean/time/chrono/Gregorian.d
@@ -19,7 +19,7 @@
 
 module ocean.time.chrono.Gregorian;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.time.chrono.Calendar;
 

--- a/src/ocean/time/chrono/Hijri.d
+++ b/src/ocean/time/chrono/Hijri.d
@@ -21,7 +21,7 @@ module ocean.time.chrono.Hijri;
 
 import ocean.time.chrono.Calendar;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /**

--- a/src/ocean/time/timeout/TimeoutManager.d
+++ b/src/ocean/time/timeout/TimeoutManager.d
@@ -51,7 +51,7 @@ import ocean.util.container.map.Map,
        ocean.util.container.map.model.StandardHash,
        ocean.util.container.map.model.IAllocator;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 debug
 {

--- a/src/ocean/time/timeout/model/ExpiryRegistrationBase.d
+++ b/src/ocean/time/timeout/model/ExpiryRegistrationBase.d
@@ -20,7 +20,7 @@
 module ocean.time.timeout.model.ExpiryRegistrationBase;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.time.timeout.model.IExpiryRegistration,
        ocean.time.timeout.model.ITimeoutClient;

--- a/src/ocean/time/timeout/model/IExpiryRegistration.d
+++ b/src/ocean/time/timeout/model/IExpiryRegistration.d
@@ -26,7 +26,7 @@ module ocean.time.timeout.model.IExpiryRegistration;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.time.timeout.model.ITimeoutClient;
 
 /*******************************************************************************

--- a/src/ocean/time/timeout/model/ITimeoutClient.d
+++ b/src/ocean/time/timeout/model/ITimeoutClient.d
@@ -17,7 +17,7 @@ module ocean.time.timeout.model.ITimeoutClient;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /******************************************************************************/

--- a/src/ocean/util/Convert.d
+++ b/src/ocean/util/Convert.d
@@ -20,7 +20,7 @@
 
 module ocean.util.Convert;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.ExceptionDefinitions;
 

--- a/src/ocean/util/DeepReset.d
+++ b/src/ocean/util/DeepReset.d
@@ -18,7 +18,7 @@
 module ocean.util.DeepReset;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Array;
 import ocean.meta.traits.Basic /* isArrayType */;
 

--- a/src/ocean/util/ReusableException.d
+++ b/src/ocean/util/ReusableException.d
@@ -15,7 +15,7 @@
 
 module ocean.util.ReusableException;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/ocean/util/aio/AsyncIO.d
+++ b/src/ocean/util/aio/AsyncIO.d
@@ -28,7 +28,7 @@
 
 module ocean.util.aio.AsyncIO;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 import core.stdc.errno;

--- a/src/ocean/util/aio/internal/AioScheduler.d
+++ b/src/ocean/util/aio/internal/AioScheduler.d
@@ -35,7 +35,7 @@
 
 module ocean.util.aio.internal.AioScheduler;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.io.select.client.SelectEvent;
 
 /// Ditto

--- a/src/ocean/util/aio/internal/JobQueue.d
+++ b/src/ocean/util/aio/internal/JobQueue.d
@@ -13,7 +13,7 @@
 
 module ocean.util.aio.internal.JobQueue;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import core.stdc.errno;
 import core.stdc.stdint;

--- a/src/ocean/util/app/Application.d
+++ b/src/ocean/util/app/Application.d
@@ -19,7 +19,7 @@ module ocean.util.app.Application;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.app.model.ExtensibleClassMixin;
 import ocean.util.app.model.IApplicationExtension;

--- a/src/ocean/util/app/CliApp.d
+++ b/src/ocean/util/app/CliApp.d
@@ -26,7 +26,7 @@ import ocean.util.app.Application : Application;
 import ocean.util.app.ext.model.IArgumentsExtExtension;
 import ocean.task.IScheduler;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/ocean/util/app/DaemonApp.d
+++ b/src/ocean/util/app/DaemonApp.d
@@ -44,7 +44,7 @@ import ocean.util.app.ext.model.IConfigExtExtension;
 import ocean.util.app.ext.model.ILogExtExtension;
 import ocean.util.app.ext.model.ISignalExtExtension;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 version (unittest) import ocean.core.Test;
 import ocean.core.Verify;
 import ocean.task.IScheduler;

--- a/src/ocean/util/app/ExitException.d
+++ b/src/ocean/util/app/ExitException.d
@@ -17,7 +17,7 @@ module ocean.util.app.ExitException;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /*******************************************************************************

--- a/src/ocean/util/app/ext/ArgumentsExt.d
+++ b/src/ocean/util/app/ext/ArgumentsExt.d
@@ -25,7 +25,7 @@ import ocean.util.app.ext.model.IArgumentsExtExtension;
 import ocean.text.Arguments;
 import ocean.io.Stdout : Stdout, Stderr;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.io.stream.Format : FormatOutput;
 
 

--- a/src/ocean/util/app/ext/ConfigExt.d
+++ b/src/ocean/util/app/ext/ConfigExt.d
@@ -28,7 +28,7 @@ import ocean.util.config.ConfigParser;
 import ocean.text.Arguments;
 import ocean.io.Stdout : Stderr;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 import ocean.text.Util : join, locate, locatePrior, trim;
 import ocean.core.ExceptionDefinitions : IOException;

--- a/src/ocean/util/app/ext/DropPrivilegesExt.d
+++ b/src/ocean/util/app/ext/DropPrivilegesExt.d
@@ -17,7 +17,8 @@ module ocean.util.app.ext.DropPrivilegesExt;
 
 
 import ocean.core.array.Mutation;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
+import ocean.core.TypeConvert: assumeUnique;
 import ocean.text.util.StringC;
 import ConfigFiller = ocean.util.config.ConfigFiller;
 import ocean.util.app.ext.model.IConfigExtExtension;

--- a/src/ocean/util/app/ext/LogExt.d
+++ b/src/ocean/util/app/ext/LogExt.d
@@ -33,7 +33,7 @@ import ocean.util.config.ConfigParser;
 import LogUtil = ocean.util.log.Config;
 import ConfigFiller = ocean.util.config.ConfigFiller;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.io.device.File;
 
 import ocean.util.log.Appender;

--- a/src/ocean/util/app/ext/PidLockExt.d
+++ b/src/ocean/util/app/ext/PidLockExt.d
@@ -32,7 +32,7 @@ import ocean.util.app.model.ExtensibleClassMixin;
 import ocean.util.app.model.IApplicationExtension;
 import ocean.util.app.ext.model.IConfigExtExtension;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /// ditto

--- a/src/ocean/util/app/ext/RefuseRootExt.d
+++ b/src/ocean/util/app/ext/RefuseRootExt.d
@@ -17,7 +17,7 @@ module ocean.util.app.ext.RefuseRootExt;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.util.app.ext.model.IArgumentsExtExtension;
 import core.sys.posix.unistd;
 

--- a/src/ocean/util/app/ext/ReopenableFilesExt.d
+++ b/src/ocean/util/app/ext/ReopenableFilesExt.d
@@ -21,7 +21,7 @@ module ocean.util.app.ext.ReopenableFilesExt;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/ocean/util/app/ext/SignalExt.d
+++ b/src/ocean/util/app/ext/SignalExt.d
@@ -91,7 +91,7 @@ module ocean.util.app.ext.SignalExt;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 import ocean.util.app.model.IApplicationExtension;

--- a/src/ocean/util/app/ext/StatsExt.d
+++ b/src/ocean/util/app/ext/StatsExt.d
@@ -52,7 +52,7 @@ import ocean.util.log.Appender;
 import ocean.util.log.Stats;
 import ConfigFiller = ocean.util.config.ConfigFiller;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 import ocean.io.device.File;
 

--- a/src/ocean/util/app/ext/TaskExt.d
+++ b/src/ocean/util/app/ext/TaskExt.d
@@ -30,7 +30,7 @@
 
 module ocean.util.app.ext.TaskExt;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.util.app.ext.model.IConfigExtExtension;
 import ocean.task.Scheduler;
 import ocean.util.config.ConfigParser;

--- a/src/ocean/util/app/ext/TimerExt.d
+++ b/src/ocean/util/app/ext/TimerExt.d
@@ -47,7 +47,7 @@ unittest
     class App : Application
     {
         import ocean.io.select.EpollSelectDispatcher;
-        import ocean.transition;
+        import ocean.meta.types.Qualifiers;
 
         private EpollSelectDispatcher epoll;
         private TimerExt timers;
@@ -92,7 +92,7 @@ unittest
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.util.app.model.IApplicationExtension;
 
 

--- a/src/ocean/util/app/ext/UnixSocketExt.d
+++ b/src/ocean/util/app/ext/UnixSocketExt.d
@@ -25,7 +25,7 @@
 
 module ocean.util.app.ext.UnixSocketExt;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 import ocean.core.Enforce;

--- a/src/ocean/util/app/ext/VersionArgsExt.d
+++ b/src/ocean/util/app/ext/VersionArgsExt.d
@@ -36,7 +36,7 @@ import ocean.util.config.ConfigParser;
 import ocean.io.Stdout;
 import ocean.core.Array: startsWith, map;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 import ocean.util.log.Logger;
 import ocean.util.log.AppendFile;

--- a/src/ocean/util/app/ext/VersionInfo.d
+++ b/src/ocean/util/app/ext/VersionInfo.d
@@ -16,6 +16,6 @@
 module ocean.util.app.ext.VersionInfo;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 public import ocean.application.components.Version : VersionInfo;

--- a/src/ocean/util/app/ext/model/IArgumentsExtExtension.d
+++ b/src/ocean/util/app/ext/model/IArgumentsExtExtension.d
@@ -18,7 +18,7 @@ module ocean.util.app.ext.model.IArgumentsExtExtension;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 public import ocean.util.app.model.IApplication;
 public import ocean.text.Arguments : Arguments;

--- a/src/ocean/util/app/ext/model/IConfigExtExtension.d
+++ b/src/ocean/util/app/ext/model/IConfigExtExtension.d
@@ -23,7 +23,7 @@ public import ocean.util.config.ConfigParser : ConfigParser;
 
 import ocean.util.app.model.IExtension;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /*******************************************************************************

--- a/src/ocean/util/app/model/IApplication.d
+++ b/src/ocean/util/app/model/IApplication.d
@@ -18,7 +18,7 @@ module ocean.util.app.model.IApplication;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.app.model.IApplicationExtension;
 

--- a/src/ocean/util/app/model/IApplicationExtension.d
+++ b/src/ocean/util/app/model/IApplicationExtension.d
@@ -18,7 +18,7 @@ module ocean.util.app.model.IApplicationExtension;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 public import ocean.util.app.ExitException : ExitException;
 

--- a/src/ocean/util/cipher/misc/ByteConverter.d
+++ b/src/ocean/util/cipher/misc/ByteConverter.d
@@ -16,7 +16,7 @@
 
 module ocean.util.cipher.misc.ByteConverter;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 version (unittest)
 {

--- a/src/ocean/util/cipher/misc/Padding.d
+++ b/src/ocean/util/cipher/misc/Padding.d
@@ -16,7 +16,7 @@
 module ocean.util.cipher.misc.Padding;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 version (unittest)

--- a/src/ocean/util/compress/c/zlib.d
+++ b/src/ocean/util/compress/c/zlib.d
@@ -21,7 +21,8 @@
 
 module ocean.util.compress.c.zlib;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
+import ocean.meta.types.Typedef;
 
 /// See original's library documentation for details.
 static immutable ZLIB_VERSION = "1.2.3".ptr;

--- a/src/ocean/util/config/ConfigFiller.d
+++ b/src/ocean/util/config/ConfigFiller.d
@@ -50,7 +50,7 @@ module ocean.util.config.ConfigFiller;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/ocean/util/config/ConfigParser.d
+++ b/src/ocean/util/config/ConfigParser.d
@@ -16,7 +16,7 @@
 module ocean.util.config.ConfigParser;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Array;
 import ocean.core.ExceptionDefinitions;

--- a/src/ocean/util/container/AppendBuffer.d
+++ b/src/ocean/util/container/AppendBuffer.d
@@ -23,7 +23,7 @@
 module ocean.util.container.AppendBuffer;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import core.stdc.stdlib: malloc, realloc, free;
 

--- a/src/ocean/util/container/ConcatBuffer.d
+++ b/src/ocean/util/container/ConcatBuffer.d
@@ -28,7 +28,7 @@ module ocean.util.container.ConcatBuffer;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Array : removeShift;
 

--- a/src/ocean/util/container/FixedKeyMap.d
+++ b/src/ocean/util/container/FixedKeyMap.d
@@ -60,7 +60,7 @@ module ocean.util.container.FixedKeyMap;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Array;
 import ocean.core.Array: copy, bsearch;
 import ocean.core.Enforce;

--- a/src/ocean/util/container/HashRangeMap.d
+++ b/src/ocean/util/container/HashRangeMap.d
@@ -24,7 +24,7 @@ module ocean.util.container.HashRangeMap;
 import ocean.core.Enforce;
 import ocean.math.Range;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 version (unittest)
 {

--- a/src/ocean/util/container/RedBlack.d
+++ b/src/ocean/util/container/RedBlack.d
@@ -19,7 +19,8 @@
 
 module ocean.util.container.RedBlack;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
+import ocean.meta.types.Typedef;
 
 import ocean.util.container.model.IContainer;
 

--- a/src/ocean/util/container/Slink.d
+++ b/src/ocean/util/container/Slink.d
@@ -21,7 +21,8 @@ module ocean.util.container.Slink;
 
 import ocean.core.Enforce;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
+import ocean.meta.types.Typedef;
 
 import ocean.util.container.model.IContainer;
 

--- a/src/ocean/util/container/SortedMap.d
+++ b/src/ocean/util/container/SortedMap.d
@@ -25,7 +25,7 @@ import ocean.util.container.RedBlack;
 
 import ocean.util.container.model.IContainer;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.ExceptionDefinitions : NoSuchElementException;
 

--- a/src/ocean/util/container/VoidBufferAsArrayOf.d
+++ b/src/ocean/util/container/VoidBufferAsArrayOf.d
@@ -46,7 +46,7 @@
 
 module ocean.util.container.VoidBufferAsArrayOf;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/ocean/util/container/btree/BTreeMap.d
+++ b/src/ocean/util/container/btree/BTreeMap.d
@@ -14,7 +14,7 @@
 
 module ocean.util.container.btree.BTreeMap;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.util.container.mem.MemManager;
 
 /******************************************************************************

--- a/src/ocean/util/container/btree/BTreeMapRange.d
+++ b/src/ocean/util/container/btree/BTreeMapRange.d
@@ -14,7 +14,7 @@
 
 module ocean.util.container.btree.BTreeMapRange;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.util.container.btree.BTreeMap;
 
 /*******************************************************************************

--- a/src/ocean/util/container/btree/Implementation.d
+++ b/src/ocean/util/container/btree/Implementation.d
@@ -14,7 +14,7 @@
 
 module ocean.util.container.btree.Implementation;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/ocean/util/container/cache/ExpiringCache.d
+++ b/src/ocean/util/container/cache/ExpiringCache.d
@@ -23,7 +23,7 @@
 
 module ocean.util.container.cache.ExpiringCache;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.container.cache.model.IExpiringCacheInfo;
 

--- a/src/ocean/util/container/cache/ExpiringLRUCache.d
+++ b/src/ocean/util/container/cache/ExpiringLRUCache.d
@@ -20,7 +20,7 @@
 module ocean.util.container.cache.ExpiringLRUCache;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.container.cache.model.IExpiringCacheInfo;
 

--- a/src/ocean/util/container/ebtree/EBTree128.d
+++ b/src/ocean/util/container/ebtree/EBTree128.d
@@ -21,7 +21,7 @@
 module ocean.util.container.ebtree.EBTree128;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.container.ebtree.model.IEBTree,
        ocean.util.container.ebtree.model.Node,

--- a/src/ocean/util/container/ebtree/EBTree32.d
+++ b/src/ocean/util/container/ebtree/EBTree32.d
@@ -53,7 +53,7 @@
 module ocean.util.container.ebtree.EBTree32;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.container.ebtree.model.IEBTree,
        ocean.util.container.ebtree.model.Node,

--- a/src/ocean/util/container/ebtree/EBTree64.d
+++ b/src/ocean/util/container/ebtree/EBTree64.d
@@ -53,7 +53,7 @@
 module ocean.util.container.ebtree.EBTree64;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.container.ebtree.model.IEBTree,
        ocean.util.container.ebtree.model.Node,

--- a/src/ocean/util/container/ebtree/c/eb128tree.d
+++ b/src/ocean/util/container/ebtree/c/eb128tree.d
@@ -37,7 +37,7 @@ module ocean.util.container.ebtree.c.eb128tree;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.util.container.ebtree.c.ebtree: eb_root, eb_node;
 
 

--- a/src/ocean/util/container/ebtree/c/ebtree.d
+++ b/src/ocean/util/container/ebtree/c/ebtree.d
@@ -26,7 +26,7 @@
 module ocean.util.container.ebtree.c.ebtree;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /// See original's library documentation for details.

--- a/src/ocean/util/container/ebtree/nodepool/NodePool.d
+++ b/src/ocean/util/container/ebtree/nodepool/NodePool.d
@@ -17,7 +17,7 @@
 
 module ocean.util.container.ebtree.nodepool.NodePool;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/ocean/util/container/map/Map.d
+++ b/src/ocean/util/container/map/Map.d
@@ -82,7 +82,7 @@ module ocean.util.container.map.Map;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.container.map.model.BucketSet;
 

--- a/src/ocean/util/container/map/TreeMap.d
+++ b/src/ocean/util/container/map/TreeMap.d
@@ -33,7 +33,7 @@ import ocean.util.container.ebtree.c.ebtree;
 
 struct TreeMap ( T )
 {
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     /***************************************************************************
 

--- a/src/ocean/util/container/map/model/BucketElementMallocAllocator.d
+++ b/src/ocean/util/container/map/model/BucketElementMallocAllocator.d
@@ -110,7 +110,7 @@ module ocean.util.container.map.model.BucketElementMallocAllocator;
 import ocean.util.container.map.model.IAllocator;
 
 import core.memory;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/ocean/util/container/map/model/BucketInfo.d
+++ b/src/ocean/util/container/map/model/BucketInfo.d
@@ -17,7 +17,7 @@
 module ocean.util.container.map.model.BucketInfo;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 debug (BucketInfo) import ocean.io.Stdout;
 
 /*******************************************************************************/

--- a/src/ocean/util/container/map/model/BucketSet.d
+++ b/src/ocean/util/container/map/model/BucketSet.d
@@ -36,7 +36,7 @@
 
 module ocean.util.container.map.model.BucketSet;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.container.map.model.Bucket,
        ocean.util.container.map.model.BucketInfo,

--- a/src/ocean/util/container/map/model/StandardHash.d
+++ b/src/ocean/util/container/map/model/StandardHash.d
@@ -16,7 +16,7 @@
 
 module ocean.util.container.map.model.StandardHash;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 struct StandardHash
 {

--- a/src/ocean/util/container/map/utils/MapSerializer.d
+++ b/src/ocean/util/container/map/utils/MapSerializer.d
@@ -26,7 +26,7 @@
 module ocean.util.container.map.utils.MapSerializer;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.io.digest.Fnv1,
        ocean.io.serialize.SimpleStreamSerializer,

--- a/src/ocean/util/container/mem/MemManager.d
+++ b/src/ocean/util/container/mem/MemManager.d
@@ -26,7 +26,7 @@ import core.stdc.stdlib : malloc, free;
 
 import core.memory;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/ocean/util/container/pool/AcquiredResources.d
+++ b/src/ocean/util/container/pool/AcquiredResources.d
@@ -52,7 +52,7 @@
 
 module ocean.util.container.pool.AcquiredResources;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 import ocean.util.container.pool.FreeList;
 

--- a/src/ocean/util/container/pool/model/IAggregatePool.d
+++ b/src/ocean/util/container/pool/model/IAggregatePool.d
@@ -87,7 +87,7 @@ module ocean.util.container.pool.model.IAggregatePool;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.container.pool.model.IPool;
 import ocean.util.container.pool.model.IFreeList;

--- a/src/ocean/util/container/pool/model/IFreeList.d
+++ b/src/ocean/util/container/pool/model/IFreeList.d
@@ -15,7 +15,7 @@
 
 module ocean.util.container.pool.model.IFreeList;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 

--- a/src/ocean/util/container/pool/model/IPool.d
+++ b/src/ocean/util/container/pool/model/IPool.d
@@ -39,7 +39,7 @@ module ocean.util.container.pool.model.IPool;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.container.pool.model.IPoolInfo;
 import ocean.util.container.pool.model.ILimitable;

--- a/src/ocean/util/container/queue/FixedRingQueue.d
+++ b/src/ocean/util/container/queue/FixedRingQueue.d
@@ -32,7 +32,7 @@ import ocean.util.container.mem.MemManager;
 
 version (unittest) import ocean.core.Test;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /*******************************************************************************

--- a/src/ocean/util/container/queue/FlexibleFileQueue.d
+++ b/src/ocean/util/container/queue/FlexibleFileQueue.d
@@ -24,7 +24,7 @@
 module ocean.util.container.queue.FlexibleFileQueue;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Buffer;
 import ocean.util.container.queue.FlexibleRingQueue;
 import ocean.util.container.queue.model.IByteQueue;

--- a/src/ocean/util/container/queue/FlexibleRingQueue.d
+++ b/src/ocean/util/container/queue/FlexibleRingQueue.d
@@ -17,8 +17,9 @@ module ocean.util.container.queue.FlexibleRingQueue;
 
 
 
+import ocean.core.TypeConvert: assumeUnique;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.container.queue.model.IRingQueue;
 

--- a/src/ocean/util/container/queue/LinkedListQueue.d
+++ b/src/ocean/util/container/queue/LinkedListQueue.d
@@ -13,7 +13,7 @@
 
 module ocean.util.container.queue.LinkedListQueue;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import core.memory;
 import ocean.util.container.Container;

--- a/src/ocean/util/container/queue/NotifyingQueue.d
+++ b/src/ocean/util/container/queue/NotifyingQueue.d
@@ -104,7 +104,7 @@ import ocean.util.serialize.contiguous.Deserializer;
 
 import ocean.core.Array;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.container.AppendBuffer;
 

--- a/src/ocean/util/container/queue/QueueChain.d
+++ b/src/ocean/util/container/queue/QueueChain.d
@@ -40,7 +40,7 @@ import ocean.io.stream.Buffered,
        ocean.io.device.File,
        Filesystem = ocean.io.Path;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 public class QueueChain : IByteQueue

--- a/src/ocean/util/container/queue/model/IByteQueue.d
+++ b/src/ocean/util/container/queue/model/IByteQueue.d
@@ -20,7 +20,7 @@ module ocean.util.container.queue.model.IByteQueue;
 
 import ocean.util.container.queue.model.IQueueInfo;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /*******************************************************************************

--- a/src/ocean/util/digest/Crc32.d
+++ b/src/ocean/util/digest/Crc32.d
@@ -17,7 +17,7 @@
 
 module ocean.util.digest.Crc32;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 public import ocean.util.digest.Digest;
 
 version (unittest) import ocean.core.Test;

--- a/src/ocean/util/digest/Digest.d
+++ b/src/ocean/util/digest/Digest.d
@@ -19,7 +19,7 @@
 
 module ocean.util.digest.Digest;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/ocean/util/digest/Md2.d
+++ b/src/ocean/util/digest/Md2.d
@@ -20,7 +20,7 @@
 
 module ocean.util.digest.Md2;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 public  import ocean.util.digest.Digest;
 

--- a/src/ocean/util/digest/Md4.d
+++ b/src/ocean/util/digest/Md4.d
@@ -20,7 +20,7 @@
 
 module ocean.util.digest.Md4;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 public  import ocean.util.digest.Digest;
 

--- a/src/ocean/util/digest/Md5.d
+++ b/src/ocean/util/digest/Md5.d
@@ -20,7 +20,7 @@
 
 module ocean.util.digest.Md5;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 public  import ocean.util.digest.Md4;
 

--- a/src/ocean/util/digest/MerkleDamgard.d
+++ b/src/ocean/util/digest/MerkleDamgard.d
@@ -19,7 +19,7 @@
 
 module ocean.util.digest.MerkleDamgard;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 

--- a/src/ocean/util/digest/Ripemd128.d
+++ b/src/ocean/util/digest/Ripemd128.d
@@ -27,7 +27,7 @@
 
 module ocean.util.digest.Ripemd128;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.digest.MerkleDamgard;
 

--- a/src/ocean/util/digest/Ripemd160.d
+++ b/src/ocean/util/digest/Ripemd160.d
@@ -27,7 +27,7 @@
 
 module ocean.util.digest.Ripemd160;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.digest.MerkleDamgard;
 

--- a/src/ocean/util/digest/Ripemd256.d
+++ b/src/ocean/util/digest/Ripemd256.d
@@ -27,7 +27,7 @@
 
 module ocean.util.digest.Ripemd256;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.digest.MerkleDamgard;
 

--- a/src/ocean/util/digest/Ripemd320.d
+++ b/src/ocean/util/digest/Ripemd320.d
@@ -27,7 +27,7 @@
 
 module ocean.util.digest.Ripemd320;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.digest.MerkleDamgard;
 

--- a/src/ocean/util/digest/Sha0.d
+++ b/src/ocean/util/digest/Sha0.d
@@ -20,7 +20,7 @@
 
 module ocean.util.digest.Sha0;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.digest.Sha01;
 

--- a/src/ocean/util/digest/Sha01.d
+++ b/src/ocean/util/digest/Sha01.d
@@ -19,7 +19,7 @@
 
 module ocean.util.digest.Sha01;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.ByteSwap;
 

--- a/src/ocean/util/digest/Sha1.d
+++ b/src/ocean/util/digest/Sha1.d
@@ -21,7 +21,7 @@
 
 module ocean.util.digest.Sha1;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.digest.Sha01;
 

--- a/src/ocean/util/digest/Sha256.d
+++ b/src/ocean/util/digest/Sha256.d
@@ -20,7 +20,7 @@
 
 module ocean.util.digest.Sha256;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.ByteSwap;
 

--- a/src/ocean/util/digest/Sha512.d
+++ b/src/ocean/util/digest/Sha512.d
@@ -20,7 +20,7 @@
 
 module ocean.util.digest.Sha512;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.ByteSwap;
 

--- a/src/ocean/util/digest/Tiger.d
+++ b/src/ocean/util/digest/Tiger.d
@@ -20,7 +20,7 @@
 
 module ocean.util.digest.Tiger;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Verify;
 import ocean.core.TypeConvert;

--- a/src/ocean/util/digest/Whirlpool.d
+++ b/src/ocean/util/digest/Whirlpool.d
@@ -23,7 +23,7 @@
 
 module ocean.util.digest.Whirlpool;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.digest.MerkleDamgard;
 

--- a/src/ocean/util/encode/Base16.d
+++ b/src/ocean/util/encode/Base16.d
@@ -37,7 +37,7 @@
 
 module ocean.util.encode.Base16;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 version (unittest) import ocean.core.Test;

--- a/src/ocean/util/encode/Base32.d
+++ b/src/ocean/util/encode/Base32.d
@@ -37,7 +37,7 @@
 
 module ocean.util.encode.Base32;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 version (unittest) import ocean.core.Test;

--- a/src/ocean/util/encode/Base64.d
+++ b/src/ocean/util/encode/Base64.d
@@ -29,7 +29,7 @@
 
 module ocean.util.encode.Base64;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 version (unittest) import ocean.core.Test;
@@ -610,6 +610,8 @@ private istring validateEncodeTable (istring s)
 
 unittest
 {
+    import ocean.core.TypeConvert: assumeUnique;
+
     test!("is")(validateEncodeTable(defaultEncodeTable), istring.init);
     test!("is")(validateEncodeTable(urlSafeEncodeTable), istring.init);
     istring too_long = defaultEncodeTable ~ 'A';

--- a/src/ocean/util/log/AppendConsole.d
+++ b/src/ocean/util/log/AppendConsole.d
@@ -17,7 +17,7 @@
 
 module ocean.util.log.AppendConsole;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.io.Console;
 

--- a/src/ocean/util/log/AppendFile.d
+++ b/src/ocean/util/log/AppendFile.d
@@ -21,7 +21,7 @@ import ocean.io.device.File;
 import ocean.io.model.IFile;
 import ocean.io.model.IConduit;
 import ocean.io.stream.Buffered;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.util.log.Appender;
 import ocean.util.log.Event;
 

--- a/src/ocean/util/log/AppendStderrStdout.d
+++ b/src/ocean/util/log/AppendStderrStdout.d
@@ -17,7 +17,7 @@
 module ocean.util.log.AppendStderrStdout;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.util.log.Appender;
 import ocean.util.log.Event;
 import ocean.util.log.ILogger;

--- a/src/ocean/util/log/AppendSysLog.d
+++ b/src/ocean/util/log/AppendSysLog.d
@@ -16,7 +16,7 @@
 module ocean.util.log.AppendSysLog;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 import ocean.util.log.Appender;
 import ocean.util.log.Event;

--- a/src/ocean/util/log/Appender.d
+++ b/src/ocean/util/log/Appender.d
@@ -20,11 +20,12 @@
 
 module ocean.util.log.Appender;
 
-import ocean.transition;
 import ocean.core.Verify;
 import ocean.core.ExceptionDefinitions;
 import ocean.io.model.IConduit;
 import ocean.text.convert.Formatter;
+import ocean.meta.types.Qualifiers;
+import ocean.meta.types.Typedef;
 import ocean.util.log.Event;
 import ocean.util.log.ILogger;
 

--- a/src/ocean/util/log/Config.d
+++ b/src/ocean/util/log/Config.d
@@ -71,7 +71,7 @@
 module ocean.util.log.Config;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.io.Stdout;
 import ocean.core.Array : insertShift, removePrefix, removeSuffix, sort;

--- a/src/ocean/util/log/Event.d
+++ b/src/ocean/util/log/Event.d
@@ -23,7 +23,7 @@
 
 module ocean.util.log.Event;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 import ocean.time.Clock;
 import ocean.util.log.ILogger;

--- a/src/ocean/util/log/Hierarchy.d
+++ b/src/ocean/util/log/Hierarchy.d
@@ -23,8 +23,9 @@
 
 module ocean.util.log.Hierarchy;
 
-import ocean.transition;
 import ocean.core.ExceptionDefinitions;
+import ocean.core.TypeConvert: assumeUnique;
+import ocean.meta.types.Qualifiers;
 import ocean.util.log.ILogger;
 
 

--- a/src/ocean/util/log/ILogger.d
+++ b/src/ocean/util/log/ILogger.d
@@ -24,7 +24,7 @@
 module ocean.util.log.ILogger;
 
 import ocean.stdc.string;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 version (unittest)
 {

--- a/src/ocean/util/log/InsertConsole.d
+++ b/src/ocean/util/log/InsertConsole.d
@@ -24,7 +24,7 @@
 module ocean.util.log.InsertConsole;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 import ocean.io.Terminal;

--- a/src/ocean/util/log/Logger.d
+++ b/src/ocean/util/log/Logger.d
@@ -13,7 +13,7 @@
     // Workaround: https://github.com/dlang/dub/issues/1761
     module_ superapp.main;
 
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
     import ocean.util.log.Logger;
 
     private Logger log;
@@ -57,7 +57,7 @@
 
 module ocean.util.log.Logger;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 import ocean.core.ExceptionDefinitions;
 import ocean.io.model.IConduit;
@@ -97,7 +97,7 @@ public alias ILogger.Level Level;
 
 public struct Log
 {
-    mixin TypeofThis!();
+    alias typeof(this) This;
 
     /***************************************************************************
 
@@ -111,7 +111,7 @@ public struct Log
 
     public struct Stats
     {
-        mixin TypeofThis!();
+        alias typeof(this) This;
 
         /// Number of trace log events issued
         public uint logged_trace;

--- a/src/ocean/util/log/PeriodicTrace.d
+++ b/src/ocean/util/log/PeriodicTrace.d
@@ -72,7 +72,7 @@ import ocean.core.TypeConvert;
 import ocean.io.Stdout;
 import ocean.text.convert.Formatter;
 import ocean.time.StopWatch;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.util.log.StaticTrace;
 
 

--- a/src/ocean/util/log/StaticTrace.d
+++ b/src/ocean/util/log/StaticTrace.d
@@ -24,7 +24,7 @@ import ocean.io.model.IConduit;
 import ocean.io.Terminal;
 import ocean.text.convert.Formatter;
 import ocean.text.Search;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 
 /*******************************************************************************

--- a/src/ocean/util/log/Stats.d
+++ b/src/ocean/util/log/Stats.d
@@ -39,7 +39,7 @@ module ocean.util.log.Stats;
 
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 import ocean.core.Verify;
 import ocean.core.Enforce;

--- a/src/ocean/util/log/StatsReader.d
+++ b/src/ocean/util/log/StatsReader.d
@@ -22,7 +22,7 @@
 
 module ocean.util.log.StatsReader;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Buffer;
 import ocean.core.Enforce;
 import ocean.core.array.Search;

--- a/src/ocean/util/log/Stats_slowtest.d
+++ b/src/ocean/util/log/Stats_slowtest.d
@@ -18,7 +18,7 @@ module ocean.util.log.Stats_slowtest;
 import ocean.core.Test,
        ocean.util.log.Stats;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.io.device.TempFile;
 
 unittest

--- a/src/ocean/util/log/layout/LayoutMessageOnly.d
+++ b/src/ocean/util/log/layout/LayoutMessageOnly.d
@@ -16,7 +16,7 @@
 
 module ocean.util.log.layout.LayoutMessageOnly;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.util.log.Appender;
 import ocean.util.log.Event;
 

--- a/src/ocean/util/log/layout/LayoutSimple.d
+++ b/src/ocean/util/log/layout/LayoutSimple.d
@@ -16,7 +16,7 @@
 module ocean.util.log.layout.LayoutSimple;
 
 import ocean.text.convert.Formatter;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.util.log.Appender;
 import ocean.util.log.Event;
 

--- a/src/ocean/util/log/layout/LayoutStatsLog.d
+++ b/src/ocean/util/log/layout/LayoutStatsLog.d
@@ -20,7 +20,7 @@
 
 module ocean.util.log.layout.LayoutStatsLog;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.text.convert.Formatter;
 import ocean.time.Clock;
 import ocean.time.WallClock;

--- a/src/ocean/util/prometheus/collector/Collector.d
+++ b/src/ocean/util/prometheus/collector/Collector.d
@@ -79,7 +79,7 @@ public class Collector
     import Traits = ocean.core.Traits;
     import ocean.math.IEEE;
     import ocean.text.convert.Formatter;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
     import StatFormatter = ocean.util.prometheus.collector.StatFormatter;
 
     /// A buffer used for storing collected stats. Is cleared when the `reset`
@@ -188,7 +188,7 @@ public class Collector
 version (unittest)
 {
     import ocean.core.Test;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     struct Statistics
     {

--- a/src/ocean/util/prometheus/collector/CollectorRegistry.d
+++ b/src/ocean/util/prometheus/collector/CollectorRegistry.d
@@ -18,7 +18,7 @@ module ocean.util.prometheus.collector.CollectorRegistry;
 /// ditto
 public class CollectorRegistry
 {
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
     import ocean.util.prometheus.collector.Collector : Collector;
 
     /// An alias for the type of delegates that are called for stat collection
@@ -99,7 +99,7 @@ version (unittest)
 {
     import ocean.core.Test;
     import Traits = ocean.core.Traits;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
     import ocean.util.prometheus.collector.Collector;
 
     ///

--- a/src/ocean/util/prometheus/collector/StatFormatter.d
+++ b/src/ocean/util/prometheus/collector/StatFormatter.d
@@ -19,7 +19,7 @@ import ocean.meta.traits.Basic;
 import ocean.meta.codegen.Identifier;
 import ocean.math.IEEE;
 import ocean.text.convert.Formatter;
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 /*******************************************************************************
 
@@ -301,7 +301,7 @@ unittest
 version (unittest)
 {
     import ocean.core.Test;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     struct Statistics
     {

--- a/src/ocean/util/prometheus/server/PrometheusHandler.d
+++ b/src/ocean/util/prometheus/server/PrometheusHandler.d
@@ -26,7 +26,7 @@ public class PrometheusHandler : HttpConnectionHandler
     import ocean.net.http.HttpConst: HttpResponseCode;
     import ocean.net.http.consts.HttpMethod: HttpMethod;
     import ocean.text.convert.Formatter : sformat;
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
     import ocean.util.log.Logger : Logger, Log;
     import ocean.util.prometheus.collector.CollectorRegistry :
         CollectorRegistry;

--- a/src/ocean/util/prometheus/server/PrometheusListener.d
+++ b/src/ocean/util/prometheus/server/PrometheusListener.d
@@ -45,7 +45,7 @@ public class PrometheusListener :
     import ocean.text.convert.Formatter : sformat;
     import ocean.util.log.Logger : Logger, Log;
 
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
 
     /// A static logger for logging information about connections.
     private static Logger log;

--- a/src/ocean/util/serialize/Version.d
+++ b/src/ocean/util/serialize/Version.d
@@ -29,7 +29,7 @@
 module ocean.util.serialize.Version;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 import ocean.core.Buffer;
 

--- a/src/ocean/util/serialize/contiguous/Contiguous.d
+++ b/src/ocean/util/serialize/contiguous/Contiguous.d
@@ -17,7 +17,7 @@
 module ocean.util.serialize.contiguous.Contiguous;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 import ocean.meta.traits.Indirections;
 import ocean.core.Enforce;
@@ -297,7 +297,11 @@ package template ensureValueTypeMember ( S, size_t i, T )
 }
 
 version (unittest)
+{
     import core.stdc.string: memset;
+    import ocean.meta.types.Typedef;
+
+}
 
 unittest
 {

--- a/src/ocean/util/serialize/contiguous/Deserializer.d
+++ b/src/ocean/util/serialize/contiguous/Deserializer.d
@@ -17,7 +17,7 @@
 module ocean.util.serialize.contiguous.Deserializer;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Verify;
 
 import ocean.util.serialize.contiguous.Contiguous;

--- a/src/ocean/util/serialize/contiguous/MultiVersionDecorator.d
+++ b/src/ocean/util/serialize/contiguous/MultiVersionDecorator.d
@@ -17,7 +17,7 @@
 
 module ocean.util.serialize.contiguous.MultiVersionDecorator;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.Buffer;
 import ocean.core.Verify;

--- a/src/ocean/util/serialize/contiguous/Serializer.d
+++ b/src/ocean/util/serialize/contiguous/Serializer.d
@@ -17,7 +17,7 @@
 module ocean.util.serialize.contiguous.Serializer;
 
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.serialize.contiguous.Contiguous;
 import ocean.meta.traits.Indirections;

--- a/src/ocean/util/serialize/contiguous/Util.d
+++ b/src/ocean/util/serialize/contiguous/Util.d
@@ -20,7 +20,7 @@ import ocean.util.serialize.contiguous.Contiguous;
 import ocean.util.serialize.contiguous.Serializer;
 import ocean.util.serialize.contiguous.Deserializer;
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Test;
 
 /*******************************************************************************

--- a/src/ocean/util/serialize/contiguous/package.d
+++ b/src/ocean/util/serialize/contiguous/package.d
@@ -144,7 +144,7 @@ version (unittest):
 
 ******************************************************************************/
 
-import ocean.transition;
+import ocean.meta.types.Qualifiers;
 import ocean.core.Test;
 import ocean.core.Verify;
 import ocean.core.StructConverter;

--- a/src/ocean/util/test/DirectorySandbox.d
+++ b/src/ocean/util/test/DirectorySandbox.d
@@ -22,7 +22,7 @@ import ocean.core.Verify;
 /// ditto
 class DirectorySandbox
 {
-    import ocean.transition;
+    import ocean.meta.types.Qualifiers;
     import ocean.sys.ErrnoException;
     import ocean.io.device.File;
     import Path = ocean.io.Path;

--- a/src/ocean/util/uuid/Uuid.d
+++ b/src/ocean/util/uuid/Uuid.d
@@ -20,7 +20,8 @@
  */
 module ocean.util.uuid.Uuid;
 
-import ocean.transition;
+import ocean.core.TypeConvert: assumeUnique;
+import ocean.meta.types.Qualifiers;
 
 import ocean.core.ExceptionDefinitions;
 import Integer = ocean.text.convert.Integer_tango;


### PR DESCRIPTION
The ocean.transition module was created to ease D2 conversion. It can now be replaced with more appropriate imports.

This PR changes the import statements and makes no other changes.

The replacement was done by executing the command
    `find . -type f -name "*.d" | xargs -o sed -i "s/import ocean.transition;/import ocean.meta.types.Qualifiers;/g"`

Virtually all modules use `cstring`, so the automatic replacement will not produce very many unnecessary imports.

I then added imports for `Typedef` and `assumeUnique` when required.
In many cases these were only required inside unit tests, so in those cases the imports were added inside `version (unittest)` blocks.

For the few modules in `ocean.core.array` I did the replacement carefully, ensuring that the imports are actually minimal, and I also cleaned up the import order. I didn't bother doing this with the rest.

Once this PR has been merged, the only remaining modules which import `ocean.transition` are:
* four modules which use `gc_usage`.
* six modules which use `Octal`.

Neither of those functions have direct replacements in ocean at present.

