### PR TITLE
Deprecate most modules in ocean.time.chrono

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -49,5 +49,11 @@ TEST_FILTER_OUT += \
 	$C/src/ocean/stdc/posix/netinet/in_.d \
 	$C/src/ocean/stdc/posix/netinet/tcp.d \
 	$C/src/ocean/stdc/posix/stdlib.d \
-	$C/src/ocean/stdc/posix/sys/types.d   \
+	$C/src/ocean/stdc/posix/sys/types.d \
+	$C/src/ocean/time/chrono/Hebrew.d \
+	$C/src/ocean/time/chrono/Hijri.d \
+	$C/src/ocean/time/chrono/Japanese.d \
+	$C/src/ocean/time/chrono/Korean.d \
+	$C/src/ocean/time/chrono/Taiwan.d \
+	$C/src/ocean/time/chrono/ThaiBuddhist.d \
 	$C/src/ocean/util/log/model/ILogger.d

--- a/dub.sdl
+++ b/dub.sdl
@@ -17,6 +17,12 @@ excludedSourceFiles \
     "src/ocean/stdc/posix/netinet/tcp.d" \
     "src/ocean/stdc/posix/stdlib.d" \
     "src/ocean/stdc/posix/sys/types.d" \
+    "src/ocean/time/chrono/Hebrew.d" \
+    "src/ocean/time/chrono/Hijri.d" \
+    "src/ocean/time/chrono/Japanese.d" \
+    "src/ocean/time/chrono/Korean.d" \
+    "src/ocean/time/chrono/Taiwan.d" \
+    "src/ocean/time/chrono/ThaiBuddhist.d" \
     "src/ocean/util/log/model/ILogger.d"
 
 configuration "unittest" {

--- a/relnotes/calendar.deprecated.md
+++ b/relnotes/calendar.deprecated.md
@@ -1,0 +1,8 @@
+### Most calendar types have been deprecated
+
+* `ocean.time.chrono.Hebrew`, `ocean.time.chrono.Hijri`,
+  `ocean.time.chrono.Japanese`, `ocean.time.chrono.Korean`,
+  `ocean.time.chrono.Taiwan`, `ocean.time.chrono.ThaiBuddhist`
+
+Those modules were not used, badly supported, and not up to
+any coding convention.

--- a/src/ocean/time/chrono/Hebrew.d
+++ b/src/ocean/time/chrono/Hebrew.d
@@ -17,6 +17,7 @@
 
 ******************************************************************************/
 
+deprecated("This module is deprecated without replacement")
 module ocean.time.chrono.Hebrew;
 
 import ocean.core.ExceptionDefinitions;
@@ -29,6 +30,7 @@ import ocean.time.chrono.Calendar;
  * $(ANCHOR _Hebrew)
  * Represents the Hebrew calendar.
  */
+deprecated("This class is deprecated without replacement")
 public class Hebrew : Calendar {
 
   private static immutable uint[14][7] MonthDays = [
@@ -291,4 +293,3 @@ public class Hebrew : Calendar {
   }
 
 }
-

--- a/src/ocean/time/chrono/Hijri.d
+++ b/src/ocean/time/chrono/Hijri.d
@@ -17,6 +17,7 @@
 
 ******************************************************************************/
 
+deprecated("This module is deprecated without replacement")
 module ocean.time.chrono.Hijri;
 
 import ocean.time.chrono.Calendar;
@@ -28,6 +29,7 @@ import ocean.meta.types.Qualifiers;
  * $(ANCHOR _Hijri)
  * Represents the Hijri calendar.
  */
+deprecated("This class is deprecated without replacement")
 public class Hijri : Calendar {
 
   private static const(uint[]) DAYS_TO_MONTH = [ 0, 30, 59, 89, 118, 148, 177, 207, 236, 266, 295, 325, 355 ];

--- a/src/ocean/time/chrono/Japanese.d
+++ b/src/ocean/time/chrono/Japanese.d
@@ -17,6 +17,7 @@
 
 ******************************************************************************/
 
+deprecated("This module is deprecated without replacement")
 module ocean.time.chrono.Japanese;
 
 import ocean.time.chrono.GregorianBased;
@@ -26,6 +27,7 @@ import ocean.time.chrono.GregorianBased;
  * $(ANCHOR _Japanese)
  * Represents the Japanese calendar.
  */
+deprecated("This class is deprecated without replacement")
 public class Japanese : GregorianBased
 {
   /**

--- a/src/ocean/time/chrono/Korean.d
+++ b/src/ocean/time/chrono/Korean.d
@@ -17,6 +17,7 @@
 
 ******************************************************************************/
 
+deprecated("This module is deprecated without replacement")
 module ocean.time.chrono.Korean;
 
 import ocean.time.chrono.GregorianBased;
@@ -26,6 +27,7 @@ import ocean.time.chrono.GregorianBased;
  * $(ANCHOR _Korean)
  * Represents the Korean calendar.
  */
+deprecated("This class is deprecated without replacement")
 public class Korean : GregorianBased {
   /**
    * $(I Property.) Overridden. Retrieves the identifier associated with the current calendar.
@@ -36,5 +38,3 @@ public class Korean : GregorianBased {
   }
 
 }
-
-

--- a/src/ocean/time/chrono/Taiwan.d
+++ b/src/ocean/time/chrono/Taiwan.d
@@ -17,6 +17,7 @@
 
 ******************************************************************************/
 
+deprecated("This module is deprecated without replacement")
 module ocean.time.chrono.Taiwan;
 
 import ocean.time.chrono.GregorianBased;
@@ -25,6 +26,7 @@ import ocean.time.chrono.GregorianBased;
  * $(ANCHOR _Taiwan)
  * Represents the Taiwan calendar.
  */
+deprecated("This class is deprecated without replacement")
 public class Taiwan : GregorianBased
 {
   /**
@@ -36,4 +38,3 @@ public class Taiwan : GregorianBased
   }
 
 }
-

--- a/src/ocean/time/chrono/ThaiBuddhist.d
+++ b/src/ocean/time/chrono/ThaiBuddhist.d
@@ -17,6 +17,7 @@
 
 ******************************************************************************/
 
+deprecated("This module is deprecated without replacement")
 module ocean.time.chrono.ThaiBuddhist;
 
 import ocean.time.chrono.GregorianBased;
@@ -26,6 +27,7 @@ import ocean.time.chrono.GregorianBased;
  * $(ANCHOR _ThaiBuddhist)
  * Represents the Thai Buddhist calendar.
  */
+deprecated("This class is deprecated without replacement")
 public class ThaiBuddhist : GregorianBased {
   /**
    * $(I Property.) Overridden. Retrieves the identifier associated with the current calendar.


### PR DESCRIPTION
```
The Calendar, Gregorian, and GregorianBased types are actually widely used,
but those 6 calendars are not, so they are an easy target for deprecation.
```

~Blocked by https://github.com/sociomantic-tsunami/ocean/pull/817 as I need to add it to the list of deprecated modules in the makefile and `dub.sdl`, but this other PR will conflict.~