### PR TITLE
Create D2 operator overloads to avoid deprecation messages

### DIFF
--- a/src/ocean/core/Enum.d
+++ b/src/ocean/core/Enum.d
@@ -184,6 +184,17 @@ public interface IEnum
 
     /***************************************************************************
 
+        Support for the 'in' operator
+
+        Aliased to opIn_r, for backwards compatibility
+
+    ***************************************************************************/
+
+    public alias opBinaryRight ( istring op : "in" ) = opIn_r;
+
+
+    /***************************************************************************
+
         Looks up an enum member's name from its value, using opIndex.
 
         Params:

--- a/src/ocean/text/entities/model/IEntitySet.d
+++ b/src/ocean/text/entities/model/IEntitySet.d
@@ -125,6 +125,18 @@ public abstract class IEntitySet
 
     /***************************************************************************
 
+        Support for the 'in' operator
+
+        Aliased to the various opIn_r member functions, for backwards
+        compatibility
+
+    ***************************************************************************/
+
+    public alias opBinaryRight ( istring op : "in" ) = opIn_r;
+
+
+    /***************************************************************************
+
         Checks whether the passed name is in the list of entities.
 
         Params:

--- a/src/ocean/util/container/AppendBuffer.d
+++ b/src/ocean/util/container/AppendBuffer.d
@@ -378,6 +378,18 @@ public class AppendBuffer ( T, Base: AppendBufferImpl ): Base, IAppendBufferRead
         }
     }
 
+
+    /***************************************************************************
+
+        Support for operator ~= for appending elements and concatenating chunks
+
+        Aliased to opCatAssign, for backwards compatibility
+
+    ***************************************************************************/
+
+    alias opOpAssign ( istring op = "~" ) = opCatAssign;
+
+
     /**************************************************************************
 
         Returns:

--- a/src/ocean/util/container/FixedKeyMap.d
+++ b/src/ocean/util/container/FixedKeyMap.d
@@ -227,6 +227,17 @@ public class FixedKeyMap ( K, V )
 
     /***************************************************************************
 
+        Support for the 'in' operator
+
+        Aliased to opIn_r, for backwards compatibility
+
+    ***************************************************************************/
+
+    public alias opBinaryRight ( istring op : "in" ) = opIn_r;
+
+
+    /***************************************************************************
+
         foreach operator over keys in the map.
 
     ***************************************************************************/

--- a/src/ocean/util/container/cache/CachingStructLoader.d
+++ b/src/ocean/util/container/cache/CachingStructLoader.d
@@ -18,6 +18,8 @@
 module ocean.util.container.cache.CachingStructLoader;
 
 
+import ocean.meta.types.Qualifiers;
+
 import ocean.util.container.cache.ExpiringCache,
        ocean.util.container.cache.model.IExpiringCacheInfo;
 import CacheValue = ocean.util.container.cache.model.Value;
@@ -336,6 +338,17 @@ class CachingStructLoader ( S )
     {
         return this.load(key).ptr;
     }
+
+
+    /***************************************************************************
+
+        Support for the 'in' operator
+
+        Aliased to opIn_r, for backwards compatibility
+
+    ***************************************************************************/
+
+    public alias opBinaryRight ( istring op : "in" ) = opIn_r;
 
 
     /**************************************************************************

--- a/src/ocean/util/container/cache/ExpiredCacheReloader.d
+++ b/src/ocean/util/container/cache/ExpiredCacheReloader.d
@@ -18,6 +18,8 @@
 module ocean.util.container.cache.ExpiredCacheReloader;
 
 
+import ocean.meta.types.Qualifiers;
+
 import ocean.util.container.cache.ExpiringLRUCache,
        ocean.util.container.cache.model.IExpiringCacheInfo;
 import CacheValue = ocean.util.container.cache.model.Value;
@@ -338,6 +340,16 @@ class ExpiredCacheReloader ( S )
     {
         return this.load(key).ptr;
     }
+
+    /***************************************************************************
+
+        Support for the 'in' operator
+
+        Aliased to opIn_r, for backwards compatibility
+
+    ***************************************************************************/
+
+    public alias opBinaryRight ( istring op : "in" ) = opIn_r;
 }
 
 unittest

