### PR TITLE
More changes required by 2.092

### DIFF
--- a/src/ocean/core/SmartEnum.d
+++ b/src/ocean/core/SmartEnum.d
@@ -372,9 +372,9 @@ public template SmartEnumCore ( BaseType )
     static public int opApply ( scope int delegate ( ref BaseType code, ref istring desc ) dg )
     {
         int res;
-        foreach ( code, description; map )
+        foreach ( enum_code, enum_description; map )
         {
-            res = dg(code, description);
+            res = dg(enum_code, enum_description);
         }
         return res;
     }
@@ -390,9 +390,9 @@ public template SmartEnumCore ( BaseType )
     static public int opApply ( scope int delegate ( ref size_t index, ref BaseType code, ref istring desc ) dg )
     {
         int res;
-        foreach ( index, code, description; map )
+        foreach ( index, enum_code, enum_description; map )
         {
-            res = dg(index, code, description);
+            res = dg(index, enum_code, enum_description);
         }
         return res;
     }

--- a/src/ocean/core/SmartEnum.d
+++ b/src/ocean/core/SmartEnum.d
@@ -209,7 +209,7 @@ public template SmartEnumCore ( BaseType )
         return code in map;
     }
 
-    public alias description opIn_r;
+    public alias opBinaryRight ( istring op : "in" ) = description;
 
 
     /***************************************************************************
@@ -231,7 +231,8 @@ public template SmartEnumCore ( BaseType )
         return description in map;
     }
 
-    public alias code opIn_r;
+    public alias opBinaryRight ( istring op : "in" ) = code;
+
 
 
     /***************************************************************************

--- a/src/ocean/io/FilePath.d
+++ b/src/ocean/io/FilePath.d
@@ -62,7 +62,15 @@ class FilePath : PathView
     private PathParser      p;              // the parsed path
     private bool            dir_;           // this represents a dir?
 
-    public alias    append  opCatAssign;    // path ~= x;
+
+    /***********************************************************************
+
+        Support path ~= x; syntax
+
+    ***********************************************************************/
+
+    public alias opOpAssign ( istring op = "~" ) = append;
+
 
     /***********************************************************************
 

--- a/src/ocean/math/random/Random.d
+++ b/src/ocean/math/random/Random.d
@@ -1301,9 +1301,13 @@ version (unittest)
             if (cast(real)maxV<minmax) printM=true;
             if (expectedMean-maxOffset>meanV || meanV>expectedMean+maxOffset) printM=true;
             if (printM){
-                printf("WARNING ocean.math.Random statistic is strange: %.*s[%d] %Lg %Lg %Lg\n\0",cast(int)T.stringof.length,T.stringof.ptr,a.length,cast(real)minV,meanV,cast(real)maxV);
+                printf("WARNING ocean.math.Random statistic is strange: %.*s[%d] %Lg %Lg %Lg\n\0",
+                    cast(int)T.stringof.length, T.stringof.ptr, cast(int)a.length,
+                    cast(real)minV,meanV,cast(real)maxV);
             } else if (alwaysPrint) {
-                printf("ocean.math.Random statistic: %.*s[%d] %Lg %Lg %Lg\n\0",cast(int)T.stringof.length,T.stringof.ptr,a.length,cast(real)minV,meanV,cast(real)maxV);
+                printf("ocean.math.Random statistic: %.*s[%d] %Lg %Lg %Lg\n\0",
+                    cast(int)T.stringof.length, T.stringof.ptr, cast(int)a.length,
+                    cast(real)minV,meanV,cast(real)maxV);
             }
             return printM;
         }

--- a/src/ocean/util/container/btree/BTreeMap.d
+++ b/src/ocean/util/container/btree/BTreeMap.d
@@ -350,9 +350,9 @@ unittest
 
     // find the element by key
     bool found;
-    auto val = map.get(5, found);
+    auto valfive = map.get(5, found);
     test!("==")(found, true);
-    test!("==")(val.x, 10);
+    test!("==")(valfive.x, 10);
 
     // remove the element
     map.remove(10);


### PR DESCRIPTION
A couple more deprecation warnings which are generated when compiling ocean unit tests.

* Two cases of D1-style operator syntax, where it is just an alias rather than a virtual function;
* Some variable shadowing in foreach statements
* An inconsequential `printf` inside a unittest.