### PR TITLE
Deprecate `ocean.core.Time`

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -43,6 +43,7 @@ $O/%unittests: override LDFLAGS += -lglib-2.0 -lpcre -lxml2 -lxslt -lebtree \
 
 # Remove deprecated modules from testing:
 TEST_FILTER_OUT += \
+	$C/src/ocean/core/Time.d \
 	$C/src/ocean/stdc/posix/arpa/inet.d \
 	$C/src/ocean/stdc/posix/net/if_.d \
 	$C/src/ocean/stdc/posix/netinet/in_.d \

--- a/dub.sdl
+++ b/dub.sdl
@@ -9,7 +9,7 @@ importPaths "src"
 targetType "sourceLibrary"
 
 // Deprecated files are excluded
-excludedSourceFiles "src/ocean/stdc/posix/arpa/inet.d" "src/ocean/stdc/posix/net/if_.d" "src/ocean/stdc/posix/netinet/in_.d" "src/ocean/stdc/posix/stdlib.d" \
+excludedSourceFiles "src/ocean/core/Time.d" "src/ocean/stdc/posix/arpa/inet.d" "src/ocean/stdc/posix/net/if_.d" "src/ocean/stdc/posix/netinet/in_.d" "src/ocean/stdc/posix/stdlib.d" \
                     "src/ocean/stdc/posix/sys/types.d" "src/ocean/util/log/model/ILogger.d"
 
 configuration "unittest" {

--- a/integrationtest/selectlistener/main.d
+++ b/integrationtest/selectlistener/main.d
@@ -25,7 +25,6 @@ import ocean.meta.types.Qualifiers;
 
 import ocean.core.Enforce: enforce;
 import Ocean = ocean.core.Test;
-import ocean.core.Time: seconds;
 import ocean.io.select.EpollSelectDispatcher;
 import ocean.stdc.posix.sys.wait: waitpid;
 import ocean.time.timeout.TimeoutManager;
@@ -37,6 +36,7 @@ import core.sys.posix.unistd: fork, unlink;
 import core.sys.posix.sys.socket;
 import core.sys.posix.sys.types : pid_t;
 import core.thread;
+import core.time;
 
 import integrationtest.selectlistener.UnixServer;
 

--- a/integrationtest/unixlistener/main.d
+++ b/integrationtest/unixlistener/main.d
@@ -28,7 +28,6 @@ import core.sys.posix.sys.wait;
 
 import ocean.core.Test;
 import ocean.core.Enforce;
-import ocean.core.Time;
 import ocean.io.select.EpollSelectDispatcher;
 import core.stdc.errno: ECONNREFUSED;
 import ocean.stdc.posix.sys.un;

--- a/integrationtest/unixsocket/main.d
+++ b/integrationtest/unixsocket/main.d
@@ -24,7 +24,6 @@ module integrationtest.unixsocket.main;
 
 import ocean.core.Enforce;
 import ocean.core.Test;
-import ocean.core.Time;
 import ocean.math.Math;
 import ocean.stdc.posix.sys.socket;
 import ocean.stdc.posix.sys.un;

--- a/relnotes/core-time.deprecation.md
+++ b/relnotes/core-time.deprecation.md
@@ -1,0 +1,8 @@
+### `ocean.core.Time` has been deprecated
+
+* `ocean.core.Time`
+
+This module has been completely deprecated and should be replaced by usages of `core.time`.
+The sole function in this module, `seconds`, was mostly used as argument to `Thread.sleep`.
+It can be replaced by `seconds` from `core.time` if the argument is an integer,
+or `msecs`, `usecs`, `hnsecs` or `nsecs` depending on the expected precision.

--- a/src/ocean/core/Time.d
+++ b/src/ocean/core/Time.d
@@ -15,6 +15,7 @@
  * Authors: Pavel Sountsov
  *
  */
+deprecated("Use `core.time` directly")
 module ocean.core.Time;
 
 static import core.time;
@@ -22,6 +23,7 @@ static import core.time;
 /**
  * Returns a Duration struct that represents secs seconds.
  */
+deprecated("Use `core.time : seconds` (or variants such as `msecs` if you need sub-second precision)")
 core.time.Duration seconds(double secs)
 {
         // TODO: check if this can be replaced with plain


### PR DESCRIPTION
Now that Ocean is D2 only, we can simply replace this with the druntime variant,
which was not possible before because Tango didn't have it.