### PR TITLE
Fix 827 - SmartUnion generates conflicting opCalls

### DIFF
--- a/relnotes/smartunion.bug.md
+++ b/relnotes/smartunion.bug.md
@@ -1,0 +1,10 @@
+### `SmartUnion` will no longer produce conflicting `opCall`
+
+* `ocean.core.SmartUnion`
+
+Before this change, `SmartUnion` would generate duplicated `static opCall`
+for initialization. However those `opCall` were not callable,
+as the call would be ambiguous.
+After this change, those `opCall` won't be generated anymore,
+and only the `set` and `get` methods will be available on fields
+which don't have a unique type in the `union`.

--- a/src/ocean/core/SmartUnion.d
+++ b/src/ocean/core/SmartUnion.d
@@ -484,8 +484,19 @@ private template Methods ( U, uint i )
         ~ "{ _.active = _.active." ~ member ~ ";"
         ~ "return " ~ member_access ~ '=' ~ member ~ "; }";
 
-    static immutable ini = "static Type opCall(" ~ type ~ ' ' ~ member ~ ")"
-        ~ "{ Type su; su." ~ member ~ '=' ~ member ~ "; return su; }";
+    import ocean.core.Tuple : IndexOf;
+    alias Ts = typeof(U.tupleof);
+
+    // Create an `opCall` only for unique types
+    static if (IndexOf!(Ts[i], Ts[0 .. i], Ts[i + 1 .. $]) == Ts.length - 1)
+    {
+        static immutable ini = "static Type opCall(" ~ type ~ ' ' ~ member ~ ")"
+            ~ "{ Type su; su." ~ member ~ '=' ~ member ~ "; return su; }";
+    }
+    else
+    {
+        static immutable ini = "";
+    }
 
     static immutable local_import = "import ocean.core.Enforce;\n";
 
@@ -517,4 +528,27 @@ private template AllMethods ( U, istring pre, uint i)
     {
         static immutable AllMethods = pre;
     }
+}
+
+// https://github.com/sociomantic-tsunami/ocean/issues/827
+unittest
+{
+    static union HasDuplicates
+    {
+        Object a;
+        int b;
+        string c;
+        int d;
+        bool[] e;
+    }
+
+    alias U = SmartUnion!HasDuplicates;
+
+    // These calls are unambiguous.
+    U(Object.init);
+    U("c");
+    U([true]);
+
+    // Dont allow ambiguous opCalls
+    static assert(!__traits(compiles, U(1)));
 }


### PR DESCRIPTION
Only generate `opCall` for members with unique types. This bug wasn't
reported due to [1] but the generated `opCall`s were unusable
anyway (calling them caused an ambiguity error).

[1] https://issues.dlang.org/show_bug.cgi?id=2789

Note: I hope this is the correct target branch(?)