### PR TITLE
Replace SortedMap.opIn_r with opBinaryRight!"in"

### DIFF
--- a/src/ocean/core/SmartEnum.d
+++ b/src/ocean/core/SmartEnum.d
@@ -1063,7 +1063,7 @@ public struct TwoWayMap ( A )
 
     /***************************************************************************
 
-        opIn_r operator - performs a lookup of an item A in the map
+        `in` operator - performs a lookup of an item A in the map
         corresponding to an item B.
 
         Params:
@@ -1075,7 +1075,7 @@ public struct TwoWayMap ( A )
 
     ***************************************************************************/
 
-    public KeyType* opIn_r ( cstring b )
+    public KeyType* opBinaryRight ( istring op : "in" ) ( cstring b )
     {
         return b in this.b_to_a;
     }
@@ -1095,7 +1095,7 @@ public struct TwoWayMap ( A )
 
     ***************************************************************************/
 
-    public ValueType* opIn_r ( KeyType a )
+    public ValueType* opBinaryRight ( istring op : "in" ) ( KeyType a )
     {
         return a in this.a_to_b;
     }

--- a/src/ocean/util/container/SortedMap.d
+++ b/src/ocean/util/container/SortedMap.d
@@ -57,7 +57,7 @@ import ocean.core.ExceptionDefinitions : NoSuchElementException;
         bool opIndexAssign (V element, K key)
         K    nearbyKey (K key, bool greater)
         V    opIndex (K key)
-        V*   opIn_r (K key)
+        V*   opBinaryRight!"in" (K key)
 
         size_t size ()
         bool isEmpty ()
@@ -391,7 +391,7 @@ class SortedMap (K, V, alias Reap = Container.reap,
 
         ***********************************************************************/
 
-        final V* opIn_r (K key)
+        V* opBinaryRight (string op : "in") (K key)
         {
                 if (count)
                    {
@@ -589,7 +589,7 @@ class SortedMap (K, V, alias Reap = Container.reap,
 
         final V opIndex (K key)
         {
-                auto p = opIn_r (key);
+                auto p = key in this;
                 if (p)
                     return *p;
 


### PR DESCRIPTION
Even though SortedMap is a class, the opIn_r function was marked as `final` so the fact that the D2 overload is non-virtual is not a problem.

This fixes a large number of deprecation warnings in dmd 2.090