### PR TITLE
Deprecate most of ocean.stdc.posix.sys

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -49,7 +49,16 @@ TEST_FILTER_OUT += \
 	$C/src/ocean/stdc/posix/netinet/in_.d \
 	$C/src/ocean/stdc/posix/netinet/tcp.d \
 	$C/src/ocean/stdc/posix/stdlib.d \
+	$C/src/ocean/stdc/posix/sys/ipc.d \
+	$C/src/ocean/stdc/posix/sys/mman.d \
+	$C/src/ocean/stdc/posix/sys/select.d \
+	$C/src/ocean/stdc/posix/sys/shm.d \
+	$C/src/ocean/stdc/posix/sys/stat.d \
+	$C/src/ocean/stdc/posix/sys/statvfs.d \
 	$C/src/ocean/stdc/posix/sys/types.d \
+	$C/src/ocean/stdc/posix/sys/uio.d \
+	$C/src/ocean/stdc/posix/sys/utsname.d \
+	$C/src/ocean/stdc/posix/sys/wait.d \
 	$C/src/ocean/time/chrono/Hebrew.d \
 	$C/src/ocean/time/chrono/Hijri.d \
 	$C/src/ocean/time/chrono/Japanese.d \

--- a/dub.sdl
+++ b/dub.sdl
@@ -16,7 +16,16 @@ excludedSourceFiles \
     "src/ocean/stdc/posix/netinet/in_.d" \
     "src/ocean/stdc/posix/netinet/tcp.d" \
     "src/ocean/stdc/posix/stdlib.d" \
+    "src/ocean/stdc/posix/sys/ipc.d" \
+    "src/ocean/stdc/posix/sys/mman.d" \
+    "src/ocean/stdc/posix/sys/select.d" \
+    "src/ocean/stdc/posix/sys/shm.d" \
+    "src/ocean/stdc/posix/sys/stat.d" \
+    "src/ocean/stdc/posix/sys/statvfs.d" \
     "src/ocean/stdc/posix/sys/types.d" \
+    "src/ocean/stdc/posix/sys/uio.d" \
+    "src/ocean/stdc/posix/sys/utsname.d" \
+    "src/ocean/stdc/posix/sys/wait.d" \
     "src/ocean/time/chrono/Hebrew.d" \
     "src/ocean/time/chrono/Hijri.d" \
     "src/ocean/time/chrono/Japanese.d" \

--- a/relnotes/ocean-stdc-posix.deprecation.md
+++ b/relnotes/ocean-stdc-posix.deprecation.md
@@ -1,0 +1,14 @@
+### Most modules in `ocean.stdc.posix.sys` are deprecated
+
+* `ocean.stdc.posix.sys.ipc`, `ocean.stdc.posix.sys.mman`,
+  `ocean.stdc.posix.sys.select`, `ocean.stdc.posix.sys.shm`,
+  `ocean.stdc.posix.sys.stat`, `ocean.stdc.posix.sys.statvfs`,
+  `ocean.stdc.posix.sys.uio`,
+  `ocean.stdc.posix.sys.utsname`, `ocean.stdc.posix.sys.wait`
+
+Those modules where just thin wrapper, publicly importing their
+`core.sys.posix.sys` counterpart and can be trivially replaced.
+The only two remaining modules are `ocean.stdc.posix.sys.un`,
+which a `create` method and a different definition (but binary compatible)
+for the `sockaddr_un` struct, and `ocean.stdc.posix.sys.socket`,
+as it contains definitions not available as of DMD 2.091.0.

--- a/src/ocean/stdc/posix/sys/ipc.d
+++ b/src/ocean/stdc/posix/sys/ipc.d
@@ -11,7 +11,7 @@
 
 *******************************************************************************/
 
-
+deprecated("Use `core.sys.posix.sys.ipc` directly")
 module ocean.stdc.posix.sys.ipc;
 
 public import core.sys.posix.sys.ipc;

--- a/src/ocean/stdc/posix/sys/mman.d
+++ b/src/ocean/stdc/posix/sys/mman.d
@@ -11,7 +11,7 @@
 
 *******************************************************************************/
 
-
+deprecated("Use `core.sys.posix.sys.mman` directly")
 module ocean.stdc.posix.sys.mman;
 
 public import core.sys.posix.sys.mman;

--- a/src/ocean/stdc/posix/sys/select.d
+++ b/src/ocean/stdc/posix/sys/select.d
@@ -11,7 +11,7 @@
 
 *******************************************************************************/
 
-
+deprecated("Use `core.sys.posix.sys.select` directly")
 module ocean.stdc.posix.sys.select;
 
 public import core.sys.posix.sys.select;

--- a/src/ocean/stdc/posix/sys/shm.d
+++ b/src/ocean/stdc/posix/sys/shm.d
@@ -11,7 +11,7 @@
 
 *******************************************************************************/
 
-
+deprecated("Use `core.sys.posix.sys.shm` directly")
 module ocean.stdc.posix.sys.shm;
 
 public import core.sys.posix.sys.shm;

--- a/src/ocean/stdc/posix/sys/stat.d
+++ b/src/ocean/stdc/posix/sys/stat.d
@@ -11,7 +11,7 @@
 
 *******************************************************************************/
 
-
+deprecated("Use `core.sys.posix.sys.stat` directly")
 module ocean.stdc.posix.sys.stat;
 
 public import core.sys.posix.sys.stat;

--- a/src/ocean/stdc/posix/sys/statvfs.d
+++ b/src/ocean/stdc/posix/sys/statvfs.d
@@ -11,7 +11,7 @@
 
 *******************************************************************************/
 
-
+deprecated("Use `core.sys.posix.sys.statvfs` directly")
 module ocean.stdc.posix.sys.statvfs;
 
 public import core.sys.posix.sys.statvfs;

--- a/src/ocean/stdc/posix/sys/uio.d
+++ b/src/ocean/stdc/posix/sys/uio.d
@@ -11,7 +11,7 @@
 
 *******************************************************************************/
 
-
+deprecated("Use `core.sys.posix.sys.uio` directly")
 module ocean.stdc.posix.sys.uio;
 
 public import core.sys.posix.sys.uio;

--- a/src/ocean/stdc/posix/sys/utsname.d
+++ b/src/ocean/stdc/posix/sys/utsname.d
@@ -11,7 +11,7 @@
 
 *******************************************************************************/
 
-
+deprecated("Use `core.sys.posix.sys.utsname` directly")
 module ocean.stdc.posix.sys.utsname;
 
 public import core.sys.posix.sys.utsname;

--- a/src/ocean/stdc/posix/sys/wait.d
+++ b/src/ocean/stdc/posix/sys/wait.d
@@ -11,7 +11,7 @@
 
 *******************************************************************************/
 
-
+deprecated("Use `core.sys.posix.sys.wait` directly")
 module ocean.stdc.posix.sys.wait;
 
 public import core.sys.posix.sys.wait;


### PR DESCRIPTION
Pretty self-explanatory. Those are not used by any `*proto, turtle, or swarm.