### PR TITLE
[v6.0.0] Drop compatibility for anything less than v2.092

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ env:
     global:
         # Make sure beaver is in the PATH
         - PATH="$(git config -f .gitmodules submodule.beaver.path)/bin:$PATH"
-        - DIST=xenial
-        - COV=1
+        - DIST=bionic
+        - COV=0
 
 # Basic config is inherited from the global scope
 jobs:
@@ -33,31 +33,21 @@ jobs:
     include:
         # Test matrix
         - <<: *test-matrix-d2
-          env: DIST=xenial DMD=2.078.3.s* F=production
+          env: DMD=2.092.* F=production
         - <<: *test-matrix-d2
-          env: DIST=xenial DMD=2.078.3.s* F=devel
+          env: DMD=2.092.* F=devel
         - <<: *test-matrix-d2
-          env: DIST=xenial DMD=2.078.3.s* F=devel DFLAGS=-debug=ISelectClient
+          env: DMD=2.093.* F=production COV=1
+        - <<: *test-matrix-d2
+          env: DMD=2.093.* F=devel COV=1
+
+        # Special row(s), try to always use the latest compiler
+        - <<: *test-matrix-d2
+          env: DMD=2.093.* F=devel DFLAGS=-debug=ISelectClient
           script: 2>/dev/null beaver dlang make
-        - <<: *test-matrix-d2
-          env: DIST=xenial DMD=2.085.* F=production
-        - <<: *test-matrix-d2
-          env: DIST=xenial DMD=2.085.* F=devel
-        - <<: *test-matrix-d2
-          env: DIST=bionic DMD=2.078.3.s* F=production
-        - <<: *test-matrix-d2
-          env: DIST=bionic DMD=2.078.3.s* F=devel
-        - <<: *test-matrix-d2
-          env: DIST=bionic DMD=2.078.3.s* F=devel DFLAGS=-debug=ISelectClient
-          script: 2>/dev/null beaver dlang make
-        - <<: *test-matrix-d2
-          env: DIST=bionic DMD=2.091.* F=production
-        - <<: *test-matrix-d2
-          env: DIST=bionic DMD=2.091.* F=devel
 
         # Additional stages
-
         - stage: Closure allocation check
-          env: DMD=2.078.3.s* F=devel
+          env: DMD=2.093.* F=devel
           install: beaver dlang install
           script: ci/closures.sh

--- a/Build.mak
+++ b/Build.mak
@@ -33,9 +33,8 @@ $O/test-taskext_daemon: override LDFLAGS += -lglib-2.0
 $O/test-unixsockext: override LDFLAGS += -lglib-2.0
 
 # Link unittests to all used libraries
-# TODO: Remove the specific version of libssl and libcrypto once the support
-# for Ubuntu xenial is dropped and the bindings for libssl have been updated
-# to v1.1.x
+# TODO: Remove the specific version of libssl and libcrypto once the bindings
+# for libssl have been updated to v1.1.x
 $O/%unittests: override LDFLAGS += -lglib-2.0 -lpcre -lxml2 -lxslt -lebtree \
 		-lreadline -lhistory -llzo2 -lbz2 -lz -ldl -lgcrypt -lgpg-error -lrt \
 		-l:libssl.so.1.0.0 -l:libcrypto.so.1.0.0


### PR DESCRIPTION
```
Since we want to drop support for dmd-transitional,
we need to settle on the minimum supported version of DMD.
Due to the various deprecations and some codeggen bugs in -O -inline,
only v2.092.0 and higher is able to compile our code correctly.

Additionally we now only test on bionic instead of xenial,
and reduced coverage to only the latest version of the compiler.
```

As was already done in the nodes, and will be done in the protos / swarm once the deprecation is fixed.