### PR TITLE
Add `return ref` annotations when required

### DIFF
--- a/src/ocean/text/Search.d
+++ b/src/ocean/text/Search.d
@@ -456,7 +456,7 @@ public struct SearchFruct
 
      ***********************************************************************/
 
-    Substitute tokens (cstring content, cstring sub = null)
+    Substitute tokens (cstring content, cstring sub = null) return
     {
         return Substitute (sub, what, content, &forward);
     }
@@ -476,7 +476,7 @@ public struct SearchFruct
 
      ***********************************************************************/
 
-    Indices indices (cstring content)
+    Indices indices (cstring content) return
     {
         return Indices (content, &forward);
     }

--- a/src/ocean/util/container/ebtree/EBTree128.d
+++ b/src/ocean/util/container/ebtree/EBTree128.d
@@ -246,7 +246,7 @@ class EBTree128 ( bool signed = false ) : IEBTree
 
     ***************************************************************************/
 
-    public Node* update ( ref Node node, Key key )
+    public Node* update ( return ref Node node, Key key )
     out (node_out)
     {
         assert (node_out !is null);

--- a/src/ocean/util/container/ebtree/EBTree32.d
+++ b/src/ocean/util/container/ebtree/EBTree32.d
@@ -325,7 +325,7 @@ class EBTree32 ( bool signed = false ) : IEBTree
 
      ***************************************************************************/
 
-    public Node* update ( ref Node node, Key key )
+    public Node* update ( return ref Node node, Key key )
     out (node_out)
     {
         assert (node_out !is null);
@@ -349,7 +349,7 @@ class EBTree32 ( bool signed = false ) : IEBTree
 
     ***************************************************************************/
 
-    public Node* update ( ref Node node, Dual16Key key )
+    public Node* update ( return ref Node node, Dual16Key key )
     out (node_out)
     {
         assert (node_out !is null);

--- a/src/ocean/util/container/ebtree/EBTree64.d
+++ b/src/ocean/util/container/ebtree/EBTree64.d
@@ -303,7 +303,7 @@ class EBTree64 ( bool signed = false ) : IEBTree
 
      ***************************************************************************/
 
-    public Node* update ( ref Node node, Key key )
+    public Node* update ( return ref Node node, Key key )
     out (node_out)
     {
         assert (node_out !is null);
@@ -327,7 +327,7 @@ class EBTree64 ( bool signed = false ) : IEBTree
 
     ***************************************************************************/
 
-    public Node* update ( ref Node node, Dual32Key key )
+    public Node* update ( return ref Node node, Dual32Key key )
     out (node_out)
     {
         assert (node_out !is null);


### PR DESCRIPTION
From dmd2.092 onwards, when a function returns a ref parameter, the parameter
must be marked with 'return', so that memory corruption can be prevented.
Functions returning references to their data members must be similarly marked.
See DIP25.