### PR TITLE
Formatter: Support Phobos like OutputRange interface

### DIFF
--- a/src/ocean/text/convert/Formatter.d
+++ b/src/ocean/text/convert/Formatter.d
@@ -464,9 +464,13 @@ private void handle (T) (T v, FormatInfo f, scope FormatterSink sf, scope ElemSi
     // toString hook: Give priority to the non-allocating one
     // Note: sink `toString` overload should take a `scope` delegate
     else static if (is(typeof(v.toString(sf))))
+    {
+        // Some `toString` signatures expect a `ref` sink
+        scope sinkRef = (in cstring e) { se(e, f); };
         nullWrapper(&v,
-                    v.toString((in cstring e) { se(e, f); }),
+                    v.toString(sinkRef),
                     se("null", f));
+    }
     else static if (is(typeof(v.toString()) : cstring))
         nullWrapper(&v, se(v.toString(), f), se("null", f));
     else static if (is(T == interface))

--- a/src/ocean/text/convert/Formatter_test.d
+++ b/src/ocean/text/convert/Formatter_test.d
@@ -576,3 +576,13 @@ unittest
     }
     myFunc("Hello World");
 }
+
+unittest
+{
+    // Some types (e.g. Phobos's `SysTime` take a sink by ref)
+    static struct SysTime
+    {
+        void toString (W) (ref W writer) { writer("Hello World"); }
+    }
+    assert(format("{}", SysTime.init) == "Hello World");
+}


### PR DESCRIPTION
Before this patch, printing a SysTime would fail because we were passing
a literal, which would not implicitly convert to a 'ref'.