--- a/src/ocean/util/container/cache/model/ICache.d
+++ b/src/ocean/util/container/cache/model/ICache.d
@@ -16,6 +16,8 @@
 module ocean.util.container.cache.model.ICache;
 
 
+import ocean.meta.types.Qualifiers;
+
 import ocean.util.container.cache.model.ICacheInfo;
 
 import ocean.util.container.cache.model.containers.TimeToIndex;
@@ -368,6 +370,18 @@ abstract class ICache : ICacheInfo
 
         return node;
     }
+
+
+    /***************************************************************************
+
+        Support for the 'in' operator
+
+        Aliased to opIn_r, for backwards compatibility
+
+    ***************************************************************************/
+
+    protected alias opBinaryRight ( istring op : "in" ) = opIn_r;
+
 
     /***************************************************************************
 

--- a/src/ocean/util/container/ebtree/EBTree128.d
+++ b/src/ocean/util/container/ebtree/EBTree128.d
@@ -336,6 +336,18 @@ class EBTree128 ( bool signed = false ) : IEBTree
         }
     }
 
+
+    /***************************************************************************
+
+        Support for the 'in' operator
+
+        Aliased to opIn_r, for backwards compatibility
+
+    ***************************************************************************/
+
+    public alias opBinaryRight ( istring op : "in" ) = opIn_r;
+
+
     /***************************************************************************
 
         Adds node to the tree, automatically inserting it in the correct

--- a/src/ocean/util/container/ebtree/EBTree32.d
+++ b/src/ocean/util/container/ebtree/EBTree32.d
@@ -446,6 +446,18 @@ class EBTree32 ( bool signed = false ) : IEBTree
         }
     }
 
+
+    /***************************************************************************
+
+        Support for the 'in' operator
+
+        Aliased to opIn_r, for backwards compatibility
+
+    ***************************************************************************/
+
+    public alias opBinaryRight ( istring op : "in" ) = opIn_r;
+
+
     /***************************************************************************
 
         Adds a value to the tree, automatically inserting a new node in the

--- a/src/ocean/util/container/ebtree/EBTree64.d
+++ b/src/ocean/util/container/ebtree/EBTree64.d
@@ -401,6 +401,18 @@ class EBTree64 ( bool signed = false ) : IEBTree
         }
     }
 
+
+    /***************************************************************************
+
+        Support for the 'in' operator
+
+        Aliased to opIn_r, for backwards compatibility
+
+    ***************************************************************************/
+
+    public alias opBinaryRight ( istring op : "in" ) = opIn_r;
+
+
     /***************************************************************************
 
         Adds node to the tree, automatically inserting it in the correct

--- a/src/ocean/util/container/map/Set.d
+++ b/src/ocean/util/container/map/Set.d
@@ -44,6 +44,7 @@ module ocean.util.container.map.Set;
 
 
 
+import ocean.meta.types.Qualifiers;
 
 import ocean.util.container.map.model.BucketSet;
 
@@ -290,6 +291,17 @@ public abstract class Set ( K ) : BucketSet!(0, K)
     {
         return this.get_(key) !is null;
     }
+
+
+    /***************************************************************************
+
+        Support for the 'in' operator
+
+        Aliased to opIn_r, for backwards compatibility
+
+    ***************************************************************************/
+
+    public alias opBinaryRight ( istring op : "in" ) = opIn_r;
 
 
     /***************************************************************************


### PR DESCRIPTION
D1-style operator overloads are deprecated in dmd 2.090.
This PR silences most of the remaining deprecation warnings in the upcoming dmd 2.091.

There are a few remaining deprecation warnings.
(1) from `SmartEnum`, which requires a little more care;
(2) some really dreadful operator overloads, which deserve to generate warnings:

* There is an absolutely disgusting opSubAssign in IEBTree. (`--this` is used to update the reference count)
* There is an opSub in SignalMask which is a bad idea.
* This is an opCatAssign in FilePath which appends a "/" before doing the append. I don't think ~= should be used for this.

