### PR TITLE
Deprecate gc_usage, use core.memory directly

### DIFF
--- a/src/ocean/core/Test.d
+++ b/src/ocean/core/Test.d
@@ -321,19 +321,15 @@ unittest
 public void testNoAlloc ( lazy void expr, istring file = __FILE__,
     int line = __LINE__ )
 {
-    size_t used1, free1;
-    ocean.transition.gc_usage(used1, free1);
-
+    auto before = GC.stats();
     expr();
-
-    size_t used2, free2;
-    ocean.transition.gc_usage(used2, free2);
+    auto after = GC.stats();
 
     enforceImpl!(TestException, bool)(
-        used1 == used2 && free1 == free2,
+        before.usedSize == after.usedSize && before.freeSize == after.freeSize,
         format("Expression expected to not allocate but GC usage stats have " ~
                "changed from {} (used) / {} (free) to {} / {}",
-               used1, free1, used2, free2),
+               before.usedSize, before.freeSize, after.usedSize, after.freeSize),
         file,
         line
     );

--- a/src/ocean/core/UnitTestRunner.d
+++ b/src/ocean/core/UnitTestRunner.d
@@ -175,7 +175,7 @@ private class UnitTestRunner
         size_t skipped = 0;
         size_t no_tests = 0;
         size_t no_match = 0;
-        size_t gc_usage_before, gc_usage_after, mem_free;
+        GC.Stats before, after;
         bool collect_gc_usage = !!this.verbose;
 
         if (this.verbose)
@@ -235,7 +235,7 @@ private class UnitTestRunner
             if (collect_gc_usage)
             {
                 GC.collect();
-                ocean.transition.gc_usage(gc_usage_before, mem_free);
+                before = GC.stats();
             }
             switch (this.timedTest(m, t, e))
             {
@@ -243,11 +243,11 @@ private class UnitTestRunner
                     passed++;
                     if (this.verbose)
                     {
-                        ocean.transition.gc_usage(gc_usage_after, mem_free);
+                        after = GC.stats();
                         Stdout.format(" PASS [{}, {} bytes ({} -> {})]",
                                       this.toHumanTime(t),
-                                      cast(long)(gc_usage_after - gc_usage_before),
-                                      gc_usage_before, gc_usage_after);
+                                      cast(long)(after.usedSize - before.usedSize),
+                                      before.usedSize, after.usedSize);
                     }
                     this.xmlAddSuccess(m.name, t);
                     continue;

--- a/src/ocean/io/console/AppStatus.d
+++ b/src/ocean/io/console/AppStatus.d
@@ -908,14 +908,13 @@ public class AppStatus
     public bool getMemoryUsage ( out float mem_allocated, out float mem_free )
     {
         static immutable float Mb = 1024 * 1024;
-        size_t used, free;
-        ocean.transition.gc_usage(used, free);
+        auto stats = GC.stats();
 
-        if (used == 0 && free == 0)
+        if (stats.usedSize == 0 && stats.freeSize == 0)
             return false;
 
-        mem_allocated = cast(float)(used + free) / Mb;
-        mem_free = cast(float)free / Mb;
+        mem_allocated = cast(float)(stats.usedSize + stats.freeSize) / Mb;
+        mem_free = cast(float)stats.freeSize / Mb;
 
         return true;
     }

--- a/src/ocean/transition.d
+++ b/src/ocean/transition.d
@@ -320,25 +320,12 @@ unittest
 
 static import core.memory;
 
-static if (is(typeof(core.memory.GC.stats)))
+deprecated("Use `core.memory : GC.stats` directly")
+void gc_usage ( out size_t used, out size_t free )
 {
-    void gc_usage ( out size_t used, out size_t free )
-    {
-        auto stats = core.memory.GC.stats();
-        used = stats.usedSize;
-        free = stats.freeSize;
-    }
-}
-else static if (is(typeof(core.memory.GC.usage)))
-{
-    alias core.memory.GC.usage gc_usage;
-}
-else
-{
-    void gc_usage ( out size_t used, out size_t free )
-    {
-        // no-op
-    }
+    auto stats = core.memory.GC.stats();
+    used = stats.usedSize;
+    free = stats.freeSize;
 }
 
 /*******************************************************************************


### PR DESCRIPTION
gc_usage is now a pointless wrapper around core.memory : GC.usage,
which is available since v2.072.0 (2016-10-31).