### PR TITLE
Remove ++this from IEBTree, replace with increaseNodeCount

### DIFF
--- a/relnotes/ebtree-ops.migration.md
+++ b/relnotes/ebtree-ops.migration.md
@@ -1,0 +1,8 @@
+### Replacement of IEBtree protected operators
+
+* `ocean.util.container.ebtree.IEBTree`
+
+The `opAddAssign` and `opSubAssign` operators have been replaced with
+`increaseNodeCount` and `decreaseNodeCount`.
+These are protected member functions used only in the implementation of
+the EBTree classes, so no impact on user code is expected.

--- a/src/ocean/util/container/ebtree/EBTree128.d
+++ b/src/ocean/util/container/ebtree/EBTree128.d
@@ -228,7 +228,7 @@ class EBTree128 ( bool signed = false ) : IEBTree
     }
     body
     {
-        scope (success) ++this;
+        scope (success) this.increaseNodeCount(1);
 
         return this.add_(this.node_pool.get(), key);
     }

--- a/src/ocean/util/container/ebtree/EBTree32.d
+++ b/src/ocean/util/container/ebtree/EBTree32.d
@@ -284,7 +284,7 @@ class EBTree32 ( bool signed = false ) : IEBTree
     }
     body
     {
-        scope (success) ++this;
+        scope (success) this.increaseNodeCount(1);
 
         return this.add_(this.node_pool.get(), key);
     }

--- a/src/ocean/util/container/ebtree/EBTree64.d
+++ b/src/ocean/util/container/ebtree/EBTree64.d
@@ -262,7 +262,7 @@ class EBTree64 ( bool signed = false ) : IEBTree
     }
     body
     {
-        scope (success) ++this;
+        scope (success) this.increaseNodeCount(1);
 
         return this.add_(this.node_pool.get(), key);
     }

--- a/src/ocean/util/container/ebtree/model/IEBTree.d
+++ b/src/ocean/util/container/ebtree/model/IEBTree.d
@@ -80,7 +80,7 @@ abstract class IEBTree
 
     ***************************************************************************/
 
-    protected size_t opAddAssign ( size_t n )
+    protected size_t increaseNodeCount ( size_t n )
     {
         return this.count += n;
     }
@@ -100,7 +100,7 @@ abstract class IEBTree
 
     ***************************************************************************/
 
-    protected size_t opSubAssign ( size_t n )
+    protected size_t decreaseNodeCount ( size_t n )
     {
         verify (this.count >= n);
         return this.count -= n;

--- a/src/ocean/util/container/ebtree/model/KeylessMethods.d
+++ b/src/ocean/util/container/ebtree/model/KeylessMethods.d
@@ -46,7 +46,7 @@ template KeylessMethods ( Node, alias eb_first, alias eb_last )
     {
         this.node_pool.recycle(node.remove());
 
-        --this;
+        this.decreaseNodeCount(1);
     }
 
     /***************************************************************************


### PR DESCRIPTION
Using ++this, --this to maintain the counter was operator abuse and totally unnecessary, as these were `protected` implementation functions used only once per class.

The operators generate warnings in dmd2.090 onwards.

I have renamed them rather than added a new alias because `--this` doesn't deserve to live. In any case they are wrappers around C libraries so the three classes existing in ocean are the only ones that make sense.

It's weird that it supports increasing and decreasing by `n`, when it's only called with `n==1`. But the whole design is a bit broken, the modules are very tightly coupled.

After this change, ocean finally compiles cleanly with dmd 2.092 beta.

