### PR TITLE
HttpStack: Use assert(0) instead of abort()

### DIFF
--- a/src/ocean/net/http/HttpStack.d
+++ b/src/ocean/net/http/HttpStack.d
@@ -32,7 +32,6 @@ import ocean.stdc.string: strncasecmp;
 
 import ocean.stdc.string: memmove;
 import core.stdc.stdio;
-import core.stdc.stdlib;
 
 /******************************************************************************
 
@@ -61,9 +60,7 @@ class Token
     {
         printf(("Use Token.get instead of Token.toString :" ~
                 " latter allocates each time. Aborting\n").ptr);
-        abort();
-
-        return idup(value);
+        assert(0);
     }
 }
 


### PR DESCRIPTION
assert(0) will be lowered to an HLT in release mode.
This blocks upstream DMD, as DIP1034 will introduce `noreturn`,
which correctly detects that `abort` does not return,
and subsequently triggers a "Statement is not reachable" on the `return`.