### PR TITLE
Fixup Formatter to use 'in' for toString

### DIFF
--- a/src/ocean/text/convert/Formatter.d
+++ b/src/ocean/text/convert/Formatter.d
@@ -465,7 +465,7 @@ private void handle (T) (T v, FormatInfo f, scope FormatterSink sf, scope ElemSi
     // Note: sink `toString` overload should take a `scope` delegate
     else static if (is(typeof(v.toString(sf))))
         nullWrapper(&v,
-                    v.toString((cstring e) { se(e, f); }),
+                    v.toString((in cstring e) { se(e, f); }),
                     se("null", f));
     else static if (is(typeof(v.toString()) : cstring))
         nullWrapper(&v, se(v.toString(), f), se("null", f));

--- a/src/ocean/util/log/Appender.d
+++ b/src/ocean/util/log/Appender.d
@@ -231,7 +231,7 @@ public class AppendNull : Appender
     /// Append an event to the output
     final override void append (LogEvent event)
     {
-        this.layout.format(event, (cstring) {});
+        this.layout.format(event, (in cstring) {});
     }
 }
 
@@ -271,7 +271,7 @@ public class AppendStream : Appender
     {
         static immutable istring Eol = "\n";
 
-        this.layout.format(event, (cstring content) { this.stream_.write(content); });
+        this.layout.format(event, (in cstring content) { this.stream_.write(content); });
         this.stream_.write(Eol);
         if (this.flush_)
             this.stream_.flush;
@@ -307,7 +307,7 @@ unittest
        result.length = 0;
        assumeSafeAppend(result);
 
-       scope dg = (cstring v) { result ~= v; };
+       scope dg = (in cstring v) { result ~= v; };
        scope layout = new LayoutTimer();
        LogEvent event = {
            msg_: "Have you met Ted?",

--- a/src/ocean/util/log/LayoutDate.d
+++ b/src/ocean/util/log/LayoutDate.d
@@ -78,7 +78,7 @@ unittest
        result.length = 0;
        assumeSafeAppend(result);
 
-       scope dg = (cstring v) { result ~= v; };
+       scope dg = (in cstring v) { result ~= v; };
        scope layout = new LayoutDate(false);
        LogEvent event = {
            msg_: "Have you met Ted?",


### PR DESCRIPTION
This was missed in the previous commit as the CI does not test '-preview=in'.