### PR TITLE
Github CI: Correct the closure check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Test closures
       if: ${{ matrix.closure_check }}
       run: |
-        2>/dev/null beaver dlang make
+        ./ci/closures.sh
 
     - name: 'Upload coverage'
       if: ${{ matrix.coverage == 1 }}


### PR DESCRIPTION
Somehow in the transition from Travis to Github, the closure check wasn't properly ported.