### PR TITLE
Deprecate `ocean.stdc.posix.netinet.tcp` & improve segmentation

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -47,6 +47,7 @@ TEST_FILTER_OUT += \
 	$C/src/ocean/stdc/posix/arpa/inet.d \
 	$C/src/ocean/stdc/posix/net/if_.d \
 	$C/src/ocean/stdc/posix/netinet/in_.d \
+	$C/src/ocean/stdc/posix/netinet/tcp.d \
 	$C/src/ocean/stdc/posix/stdlib.d \
 	$C/src/ocean/stdc/posix/sys/types.d   \
 	$C/src/ocean/util/log/model/ILogger.d

--- a/dub.sdl
+++ b/dub.sdl
@@ -9,8 +9,14 @@ importPaths "src"
 targetType "sourceLibrary"
 
 // Deprecated files are excluded
-excludedSourceFiles "src/ocean/core/Time.d" "src/ocean/stdc/posix/arpa/inet.d" "src/ocean/stdc/posix/net/if_.d" "src/ocean/stdc/posix/netinet/in_.d" "src/ocean/stdc/posix/stdlib.d" \
-                    "src/ocean/stdc/posix/sys/types.d" "src/ocean/util/log/model/ILogger.d"
+excludedSourceFiles \
+    "src/ocean/core/Time.d" \
+    "src/ocean/stdc/posix/arpa/inet.d" \
+    "src/ocean/stdc/posix/net/if_.d" \
+    "src/ocean/stdc/posix/netinet/in_.d" \
+    "src/ocean/stdc/posix/stdlib.d" \
+    "src/ocean/stdc/posix/sys/types.d" \
+    "src/ocean/util/log/model/ILogger.d"
 
 configuration "unittest" {
     excludedSourceFiles "src/ocean/core/UnitTestRunner.d"

--- a/dub.sdl
+++ b/dub.sdl
@@ -14,6 +14,7 @@ excludedSourceFiles \
     "src/ocean/stdc/posix/arpa/inet.d" \
     "src/ocean/stdc/posix/net/if_.d" \
     "src/ocean/stdc/posix/netinet/in_.d" \
+    "src/ocean/stdc/posix/netinet/tcp.d" \
     "src/ocean/stdc/posix/stdlib.d" \
     "src/ocean/stdc/posix/sys/types.d" \
     "src/ocean/util/log/model/ILogger.d"

--- a/relnotes/netinet-tcp.deprecation.md
+++ b/relnotes/netinet-tcp.deprecation.md
@@ -1,0 +1,6 @@
+### Module `ocean.stdc.posix.netinet.tcp` is deprecated
+
+`ocean.stdc.posix.netinet.tcp`
+
+This module was just a thin wrapper around `core.sys.posix.netinet.tcp`,
+which should now be imported directly.

--- a/src/ocean/stdc/gnu/string.d
+++ b/src/ocean/stdc/gnu/string.d
@@ -21,16 +21,25 @@ import core.stdc.stddef: wchar_t;
 
 extern (C):
 
-size_t   strnlen(in char* s, size_t maxlen);
 size_t   wcsnlen(in wchar_t* ws, size_t maxlen);
 void*    mempcpy(void* to, void *from, size_t size);
 wchar_t* wmempcpy(wchar_t* wto, wchar_t* wfrom, size_t size);
 wchar_t* wcsdup (in wchar_t* ws);
-char*    strndup(in char* s, size_t size);
 int      strverscmp(in char* s1, in char* s2);
 inout(void)* rawmemchr(inout(void)* block, int c);
 inout(void)* memrchr(inout(void)* block, int c, size_t size);
 inout(char)* strchrnul(inout(char)* str, int c);
 inout(wchar_t)* wcschrnul(inout(wchar_t)* wstr, wchar_t wc);
-inout(void)* memmem(inout(void)* haystack, size_t hlen,
-                    in void *needle, size_t nlen);
+
+static if (__VERSION__ < 2089)
+{
+    size_t   strnlen(in char* s, size_t maxlen);
+    char*    strndup(in char* s, size_t size);
+    inout(void)* memmem(inout(void)* haystack, size_t hlen,
+                        in void *needle, size_t nlen);
+}
+else
+{
+    public import core.sys.posix.string : strnlen, strndup;
+    public import core.sys.linux.string : memmem;
+}

--- a/src/ocean/stdc/posix/netinet/tcp.d
+++ b/src/ocean/stdc/posix/netinet/tcp.d
@@ -11,7 +11,7 @@
 
 *******************************************************************************/
 
-
+deprecated("Use `core.sys.posix.netinet.tcp` directly")
 module ocean.stdc.posix.netinet.tcp;
 
 public import core.sys.posix.netinet.tcp;

--- a/src/ocean/stdc/string.d
+++ b/src/ocean/stdc/string.d
@@ -21,6 +21,14 @@ public import ocean.stdc.gnu.string;
 
 extern (C):
 
-char *strsignal(int sig);
-int strcasecmp(in char *s1, in char *s2);
-int strncasecmp(in char *s1, in char *s2, size_t n);
+static if (__VERSION__ < 2089)
+{
+    char *strsignal(int sig);
+    int strcasecmp(in char *s1, in char *s2);
+    int strncasecmp(in char *s1, in char *s2, size_t n);
+}
+else
+{
+    public import core.sys.posix.string  : strsignal;
+    public import core.sys.posix.strings : strcasecmp, strncasecmp;
+}


### PR DESCRIPTION
As can be seen from the diff, this deprecate a module that was missed in a previous pass, and improve segmentation of C binding so that future contributors know when a specific binding can be dropped from Ocean.

See https://github.com/dlang/druntime/pull/2789