### PR TITLE
Remove v2.071.2.s* from the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,6 @@ jobs:
     include:
         # Test matrix
         - <<: *test-matrix-d2
-          env: DIST=xenial DMD=2.071.2.s* F=production
-        - <<: *test-matrix-d2
-          env: DIST=xenial DMD=2.071.2.s* F=devel
-        - <<: *test-matrix-d2
           env: DIST=xenial DMD=2.078.3.s* F=production
         - <<: *test-matrix-d2
           env: DIST=xenial DMD=2.078.3.s* F=devel


### PR DESCRIPTION
```
This compiler is long gone and there is no interest in supporting it in the future.
This is the lowest hanging fruit in the matrix and will allow upstream to move
forward immediately.
```

CC @joseph-wakeling-frequenz 