### PR TITLE
Add missing versions in LibFeatures

### DIFF
--- a/relnotes/libfeatures.bug.md
+++ b/relnotes/libfeatures.bug.md
@@ -1,0 +1,9 @@
+### Missing versions added to `ocean.LibFeatures`
+
+* `ocean.LibFeatures`
+
+This module was supposed to provide means for library writers depending
+on Ocean to conditionally support a feature. However the module hasn't been
+updated for a long time, and versions `4.2` to `4.8` were missing in the `v4`
+suite, while no `v5` version (so `5.0` - `5.3`) were present.
+This release adds all the missing features as well as the current (`5.4`).

--- a/src/ocean/LibFeatures.d
+++ b/src/ocean/LibFeatures.d
@@ -17,6 +17,17 @@
 
 module ocean.LibFeatures;
 
+static immutable has_features_5_4  = true;
+static immutable has_features_5_3  = true;
+static immutable has_features_5_2  = true;
+static immutable has_features_5_1  = true;
+static immutable has_features_5_0  = true;
+static immutable has_features_4_8  = true;
+static immutable has_features_4_7  = true;
+static immutable has_features_4_6  = true;
+static immutable has_features_4_5  = true;
+static immutable has_features_4_4  = true;
+static immutable has_features_4_3  = true;
 static immutable has_features_4_2  = true;
 static immutable has_features_4_1  = true;
 static immutable has_features_4_0  = true;


### PR DESCRIPTION
LibFeatures hadn't been updated since version v4.2.0, which shows how used it is.
This adds all the previously-missed version as well as the upcoming v5.4.0.