### PR TITLE
dub.sdl: Exclude deprecated modules from source file

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -8,6 +8,10 @@ systemDependencies "Depending on the component used you might need one of the fo
 importPaths "src"
 targetType "sourceLibrary"
 
+// Deprecated files are excluded
+excludedSourceFiles "src/ocean/stdc/posix/arpa/inet.d" "src/ocean/stdc/posix/net/if_.d" "src/ocean/stdc/posix/netinet/in_.d" "src/ocean/stdc/posix/stdlib.d" \
+                    "src/ocean/stdc/posix/sys/types.d" "src/ocean/util/log/model/ILogger.d"
+
 configuration "unittest" {
     excludedSourceFiles "src/ocean/core/UnitTestRunner.d"
     libs "glib-2.0" "pcre" "ebtree" "readline" "lzo2" "gcrypt" "gpg-error"


### PR DESCRIPTION
Avoid deprecation warnings when compiling.