### PR TITLE
Replace 'body' with 'do'

### DIFF
--- a/integrationtest/signalfd/main.d
+++ b/integrationtest/signalfd/main.d
@@ -257,7 +257,7 @@ private class SignalFDTest
         {
             assert(signal < max_signal);
         }
-        body
+        do
         {
             return typeof(this).fired_signals[signal];
         }

--- a/src/ocean/core/BitArray.d
+++ b/src/ocean/core/BitArray.d
@@ -251,7 +251,7 @@ struct BitArray
     {
         assert(compare(result, this));
     }
-    body
+    do
     {
         if( len >= 2 )
         {
@@ -295,7 +295,7 @@ struct BitArray
     {
         assert(compare(result, this));
     }
-    body
+    do
     {
         if( len >= 2 )
         {

--- a/src/ocean/core/MessageFiber.d
+++ b/src/ocean/core/MessageFiber.d
@@ -468,7 +468,7 @@ class MessageFiber
         assert (a);
         assert (a != a.exc);
     }
-    body
+    do
     {
         verify(
             this.fiber.state != this.fiber.State.EXEC,
@@ -528,7 +528,7 @@ class MessageFiber
         auto msg_out = cast(Unqual!(typeof(_msg_out))) _msg_out;
         assert(msg_out.active);
     }
-    body
+    do
     {
         verify (
             this.fiber.state == this.fiber.State.EXEC,
@@ -638,7 +638,7 @@ class MessageFiber
         assert (a);
         assert (a != a.exc);
     }
-    body
+    do
     {
         verify(
             this.fiber.state == this.fiber.State.HOLD,

--- a/src/ocean/core/SmartEnum.d
+++ b/src/ocean/core/SmartEnum.d
@@ -1008,7 +1008,7 @@ public struct TwoWayMap ( A )
         assert(this.a_to_index[a] < this.keys_list.length);
         assert(this.b_to_index[b] < this.values_list.length);
     }
-    body
+    do
     {
         auto already_exists = !!(a in this.a_to_b);
 
@@ -1030,7 +1030,7 @@ public struct TwoWayMap ( A )
         assert(this.a_to_index[a] < this.keys_list.length);
         assert(this.b_to_index[b] < this.values_list.length);
     }
-    body
+    do
     {
         auto already_exists = !!(a in this.a_to_b);
 

--- a/src/ocean/core/array/Mutation.d
+++ b/src/ocean/core/array/Mutation.d
@@ -1419,7 +1419,7 @@ unittest
     {
         test(n_iterations);
     }
-    body
+    do
     {
         test(index);
         test(index < array.length);
@@ -1517,7 +1517,7 @@ out (end)
 {
     assert(end <= array.length, "result index out of bounds");
 }
-body
+do
 {
     static assert (
         isCallableType!(Exclude),
@@ -1589,7 +1589,7 @@ out (end)
 {
     assert(end <= length, "result length out of bounds");
 }
-body
+do
 {
     for (size_t i = 0; i < length; i++)
     {

--- a/src/ocean/core/array/Search.d
+++ b/src/ocean/core/array/Search.d
@@ -1172,7 +1172,7 @@ out (found)
         assert (position <= array.length);
     }
 }
-body
+do
 {
     return bsearchCustom(
         array.length,
@@ -1266,7 +1266,7 @@ out (found)
         assert (position <= array_length);
     }
 }
-body
+do
 {
     verify(cast (ssize_t) array_length >= 0,
         "bsearchCustom: array_length integer overflow (maximum is " ~

--- a/src/ocean/io/device/DirectIO.d
+++ b/src/ocean/io/device/DirectIO.d
@@ -189,7 +189,7 @@ private template AlignedBufferedStream ( )
         assert(isAligned(buffer.ptr));
         assert((buffer.length % BLOCK_SIZE) == 0);
     }
-    body
+    do
     {
         auto bytes = buffer_blocks * BLOCK_SIZE;
         auto buffer = cast(ubyte[]) GC.malloc(bytes)[0 .. bytes];
@@ -832,4 +832,3 @@ public class BufferedDirectReadFile: InputStream
     }
 
 }
-

--- a/src/ocean/io/select/client/TimerSet.d
+++ b/src/ocean/io/select/client/TimerSet.d
@@ -314,7 +314,7 @@ public class TimerSet ( EventData ) : TimerEventTimeoutManager
     {
         assert(event !is null);
     }
-    body
+    do
     {
         verify(setup_dg !is null, typeof(this).stringof ~ ".schedule: event setup delegate is null");
         verify(fired_dg !is null, typeof(this).stringof ~ ".schedule: event fired delegate is null");

--- a/src/ocean/io/select/protocol/fiber/BufferedFiberSelectWriter.d
+++ b/src/ocean/io/select/protocol/fiber/BufferedFiberSelectWriter.d
@@ -168,7 +168,7 @@ class BufferedFiberSelectWriter : FiberSelectWriter
     {
         assert (n == s);
     }
-    body
+    do
     {
         verify(s != 0, typeof (this).stringof ~ ".buffer_size: 0 specified");
 

--- a/src/ocean/io/select/protocol/fiber/FiberSelectReader.d
+++ b/src/ocean/io/select/protocol/fiber/FiberSelectReader.d
@@ -474,7 +474,7 @@ class FiberSelectReader : IFiberSelectProtocol
     {
         assert (received <= data.length, "received length too high");
     }
-    body
+    do
     {
         verify(this.available < this.data.length, "requested to receive nothing");
 

--- a/src/ocean/io/select/protocol/fiber/FiberSelectWriter.d
+++ b/src/ocean/io/select/protocol/fiber/FiberSelectWriter.d
@@ -172,7 +172,7 @@ class FiberSelectWriter : IFiberSelectProtocol
     {
         assert (!this.data);
     }*/
-    body
+    do
     {
         if (data.length)
         {
@@ -328,7 +328,7 @@ class FiberSelectWriter : IFiberSelectProtocol
     {
         assert (this);
     }
-    body
+    do
     {
         debug (Raw) Stderr.formatln("[{}] Write {:X2} ({} bytes)",
             super.conduit.fileHandle, this.data_slice, this.data_slice.length);

--- a/src/ocean/io/select/protocol/fiber/FiberSocketConnection.d
+++ b/src/ocean/io/select/protocol/fiber/FiberSocketConnection.d
@@ -474,7 +474,7 @@ public class IFiberSocketConnection : IFiberSelectProtocol
     {
         assert (!this.connected_);
     }
-    body
+    do
     {
         if (this.connected_ || force)
         {
@@ -556,7 +556,7 @@ public class IFiberSocketConnection : IFiberSelectProtocol
         assert (this.connected_);
         assert (status);
     }
-    body
+    do
     {
         // Create a socket if it is currently closed.
         if (this.socket.fileHandle < 0)

--- a/src/ocean/io/select/protocol/task/TaskSelectClient.d
+++ b/src/ocean/io/select/protocol/task/TaskSelectClient.d
@@ -131,7 +131,7 @@ class TaskSelectClient: ISelectClient
     {
         assert(!this.task);
     }
-    body
+    do
     {
         verify(events_expected != Event.init);
         verify(this.task is null);

--- a/src/ocean/io/select/protocol/task/TaskSelectTransceiver.d
+++ b/src/ocean/io/select/protocol/task/TaskSelectTransceiver.d
@@ -352,7 +352,7 @@ class TaskSelectTransceiver
     {
         assert(n > 0);
     }
-    body
+    do
     {
         // Prevent misinformation if an error happens that is not detected by
         // io_op, such as a socket error reported by getsockopt(SO_ERROR) or an
@@ -459,7 +459,7 @@ class TaskSelectTransceiver
             "[{}] Read  {:X2} ({} bytes)", this.iodev.fileHandle, dst[0 .. n], n
         );
     }
-    body
+    do
     {
         return this.transfer(this.iodev.read(dst), Event.EPOLLIN, "read");
     }
@@ -502,7 +502,7 @@ class TaskSelectTransceiver
                     this.iodev.fileHandle, dst_a[0 .. n], n);
         }
     }
-    body
+    do
     {
         // Work around a linker error caused by a druntime packagin bug: The
         // druntime is by mistake currently not linked with the

--- a/src/ocean/math/Distribution.d
+++ b/src/ocean/math/Distribution.d
@@ -278,7 +278,7 @@ public class Distribution ( T )
             assert(result == 0, "percentValue should be 0 for empty distributions");
         }
     }
-    body
+    do
     {
         enforce(fraction >= 0.0 && fraction <= 1.0,
             "fraction must be within [0.0 ... 1.0]");

--- a/src/ocean/math/IrregularMovingAverage.d
+++ b/src/ocean/math/IrregularMovingAverage.d
@@ -183,7 +183,7 @@ public struct IrregularMovingAverage (Time = time_t, Value = real)
     {
         assert(&ima); // confirm the invariant holds
     }
-    body
+    do
     {
         verify(!isNaN(beta));
         verify(!isInfinity(beta));
@@ -312,7 +312,7 @@ public struct IrregularMovingAverage (Time = time_t, Value = real)
         assert(!isNaN(estimate));
         assert(!isInfinity(estimate));
     }
-    body
+    do
     {
         enforce(t >= this.update_time_,
                 "Cannot calculate predicted value from the past!");

--- a/src/ocean/math/Range.d
+++ b/src/ocean/math/Range.d
@@ -258,7 +258,7 @@ public struct Range ( T )
     {
         assert(&result);
     }
-    body
+    do
     {
         enforce(This.isValid(min, max));
 
@@ -292,7 +292,7 @@ public struct Range ( T )
     {
         assert(&result);
     }
-    body
+    do
     {
         static assert(boundaries == "[]" || boundaries == "[)"
                       || boundaries == "(]" || boundaries == "()",

--- a/src/ocean/math/TimeHistogram.d
+++ b/src/ocean/math/TimeHistogram.d
@@ -136,7 +136,7 @@ struct TimeHistogram
         {
             assert(suffixes.length > 0);
         }
-        body
+        do
         {
             enum type = typeof(TimeHistogram.bins[0]).stringof;
 
@@ -214,7 +214,7 @@ struct TimeHistogram
     {
         assert(this.count || !this.total_time_micros);
     }
-    body
+    do
     {
         return cast(double)this.total_time_micros / this.count;
     }

--- a/src/ocean/math/WideUInt.d
+++ b/src/ocean/math/WideUInt.d
@@ -370,7 +370,7 @@ public struct WideUInt ( size_t N )
     {
         assert(remainder < rhs);
     }
-    body
+    do
     {
         ulong remainder = 0;
 

--- a/src/ocean/net/http/cookie/CookiesHttpResponse.d
+++ b/src/ocean/net/http/cookie/CookiesHttpResponse.d
@@ -56,7 +56,7 @@ class CookiesHttpResponse : HttpResponse
             assert (cookie !is null, "null cookie instance");
         }
     }
-    body
+    do
     {
         this.cookies = cookies.dup; // No .dup caused segfaults, apparently the
                                     // array is then sliced.

--- a/src/ocean/net/http/message/HttpHeaderParser.d
+++ b/src/ocean/net/http/message/HttpHeaderParser.d
@@ -612,7 +612,7 @@ class HttpHeaderParser : IHttpHeaderParser
     {
         assert (remaining.length <= chunk.length);
     }
-    body
+    do
     {
         verify(this.content_length <= this.content.length);
 

--- a/src/ocean/net/http/time/HttpTimeFormatter.d
+++ b/src/ocean/net/http/time/HttpTimeFormatter.d
@@ -191,7 +191,7 @@ struct HttpTimeFormatter
     {
         assert (!n, "decimal formatting overflow");
     }
-    body
+    do
     {
         verify(n >= 0);
 

--- a/src/ocean/net/server/SelectListener.d
+++ b/src/ocean/net/server/SelectListener.d
@@ -509,7 +509,7 @@ public class SelectListener ( T : IConnectionHandler, Args ... ) : ISelectListen
     {
         assert (still_existent >= n);
     }
-    body
+    do
     {
         size_t limit = this.receiver_pool.limit,
                busy = this.receiver_pool.num_busy;

--- a/src/ocean/net/util/GetSocketAddress.d
+++ b/src/ocean/net/util/GetSocketAddress.d
@@ -149,7 +149,7 @@ class GetSocketAddress
         {
             assert (a);
         }
-        body
+        do
         {
             void* addrp = &this.addr_;
 

--- a/src/ocean/net/util/ParamSet.d
+++ b/src/ocean/net/util/ParamSet.d
@@ -182,7 +182,7 @@ class ParamSet
     {
        assert (element.key || !element.val);
     }
-    body
+    do
     {
         Element* element = this.get_(key);
 
@@ -518,7 +518,7 @@ class ParamSet
         if (element)
             assert (element.key || !element.val);
     }
-    body
+    do
     {
         return this.tolower(key) in this.paramset;
     }
@@ -605,7 +605,7 @@ class ParamSet
         assert (!n);
         assert (&dec[$ - 1] is &dst[$ - 1]);
     }
-    body
+    do
     {
         foreach_reverse (i, ref c; dst)
         {
@@ -673,7 +673,7 @@ class ParamSet
         static assert (T.init == 0, "initial value of type \"" ~ T.stringof ~ "\" is " ~ T.init.stringof ~ " (need 0)");
         static assert (cast (T) (T.max + 1) < T.max);                           // ensure overflow checking works
     }
-    body
+    do
     {
         cstring trimmed = ISplitIterator.trim(src);
 

--- a/src/ocean/net/util/UrlDecoder.d
+++ b/src/ocean/net/util/UrlDecoder.d
@@ -206,7 +206,7 @@ class UrlDecoder
         assert (slice.ptr is dst.ptr, typeof (this).stringof ~ ".decodeCharacter: bad returned slice");
         assert(pos <= source.length, typeof (this).stringof ~ ".decodeCharacter (out): offset out of array bounds");
     }
-    body
+    do
     {
         verify(
             pos <= source.length,
@@ -288,7 +288,7 @@ class UrlDecoder
     {
         assert (str_out.ptr is str.ptr);
     }
-    body
+    do
     {
         size_t pos = 0;
 
@@ -458,7 +458,7 @@ class UrlDecoder
     {
         assert (utf8_buf.ptr is utf8.ptr);
     }
-    body
+    do
     {
         verify (hex.length == 4);
         verify (utf8_buf.length >= 6);

--- a/src/ocean/stdc/posix/sys/un.d
+++ b/src/ocean/stdc/posix/sys/un.d
@@ -46,7 +46,7 @@ struct sockaddr_un
             assert(typeof(this).sun_path.length > path.length,
                     "Can't set path longer than UNIX_PATH_MAX.");
         }
-        body
+        do
         {
             sockaddr_un addr;
             addr.sun_path[0..path.length] = path;

--- a/src/ocean/sys/Epoll.d
+++ b/src/ocean/sys/Epoll.d
@@ -742,7 +742,7 @@ struct Epoll
     {
         assert (n <= cast (int) events.length);
     }
-    body
+    do
     {
         verify(events.length <= int.max);
         return epoll_wait(this.fd, events.ptr, cast (int) events.length, timeout_ms);

--- a/src/ocean/sys/SignalMask.d
+++ b/src/ocean/sys/SignalMask.d
@@ -201,7 +201,7 @@ public struct SignalSet
                 assert(false, "invalid pthread_sigmask opcode");
         }
     }
-    body
+    do
     {
         typeof(this) old_set;
 

--- a/src/ocean/sys/socket/AddrInfo.d
+++ b/src/ocean/sys/socket/AddrInfo.d
@@ -139,7 +139,7 @@ struct addrinfo
     {
         if (result.length) assert (result.ptr is dst.ptr);
     }
-    body
+    do
     {
         void sanity_check ( )
         {

--- a/src/ocean/text/convert/Formatter.d
+++ b/src/ocean/text/convert/Formatter.d
@@ -759,7 +759,7 @@ out (ret)
     assert(s.ptr == p);
     assert(ret.ptr + ret.length == p);
 }
-body
+do
 {
     verify(s.ptr <= p);
     verify(s.ptr + s.length >= p);

--- a/src/ocean/text/entities/model/MarkupEntityCodec.d
+++ b/src/ocean/text/entities/model/MarkupEntityCodec.d
@@ -682,7 +682,7 @@ public class MarkupEntityCodec ( E : IEntitySet ) : IEntityCodec!(E)
         assert(entity.length >= 2, "character entity too short");
         assert(entity[0] == '&' && entity[$ - 1] == ';', "invalid character entity");
     }
-    body
+    do
     {
         static assert(
             is(Unqual!(Char) == char)
@@ -728,7 +728,7 @@ public class MarkupEntityCodec ( E : IEntitySet ) : IEntityCodec!(E)
         assert(entity.length >= 2, "character entity too short");
         assert(entity[0] == '&' && entity[$ - 1] == ';', "invalid character entity");
     }
-    body
+    do
     {
         static assert(
             is(Unqual!(Char) == char)

--- a/src/ocean/text/regex/PCRE.d
+++ b/src/ocean/text/regex/PCRE.d
@@ -238,7 +238,7 @@ public class PCRE
         {
             assert(this.pcre_object !is null);
         }
-        body
+        do
         {
 
             this.cleanup();
@@ -709,4 +709,3 @@ unittest
         t.test!("==")(matches_buffer.length, 695);
     }
 }
-

--- a/src/ocean/text/utf/UtfUtil.d
+++ b/src/ocean/text/utf/UtfUtil.d
@@ -217,7 +217,7 @@ out (result)
         assert(g_utf8_strlen(result.ptr, result.length) <= n);
     }
 }
-body
+do
 {
     if (n < str.length)
     {
@@ -479,7 +479,7 @@ out (result)
 
     assert(result_length <= n);
 }
-body
+do
 {
     {
         size_t ending_length = 0;   // Ending's number of Unicode characters

--- a/src/ocean/text/util/EscapeChars.d
+++ b/src/ocean/text/util/EscapeChars.d
@@ -132,7 +132,7 @@ struct EscapeChars
         assert (!this.tokens[$ - 1]);
         assert (this.tokens.length - 1 == strlen(this.tokens.ptr));
     }
-    body
+    do
     {
         verify (tokens.ptr !is null);
         verify (!memchr(tokens.ptr, '\0', tokens.length),

--- a/src/ocean/time/ISO8601.d
+++ b/src/ocean/time/ISO8601.d
@@ -67,7 +67,7 @@ public struct ExtendedDate {
    out(val) {
       assert (  (val >= -1_000_000_000 && val <=          -1)
              || (val >=              1 && val <= 999_999_999));
-   } body {
+   } do {
       if (year_)
          return year_;
 
@@ -675,7 +675,7 @@ in {
    assert (day    >= 1 && day    <= 31);
 } out(result) {
    assert (result >= 1 && result <= 7);
-} body {
+} do {
    uint era = erafy(year);
 
    int result =

--- a/src/ocean/time/MicrosecondsClock.d
+++ b/src/ocean/time/MicrosecondsClock.d
@@ -115,7 +115,7 @@ class MicrosecondsClock
                           (cast (ulong) t.tv_sec.max + 1) * 1_000_000);
         }
     }
-    body
+    do
     {
         return t.tv_sec * 1_000_000UL + t.tv_usec;
     }
@@ -142,7 +142,7 @@ class MicrosecondsClock
     {
         assert (local || datetime.tm_isdst <= 0, "DST enabled with GMT");
     }
-    body
+    do
     {
         tm datetime;
 

--- a/src/ocean/time/timeout/TimeoutManager.d
+++ b/src/ocean/time/timeout/TimeoutManager.d
@@ -576,7 +576,7 @@ abstract class TimeoutManagerBase : ITimeoutManager
     {
         assert (expiry);
     }
-    body
+    do
     {
         ulong now = this.now;
 

--- a/src/ocean/time/timeout/model/ExpiryRegistrationBase.d
+++ b/src/ocean/time/timeout/model/ExpiryRegistrationBase.d
@@ -274,7 +274,7 @@ abstract class ExpiryRegistrationBase : IExpiryRegistration
     {
         assert (this.expiry, "not registered");
     }
-    body
+    do
     {
         return this.expiry? this.expiry.key - this.mgr.now : long.max;
     }
@@ -298,7 +298,7 @@ abstract class ExpiryRegistrationBase : IExpiryRegistration
     {
         assert (this.expiry !is null, "timeout - no client");                   // The invariant makes sure that
     }                                                                           // this.client !is null if this.expiry !is null.
-    body
+    do
     {
         debug ( TimeoutManager ) Stderr("*** timeout for ")(this.id)('\n').flush();
 
@@ -361,7 +361,7 @@ abstract class ExpiryRegistrationBase : IExpiryRegistration
         assert (this.expiry is null, "already registered");
         assert (this.client !is null, "client required to register");
     }
-    body
+    do
     {
         debug ( TimeoutManager ) Stderr("*** register ")(this.id)(": ");
 

--- a/src/ocean/util/cipher/gcrypt/core/Gcrypt.d
+++ b/src/ocean/util/cipher/gcrypt/core/Gcrypt.d
@@ -278,7 +278,7 @@ private class GcryptBase ( Algorithm algorithm, Mode mode )
     {
         assert(blk_len != 0);
     }
-    body
+    do
     {
         return gcry_cipher_get_algo_keylen(algorithm);
     }
@@ -295,7 +295,7 @@ private class GcryptBase ( Algorithm algorithm, Mode mode )
     {
         assert(key_len != 0);
     }
-    body
+    do
     {
         return gcry_cipher_get_algo_blklen(algorithm);
     }
@@ -538,7 +538,7 @@ public class GcryptWithIV ( Algorithm algorithm, Mode mode )
     {
         assert(iv_len != 0);
     }
-    body
+    do
     {
         return gcry_cipher_get_algo_blklen(algorithm);
     }

--- a/src/ocean/util/cipher/gcrypt/core/MessageDigestCore.d
+++ b/src/ocean/util/cipher/gcrypt/core/MessageDigestCore.d
@@ -62,7 +62,7 @@ abstract class MessageDigestCore
     {
         assert(this.md !is null);
     }
-    body
+    do
     {
         // `gcry_md_open` sets `this.md = null` on failure.
         GcryptException.throwNewIfGcryptError(

--- a/src/ocean/util/container/AppendBuffer.d
+++ b/src/ocean/util/container/AppendBuffer.d
@@ -268,7 +268,7 @@ public class AppendBuffer ( T, Base: AppendBufferImpl ): Base, IAppendBufferRead
                 assert (element.length == T.length);
             }
         }
-        body
+        do
         {
             return *cast (T*) this.index_(i);
         }
@@ -298,7 +298,7 @@ public class AppendBuffer ( T, Base: AppendBufferImpl ): Base, IAppendBufferRead
                 assert (element.length == T.length);
             }
         }
-        body
+        do
         {
             static if (static_array_element)
             {
@@ -517,7 +517,7 @@ public class AppendBuffer ( T, Base: AppendBufferImpl ): Base, IAppendBufferRead
     {
         assert (elements.length <= n);
     }
-    body
+    do
     {
         size_t end   = this.length,
         start = (end >= n)? end - n : 0;
@@ -945,7 +945,7 @@ private abstract class AppendBufferImpl: IAppendBufferBase
             assert (n_new == n);
         }
     }
-    body
+    do
     {
         size_t len = n * this.e;
 
@@ -1148,7 +1148,7 @@ private abstract class AppendBufferImpl: IAppendBufferBase
             assert (dst.length == src.length);
         }
     }
-    body
+    do
     {
         verify (!(src.length % this.e), typeof (this).stringof ~ ": data alignment mismatch");
 
@@ -1211,7 +1211,7 @@ private abstract class AppendBufferImpl: IAppendBufferBase
             assert (slice.length == n * this.e);
         }
     }
-    body
+    do
     {
         return this.extendBytes(n * this.e);
     }
@@ -1244,7 +1244,7 @@ private abstract class AppendBufferImpl: IAppendBufferBase
             assert (slice.length == extent);
         }
     }
-    body
+    do
     {
         verify (!(extent % this.e));
 
@@ -1291,7 +1291,7 @@ private abstract class AppendBufferImpl: IAppendBufferBase
     {
         assert (content_.length == n);
     }
-    body
+    do
     {
         verify (n > 0, typeof (this).stringof ~ ".newContent: attempted to allocate zero bytes");
 
@@ -1321,7 +1321,7 @@ private abstract class AppendBufferImpl: IAppendBufferBase
         //assert (content_.length == n,
         //        typeof (this).stringof ~ ".setContentLength: content length mismatch");
     }
-    body
+    do
     {
         content_.length = n;
         assumeSafeAppend(content_);

--- a/src/ocean/util/container/HashRangeMap.d
+++ b/src/ocean/util/container/HashRangeMap.d
@@ -186,7 +186,7 @@ public struct HashRangeMap ( Value )
     {
         assert(result !is null);
     }
-    body
+    do
     {
         enforce(!range.is_empty, "An empty range can't be put in HashRangeMap");
 

--- a/src/ocean/util/container/btree/BTreeMap.d
+++ b/src/ocean/util/container/btree/BTreeMap.d
@@ -178,7 +178,7 @@ struct BTreeMap(TreeKeyType, TreeValueType, int tree_degree)
     {
         assert(ptr !is null);
     }
-    body
+    do
     {
         return this.impl.insert(key, value, added);
     }

--- a/src/ocean/util/container/cache/Cache.d
+++ b/src/ocean/util/container/cache/Cache.d
@@ -385,7 +385,7 @@ class Cache ( size_t ValueSize = 0, bool TrackCreateTimes = false ) : CacheBase!
             assert (val.length == ValueSize);
         }
     }
-    body
+    do
     {
         bool existed;
 
@@ -433,7 +433,7 @@ class Cache ( size_t ValueSize = 0, bool TrackCreateTimes = false ) : CacheBase!
             }
         }
     }
-    body
+    do
     {
         time_t access_time;
 
@@ -480,7 +480,7 @@ class Cache ( size_t ValueSize = 0, bool TrackCreateTimes = false ) : CacheBase!
             assert (val.length == ValueSize);
         }
     }
-    body
+    do
     {
         time_t access_time;
 
@@ -580,7 +580,7 @@ class Cache ( size_t ValueSize = 0, bool TrackCreateTimes = false ) : CacheBase!
     {
         assert(key == this.items[replaced].key);
     }
-    body
+    do
     {
         verify(replaced != replace);
 
@@ -622,7 +622,7 @@ class Cache ( size_t ValueSize = 0, bool TrackCreateTimes = false ) : CacheBase!
     {
         assert (item !is null);
     }
-    body
+    do
     {
         return this.getItem(this.accessIndex(node, access_time));
     }
@@ -693,7 +693,7 @@ class Cache ( size_t ValueSize = 0, bool TrackCreateTimes = false ) : CacheBase!
     {
         assert (item !is null);
     }
-    body
+    do
     {
         CacheItem* item = this.get__(key, access_time);
 
@@ -724,7 +724,7 @@ class Cache ( size_t ValueSize = 0, bool TrackCreateTimes = false ) : CacheBase!
     {
         assert (cache_item !is null);
     }
-    body
+    do
     {
         // Add key->item mapping
 
@@ -897,7 +897,7 @@ class Cache ( T, bool TrackCreateTimes = false ) : Cache!(T.sizeof, TrackCreateT
     {
         assert (val !is null);
     }
-    body
+    do
     {
         return cast (T*) this.createRaw(key)[0 .. T.sizeof].ptr;
     }
@@ -949,7 +949,7 @@ class Cache ( T, bool TrackCreateTimes = false ) : Cache!(T.sizeof, TrackCreateT
     {
         assert (val !is null);
     }
-    body
+    do
     {
         return cast (T*) this.getOrCreateRaw(key, existed)[0 .. T.sizeof].ptr;
     }

--- a/src/ocean/util/container/cache/ExpiringCache.d
+++ b/src/ocean/util/container/cache/ExpiringCache.d
@@ -167,7 +167,7 @@ class ExpiringCache ( size_t ValueSize = 0 ) : Cache!(ValueSize, true),
     {
         if (expired) assert (val is null);
     }
-    body
+    do
     {
         bool existed;
 
@@ -231,7 +231,7 @@ class ExpiringCache ( size_t ValueSize = 0 ) : Cache!(ValueSize, true),
     {
         if (expired) assert (!does_exist);
     }
-    body
+    do
     {
         return this.getRaw(key, expired) !is null;
     }
@@ -321,7 +321,7 @@ class ExpiringCache ( size_t ValueSize = 0 ) : Cache!(ValueSize, true),
             assert (val is null);
         }
     }
-    body
+    do
     {
         TimeToIndex.Node** node = key in this;
 

--- a/src/ocean/util/container/cache/ExpiringLRUCache.d
+++ b/src/ocean/util/container/cache/ExpiringLRUCache.d
@@ -142,7 +142,7 @@ class ExpiringLRUCache(T = void[]) : LRUCache!(T, true), IExpiringCacheInfo
     {
         if (expired) assert (val is null);
     }
-    body
+    do
     {
         bool existed;
 
@@ -215,7 +215,7 @@ class ExpiringLRUCache(T = void[]) : LRUCache!(T, true), IExpiringCacheInfo
     {
         if (expired) assert (!does_exist);
     }
-    body
+    do
     {
         return this.getAndRefresh(key, expired) !is null;
     }
@@ -305,7 +305,7 @@ class ExpiringLRUCache(T = void[]) : LRUCache!(T, true), IExpiringCacheInfo
             assert (val is null);
         }
     }
-    body
+    do
     {
         verify (this.lifetime > 0,
                 "cache element lifetime is expected to be at least 1");

--- a/src/ocean/util/container/cache/LRUCache.d
+++ b/src/ocean/util/container/cache/LRUCache.d
@@ -333,7 +333,7 @@ class LRUCache(T, bool TrackCreateTimes = false) : PriorityCache!(ValueT!(T, Tra
     {
         assert (val !is null);
     }
-    body
+    do
     {
         bool existed_ignore;
 
@@ -370,7 +370,7 @@ class LRUCache(T, bool TrackCreateTimes = false) : PriorityCache!(ValueT!(T, Tra
     {
         assert (val !is null);
     }
-    body
+    do
     {
         time_t access_time;
 
@@ -408,7 +408,7 @@ class LRUCache(T, bool TrackCreateTimes = false) : PriorityCache!(ValueT!(T, Tra
     {
         assert (val !is null);
     }
-    body
+    do
     {
         if ( Value* val = this.getRefreshOrCreateRaw(key, access_time, existed) )
         {
@@ -451,7 +451,7 @@ class LRUCache(T, bool TrackCreateTimes = false) : PriorityCache!(ValueT!(T, Tra
     {
         assert (val !is null);
     }
-    body
+    do
     {
         access_time = this.now();
 

--- a/src/ocean/util/container/cache/PriorityCache.d
+++ b/src/ocean/util/container/cache/PriorityCache.d
@@ -317,7 +317,7 @@ class PriorityCache(T) : ICacheInfo
             assert(val !is null, "Null return value although item exists");
         }
     }
-    body
+    do
     {
         T* item = this.updatePriority(key, priority, tracK_get_miss);
         existed = item !is null;
@@ -713,7 +713,7 @@ class PriorityCache(T) : ICacheInfo
     ***************************************************************************/
 
     private T* create ( hash_t key, ulong priority )
-    body
+    do
     {
         bool item_added;
         auto index = this.attemptCreateNode(key, priority, item_added);
@@ -782,7 +782,7 @@ class PriorityCache(T) : ICacheInfo
         assert(&node, "ref argument is a dereferenced null pointer");
         assert (index < this.insert, "cache index out of bounds");
     }
-    body
+    do
     {
         TimeToIndex.Key node_key = node.key;
 
@@ -820,7 +820,7 @@ class PriorityCache(T) : ICacheInfo
     {
         if (node) assert (*node !is null, "null pointer value was stored in key_to_node");
     }
-    body
+    do
     {
         TimeToIndex.Node** node = key in this.key_to_node;
         if (track_misses)
@@ -863,7 +863,7 @@ class PriorityCache(T) : ICacheInfo
             assert(this.items[index].key == key, "keys mismatch");
         }
     }
-    body
+    do
     {
         size_t index;
 

--- a/src/ocean/util/container/cache/model/ICache.d
+++ b/src/ocean/util/container/cache/model/ICache.d
@@ -283,7 +283,7 @@ abstract class ICache : ICacheInfo
     {
         assert (index < this.insert, "cache index out of bounds");
     }
-    body
+    do
     {
         TimeToIndex.Key key = node.key;
 
@@ -361,7 +361,7 @@ abstract class ICache : ICacheInfo
     {
         if (node) assert (*node !is null, "null pointer value was stored in key_to_node");
     }
-    body
+    do
     {
         TimeToIndex.Node** node = key in this.key_to_node;
 
@@ -417,7 +417,7 @@ abstract class ICache : ICacheInfo
     {
         assert (index < this.max_length);
     }
-    body
+    do
     {
         size_t index;
 

--- a/src/ocean/util/container/ebtree/EBTree128.d
+++ b/src/ocean/util/container/ebtree/EBTree128.d
@@ -226,7 +226,7 @@ class EBTree128 ( bool signed = false ) : IEBTree
     {
         assert (node_out !is null);
     }
-    body
+    do
     {
         scope (success) this.increaseNodeCount(1);
 
@@ -251,7 +251,7 @@ class EBTree128 ( bool signed = false ) : IEBTree
     {
         assert (node_out !is null);
     }
-    body
+    do
     {
         return (node.key != key)? this.add_(node.remove(), key) : &node;
     }
@@ -367,7 +367,7 @@ class EBTree128 ( bool signed = false ) : IEBTree
     {
         assert (node_out !is null);
     }
-    body
+    do
     {
         verify (node !is null, "attempted to add null node (node pool returned null?)");
 

--- a/src/ocean/util/container/ebtree/EBTree32.d
+++ b/src/ocean/util/container/ebtree/EBTree32.d
@@ -282,7 +282,7 @@ class EBTree32 ( bool signed = false ) : IEBTree
     {
         assert (node_out !is null);
     }
-    body
+    do
     {
         scope (success) this.increaseNodeCount(1);
 
@@ -307,7 +307,7 @@ class EBTree32 ( bool signed = false ) : IEBTree
     {
         assert (node_out !is null);
     }
-    body
+    do
     {
         return this.add(cast (Key) key);
     }
@@ -330,7 +330,7 @@ class EBTree32 ( bool signed = false ) : IEBTree
     {
         assert (node_out !is null);
     }
-    body
+    do
     {
         return (node.node_.key != cast (ulong) key)?
                 this.add_(node.remove(), key) : &node;
@@ -354,7 +354,7 @@ class EBTree32 ( bool signed = false ) : IEBTree
     {
         assert (node_out !is null);
     }
-    body
+    do
     {
         return this.update(node, cast (Key) key);
     }
@@ -377,7 +377,7 @@ class EBTree32 ( bool signed = false ) : IEBTree
     {
         assert (node_out !is null);
     }
-    body
+    do
     {
         return this.add(cast (Key) key);
     }
@@ -476,7 +476,7 @@ class EBTree32 ( bool signed = false ) : IEBTree
     {
         assert (node_out !is null);
     }
-    body
+    do
     {
         verify (node !is null, "attempted to add null node (node pool returned null?)");
         node.node_.key = key;

--- a/src/ocean/util/container/ebtree/EBTree64.d
+++ b/src/ocean/util/container/ebtree/EBTree64.d
@@ -260,7 +260,7 @@ class EBTree64 ( bool signed = false ) : IEBTree
     {
         assert (node_out !is null);
     }
-    body
+    do
     {
         scope (success) this.increaseNodeCount(1);
 
@@ -285,7 +285,7 @@ class EBTree64 ( bool signed = false ) : IEBTree
     {
         assert (node_out !is null);
     }
-    body
+    do
     {
         return this.add(cast (Key) key);
     }
@@ -308,7 +308,7 @@ class EBTree64 ( bool signed = false ) : IEBTree
     {
         assert (node_out !is null);
     }
-    body
+    do
     {
         return (node.node_.key != cast (ulong) key)?
                 this.add_(node.remove(), key) : &node;
@@ -332,7 +332,7 @@ class EBTree64 ( bool signed = false ) : IEBTree
     {
         assert (node_out !is null);
     }
-    body
+    do
     {
         return this.update(node, cast (Key) key);
     }
@@ -432,7 +432,7 @@ class EBTree64 ( bool signed = false ) : IEBTree
     {
         assert (node_out !is null);
     }
-    body
+    do
     {
         verify (node !is null, "attempted to add null node (node pool returned null?)");
 

--- a/src/ocean/util/container/ebtree/model/KeylessMethods.d
+++ b/src/ocean/util/container/ebtree/model/KeylessMethods.d
@@ -70,7 +70,7 @@ template KeylessMethods ( Node, alias eb_first, alias eb_last )
                            ".first: got a node but the tree is empty");
         }
     }
-    body
+    do
     {
         return this.ebCall!(eb_first)();
     }
@@ -97,7 +97,7 @@ template KeylessMethods ( Node, alias eb_first, alias eb_last )
                            ".last: got a node but the tree is empty");
         }
     }
-    body
+    do
     {
         return this.ebCall!(eb_last)();
     }

--- a/src/ocean/util/container/ebtree/nodepool/NodePool.d
+++ b/src/ocean/util/container/ebtree/nodepool/NodePool.d
@@ -115,7 +115,7 @@ class NodePool ( Node ) : INodePool!(Node)
         assert((cast(size_t)node) % 16 == 0,
                "the node pointer must be an integer multiple of 16");
     }
-    body
+    do
     {
         return new Node;
     }

--- a/src/ocean/util/container/map/Map.d
+++ b/src/ocean/util/container/map/Map.d
@@ -491,7 +491,7 @@ public abstract class Map ( V, K ) : BucketSet!(V.sizeof, K)
     {
         assert (val !is null);
     }
-    body
+    do
     {
         return cast(V*)this.get_(key, true).val[0 .. V.sizeof].ptr;
     }
@@ -545,7 +545,7 @@ public abstract class Map ( V, K ) : BucketSet!(V.sizeof, K)
     {
         assert (val !is null);
     }
-    body
+    do
     {
         return cast(V*)this.put_(key, added).val[0 .. V.sizeof].ptr;
     }
@@ -575,7 +575,7 @@ public abstract class Map ( V, K ) : BucketSet!(V.sizeof, K)
     {
         assert (val !is null);
     }
-    body
+    do
     {
         return cast(V*)this.put_(key).val[0 .. V.sizeof].ptr;
     }
@@ -867,7 +867,7 @@ public abstract class Map ( size_t V, K ) : BucketSet!(V, K)
             assert (val.length == V);
         }
     }
-    body
+    do
     {
         return this.get_(key).val;
     }
@@ -897,7 +897,7 @@ public abstract class Map ( size_t V, K ) : BucketSet!(V, K)
     {
         assert (val.length == V);
     }
-    body
+    do
     {
         return this.get_(key, true).val;
     }
@@ -949,7 +949,7 @@ public abstract class Map ( size_t V, K ) : BucketSet!(V, K)
     {
         assert (val.length == V);
     }
-    body
+    do
     {
         return this.put_(key, added).val;
     }
@@ -978,7 +978,7 @@ public abstract class Map ( size_t V, K ) : BucketSet!(V, K)
     {
         assert (val.length == V);
     }
-    body
+    do
     {
         bool added;
 
@@ -1039,7 +1039,7 @@ public abstract class Map ( size_t V, K ) : BucketSet!(V, K)
             assert (val.length == V);
         }
     }
-    body
+    do
     {
         return this.remove_(key).val;
     }

--- a/src/ocean/util/container/map/model/Bucket.d
+++ b/src/ocean/util/container/map/model/Bucket.d
@@ -185,7 +185,7 @@ public struct Bucket ( size_t V, K = hash_t )
                     "element found is not from this bucket");
         }
     }
-    body
+    do
     {
         for (Element* element = this.first; element; element = element.next)
         {
@@ -224,7 +224,7 @@ public struct Bucket ( size_t V, K = hash_t )
     {
         assert (element !is null);
     }
-    body
+    do
     {
         Element* element = this.find(key);
 
@@ -287,7 +287,7 @@ public struct Bucket ( size_t V, K = hash_t )
             }
         }
     }
-    body
+    do
     {
         element.next = this.first;
         this.first   = element;
@@ -326,7 +326,7 @@ public struct Bucket ( size_t V, K = hash_t )
             }
         }
     }
-    body
+    do
     {
         if (this.first !is null)
         {

--- a/src/ocean/util/container/map/model/BucketElementFreeList.d
+++ b/src/ocean/util/container/map/model/BucketElementFreeList.d
@@ -213,7 +213,7 @@ abstract class IBucketElementFreeList: IAllocator
     {
         assert (object !is null);
     }
-    body
+    do
     {
         if (this.first)
         {

--- a/src/ocean/util/container/map/model/BucketInfo.d
+++ b/src/ocean/util/container/map/model/BucketInfo.d
@@ -289,7 +289,7 @@ class BucketInfo
 
         debug (BucketInfo) this.print("    ", bucket_index);
     }
-    body
+    do
     {
         assert (this); // call invariant
 
@@ -335,7 +335,7 @@ class BucketInfo
 
         debug (BucketInfo) this.print("    ", bucket_index);
     }
-    body
+    do
     {
         assert (this); // call invariant
 
@@ -374,7 +374,7 @@ class BucketInfo
 
         debug (BucketInfo) this.print("    ", bucket_index);
     }
-    body
+    do
     {
         assert (this); // call invariant
 
@@ -485,7 +485,7 @@ class BucketInfo
 
         assert (!this.n_elements, "clear: remaining elements");
     }
-    body
+    do
     {
         /*
          * Reset all buckets that have been in use.
@@ -579,7 +579,7 @@ unittest
     {
         test(expected.length == info.num_buckets);
     }
-    body
+    do
     {
         foreach (i, n; expected)
         {

--- a/src/ocean/util/container/map/model/BucketSet.d
+++ b/src/ocean/util/container/map/model/BucketSet.d
@@ -396,7 +396,7 @@ public abstract class BucketSet ( size_t V, K = hash_t ) : IBucketSet
             }
         }
     }
-    body
+    do
     {
         auto element = this
             .buckets[this.toHash(key) & this.bucket_mask]
@@ -443,7 +443,7 @@ public abstract class BucketSet ( size_t V, K = hash_t ) : IBucketSet
             assert (element.key == key, "key mismatch");
         }
     }
-    body
+    do
     {
         size_t bucket_index = this.toHash(key) & this.bucket_mask;
 
@@ -675,7 +675,7 @@ public abstract class BucketSet ( size_t V, K = hash_t ) : IBucketSet
             assert(bucket.first == null, "non-Null first bucket element found");
         }
     }
-    body
+    do
     {
         verify (!val_init.length || val_init.length == V);
 

--- a/src/ocean/util/container/map/model/IAllocator.d
+++ b/src/ocean/util/container/map/model/IAllocator.d
@@ -225,7 +225,7 @@ abstract class IAllocator
                 assert(!this.n);
             }
         }
-        body
+        do
         {
             if (this.n)
             {

--- a/src/ocean/util/container/pool/FreeList.d
+++ b/src/ocean/util/container/pool/FreeList.d
@@ -193,7 +193,7 @@ public class FreeList ( T ) : IFreeList!(ItemType_!(T))
     {
         assert(this.free_list.length >= num);
     }
-    body
+    do
     {
         if ( this.free_list.length < num )
         {
@@ -429,4 +429,3 @@ unittest
         fl.test();
     }
 }
-

--- a/src/ocean/util/container/pool/model/IAggregatePool.d
+++ b/src/ocean/util/container/pool/model/IAggregatePool.d
@@ -243,7 +243,7 @@ public abstract class IAggregatePool ( T ) : IPool, IFreeList!(ItemType_!(T))
     {
         assert (item !is null);
     }
-    body
+    do
     {
         return this.fromItem(super.get_(Item.from(new_item)));
     }
@@ -302,7 +302,7 @@ public abstract class IAggregatePool ( T ) : IPool, IFreeList!(ItemType_!(T))
         {
             assert (item !is null);
         }
-        body
+        do
         {
             return this.get(new T);
         }
@@ -441,7 +441,7 @@ public abstract class IAggregatePool ( T ) : IPool, IFreeList!(ItemType_!(T))
     {
         assert (obj !is null);
     }
-    body+/
+    do+/
     {
         return this.fromItem(super.opIndex_(n));
     }
@@ -602,7 +602,7 @@ public abstract class IAggregatePool ( T ) : IPool, IFreeList!(ItemType_!(T))
     {
         assert (this.isNull(item));
     }
-    body
+    do
     {
         import core.memory;
 

--- a/src/ocean/util/container/pool/model/IPool.d
+++ b/src/ocean/util/container/pool/model/IPool.d
@@ -298,7 +298,7 @@ public abstract class IPool : IPoolInfo, ILimitable
             assert (item.ptr !is null);
         }
     }
-    body
+    do
     {
         this.limited = limit != this.unlimited;
 
@@ -418,7 +418,7 @@ public abstract class IPool : IPoolInfo, ILimitable
             }
         }
     }
-    body
+    do
     {
         Item item;
 

--- a/src/ocean/util/container/queue/FixedRingQueue.d
+++ b/src/ocean/util/container/queue/FixedRingQueue.d
@@ -425,7 +425,7 @@ abstract class FixedRingQueueBase ( IBaseQueue ) : IRingQueue!(IBaseQueue)
     {
         assert (!element || element.length == this.element_size);
     }
-    body
+    do
     {
         if (super.items < this.max_items)
         {
@@ -456,7 +456,7 @@ abstract class FixedRingQueueBase ( IBaseQueue ) : IRingQueue!(IBaseQueue)
     {
         assert (!element || element.length == this.element_size);
     }
-    body
+    do
     {
         if (super.items)
         {
@@ -476,7 +476,7 @@ abstract class FixedRingQueueBase ( IBaseQueue ) : IRingQueue!(IBaseQueue)
     {
         assert (!element || element.length == this.element_size);
     }
-    body
+    do
     {
         if (super.items)
         {
@@ -577,4 +577,3 @@ unittest
     test (!queue.pop());
     test (queue.get_write_to == queue.get_read_from);
 }
-

--- a/src/ocean/util/container/queue/FlexibleRingQueue.d
+++ b/src/ocean/util/container/queue/FlexibleRingQueue.d
@@ -214,7 +214,7 @@ class FlexibleByteRingQueue : IRingQueue!(IByteQueue)
         assert(slice is null || slice.length == size,
                classname(this) ~ "push: length of returned buffer not as requested");
     }
-    body
+    do
     {
         return this.willFit(size) ? this.push_(size) : null;
     }
@@ -611,7 +611,7 @@ class FlexibleByteRingQueue : IRingQueue!(IByteQueue)
                classname(this) ~ "push_: length of returned slice not as requested");
         assert(this); // invariant
     }
-    body
+    do
     {
         assert(this); // invariant
         verify(this.willFit(size), classname(this) ~ ".push_: item will not fit");
@@ -684,7 +684,7 @@ class FlexibleByteRingQueue : IRingQueue!(IByteQueue)
         assert(buffer, classname(this) ~ ".pop_: returned a null buffer");
         assert(this); // invariant
     }
-    body
+    do
     {
         assert(this); // invariant
         verify(this.items > 0, classname(this) ~ ".pop_: no items in the queue");
@@ -1043,7 +1043,7 @@ unittest
         {
             test(n <= ubyte.max);
         }
-        body
+        do
         {
             for (ubyte i = 0; i < n; i++)
             {

--- a/src/ocean/util/container/queue/model/IRingQueue.d
+++ b/src/ocean/util/container/queue/model/IRingQueue.d
@@ -125,7 +125,7 @@ public abstract class IRingQueue ( IBaseQueue ) : IBaseQueue
         assert(mem_manager !is null, typeof(this).stringof ~ ": memory manager is null");
         assert(dimension > 0, typeof(this).stringof ~ ": cannot construct a 0-length queue");
     }
-    body
+    do
     {
         this.mem_manager = mem_manager;
 

--- a/src/ocean/util/serialize/contiguous/Deserializer.d
+++ b/src/ocean/util/serialize/contiguous/Deserializer.d
@@ -247,7 +247,7 @@ struct Deserializer
                 src[].ptr, s.ptr);
         }
     }
-    body
+    do
     {
         debug (DeserializationTrace)
         {
@@ -312,7 +312,7 @@ struct Deserializer
                 src.ptr, dst.ptr, s.ptr);
         }
     }
-    body
+    do
     {
         static assert (is(S == Unqual!(S)),
                        "Cannot deserialize qualified type : " ~ S.stringof);
@@ -396,7 +396,7 @@ struct Deserializer
             nesting--;
         }
     }
-    body
+    do
     {
         debug (DeserializationTrace)
         {
@@ -449,7 +449,7 @@ struct Deserializer
             nesting--;
         }
     }
-    body
+    do
     {
         debug (DeserializationTrace)
         {
@@ -508,7 +508,7 @@ struct Deserializer
             nesting--;
         }
     }
-    body
+    do
     {
         debug (DeserializationTrace)
         {
@@ -590,7 +590,7 @@ struct Deserializer
             nesting--;
         }
     }
-    body
+    do
     {
         debug (DeserializationTrace)
         {
@@ -688,7 +688,7 @@ struct Deserializer
             nesting--;
         }
     }
-    body
+    do
     {
         debug (DeserializationTrace)
         {
@@ -770,7 +770,7 @@ struct Deserializer
             nesting--;
         }
     }
-    body
+    do
     {
         debug (DeserializationTrace)
         {
@@ -823,7 +823,7 @@ struct Deserializer
             nesting--;
         }
     }
-    body
+    do
     {
         verify(slices_buffer !is null);
 
@@ -908,7 +908,7 @@ struct Deserializer
             nesting--;
         }
     }
-    body
+    do
     {
         verify (slices_buffer !is null);
 
@@ -1019,7 +1019,7 @@ struct Deserializer
             nesting--;
         }
     }
-    body
+    do
     {
         verify (slices_buffer !is null);
 

--- a/src/ocean/util/serialize/contiguous/Serializer.d
+++ b/src/ocean/util/serialize/contiguous/Serializer.d
@@ -85,7 +85,7 @@ struct Serializer
                 dst[].ptr, data.ptr);
         }
     }
-    body
+    do
     {
         debug (SerializationTrace)
         {
@@ -165,7 +165,7 @@ struct Serializer
             Stdout.formatln("< countRequiredSize!({})(<input>) : {}", S.stringof, cast(size_t)size);
         }
     }
-    body
+    do
     {
         debug (SerializationTrace)
         {
@@ -212,7 +212,7 @@ struct Serializer
                 buffer_out.ptr);
         }
     }
-    body
+    do
     {
         debug (SerializationTrace)
         {
@@ -255,7 +255,7 @@ struct Serializer
                 S.stringof, cast(size_t)size);
         }
     }
-    body
+    do
     {
         debug (SerializationTrace)
         {
@@ -338,7 +338,7 @@ struct Serializer
                 T.stringof, array.length, array.ptr, cast(size_t)size);
         }
     }
-    body
+    do
     {
         debug (SerializationTrace)
         {
@@ -400,7 +400,7 @@ struct Serializer
                 T.stringof, cast(size_t)size);
         }
     }
-    body
+    do
     {
         static assert (containsDynamicArray!(T), T.stringof ~
                        " contains no dynamic array - nothing to do");
@@ -471,7 +471,7 @@ struct Serializer
                 S.stringof, &s, data.ptr, result.length, result.ptr);
         }
     }
-    body
+    do
     {
         debug (SerializationTrace)
         {
@@ -563,7 +563,7 @@ struct Serializer
                 T.stringof, array.length, array.ptr, data.length, data.ptr, result.length, result.ptr);
         }
     }
-    body
+    do
     {
         debug (SerializationTrace)
         {
@@ -699,7 +699,7 @@ struct Serializer
                 T.stringof, array.ptr, data.ptr, result.ptr);
         }
     }
-    body
+    do
     {
         debug (SerializationTrace)
         {
@@ -765,7 +765,7 @@ struct Serializer
                 S.stringof, &s, result);
         }
     }
-    body
+    do
     {
         static assert (is (S == struct), "struct expected, not " ~ S.stringof);
         static assert (containsDynamicArray!(S), "nothing to do for " ~ S.stringof);
@@ -837,7 +837,7 @@ struct Serializer
                 T.stringof, array.ptr, arr.ptr);
         }
     }
-    body
+    do
     {
         debug (SerializationTrace)
         {


### PR DESCRIPTION
This should make Ocean usable with v2.096 which deprecates `body` in favor of `do`.