### PR TITLE
Remove the only remaining use of version(D_Version2)

### DIFF
--- a/integrationtest/unregisterclient/main.d
+++ b/integrationtest/unregisterclient/main.d
@@ -30,14 +30,7 @@ private int count;
 // segfault at access
 private void corruptEventObject (SelectEvent client)
 {
-    version (D_Version2)
-    {
-        auto initializer = client.classinfo.initializer();
-    }
-    else
-    {
-        auto initializer = client.classinfo.init;
-    }
+    auto initializer = client.classinfo.initializer();
 
     ubyte* ptr = cast(ubyte*)client;
     ptr[0..initializer.length] = 0;


### PR DESCRIPTION
This is no longer required now that D1 support has been dropped.