### PR TITLE
Remove a useless unreachable statement

### DIFF
--- a/src/ocean/util/container/cache/model/containers/ArrayPool.d
+++ b/src/ocean/util/container/cache/model/containers/ArrayPool.d
@@ -118,7 +118,6 @@ class GenericArrayPool
         else
         {
             onOutOfMemoryError();
-            this.elements = null;
         }
     }
 


### PR DESCRIPTION
```
This statement wasn't useful, as elements was already null to begin with,
but also because onOutOfMemoryError doesn't generally return.
The addition of noreturn and its application to onOutOfMemoryError means
that this could trigger a warning in a future release.
```

https://github.com/dlang/druntime/pull/3447#issuecomment-822892222