### PR TITLE
Fix Formatter to handle inout(char) properly

### DIFF
--- a/src/ocean/text/convert/Formatter.d
+++ b/src/ocean/text/convert/Formatter.d
@@ -545,8 +545,7 @@ private void handle (T) (T v, FormatInfo f, scope FormatterSink sf, scope ElemSi
                     || is(typeof((&v)[0 .. 1]) : const(wchar)[])
                     || is(typeof((&v)[0 .. 1]) : const(dchar)[]))
     {
-        Unqual!(T)[3] b = "'_'";
-        b[1] = v;
+        T[3] b = [ '\'', v, '\'' ];
         if (f.flags & Flags.Nested)
             UTF.toString(b, (cstring val) { se(val, f); return val.length; });
         else

--- a/src/ocean/text/convert/Formatter_test.d
+++ b/src/ocean/text/convert/Formatter_test.d
@@ -567,3 +567,12 @@ unittest
     // Used to work only with "{:X}", however this limitation was lifted
     assert(format("{X}", 42) == "2A");
 }
+
+unittest
+{
+    static void myFunc (inout char[] arg)
+    {
+        assert(format("{}", arg[0]) == "H");
+    }
+    myFunc("Hello World");
+}


### PR DESCRIPTION
```
We know this construct doesn't allocate, and avoids the need
for Unqual entirely.
```