### PR TITLE
Implement `enum` formatting in `ocean.text.convert.Formatter`

### DIFF
--- a/relnotes/enum-pretty-print.feature.md
+++ b/relnotes/enum-pretty-print.feature.md
@@ -1,0 +1,9 @@
+### The Formatter now pretty-print enums
+
+`enum` members are now correctly printed by the Formatter.
+For example `enum Foo { A, B}` will print either `Foo.A` or `Foo.B`
+instead of `0` and `1`, previously.
+If a value that is not a member of an `enum` is casted to it,
+such as `cast(Foo) 42`, the Formatter will print `cast(Foo) 42`.
+Note that the type will be printed qualified, e.g. passing a `const`
+value will print `const(Foo).A`, for example.

--- a/src/ocean/text/convert/Formatter.d
+++ b/src/ocean/text/convert/Formatter.d
@@ -379,9 +379,51 @@ private void handle (T) (T v, FormatInfo f, scope FormatterSink sf, scope ElemSi
     static if (is(T == typeof(null)))
         se("null", f);
 
-    // Cannot print enum member name in D1, so just print the value
-    else static if (is (T V == enum))
-        handle!(V)(v, f, sf, se);
+
+    // Pretty print enum
+    // Note that switch is only available for string and integer based enums.
+    // However, since it expands to a jump table for integers and a binary
+    // search for strings, we still want to special case it.
+    else static if (is(T V == enum) && canSwitchOn!(T))
+    {
+        sw: switch (v)
+        {
+            foreach (member; __traits(allMembers, T))
+            {
+            case mixin("T." ~ member):
+                sf(T.stringof);
+                sf(".");
+                sf(member);
+                break sw;
+            }
+            default :
+                sf("cast(");
+                sf(T.stringof);
+                sf(") ");
+                handle!(V)(v, f, sf, se);
+        }
+    }
+
+    // Pretty print enum for non-integer, non-string base types
+    // This branch should be rarely, if ever, used.
+    else static if (is(T E == enum))
+    {
+        foreach (member; __traits(allMembers, T))
+        {
+            if (v == mixin("T." ~ member))
+            {
+                sf(T.stringof);
+                sf(".");
+                sf(member);
+                return;
+            }
+        }
+
+        sf("cast(");
+        sf(T.stringof);
+        sf(") ");
+        handle!(E)(v, f, sf, se);
+    }
 
     // Delegate / Function pointers
     else static if (is(T == delegate))
@@ -908,4 +950,17 @@ private struct FormatInfo
     ***************************************************************************/
 
     public Flags flags;
+}
+
+/// Returns: Whether or not `T` can be `switch`ed on
+private template canSwitchOn (T)
+{
+    enum canSwitchOn = is(typeof(() { switch (T.init) { default: break; }}));
+}
+
+unittest
+{
+    static assert(canSwitchOn!string);
+    static assert(canSwitchOn!(immutable int));
+    static assert(!canSwitchOn!(real));
 }


### PR DESCRIPTION
`ocean.text.convert.Formatter` now pretty-print `enum`s.
This was not possible as long as Ocean supported D1,
since D1 did not offer the reflection tools necessary for this.