### PR TITLE
Explicitly discard `SmartUnion` in unittest

### DIFF
--- a/src/ocean/core/SmartUnion.d
+++ b/src/ocean/core/SmartUnion.d
@@ -545,9 +545,9 @@ unittest
     alias U = SmartUnion!HasDuplicates;
 
     // These calls are unambiguous.
-    U(Object.init);
-    U("c");
-    U([true]);
+    cast(void) U(Object.init);
+    cast(void) U("c");
+    cast(void) U([true]);
 
     // Dont allow ambiguous opCalls
     static assert(!__traits(compiles, U(1)));


### PR DESCRIPTION
Buildkite fails on this dmd PR:
https://github.com/dlang/dmd/pull/12890

```
./submodules/ocean/src/ocean/core/SmartUnion.d(549): Warning: calling `ocean.core.SmartUnion.SmartUnion!(HasDuplicates).SmartUnion.opCall` without side effects discards return value of type `SmartUnion!(HasDuplicates)`; prepend a `cast(void)` if intentional
```