### PR TITLE
Prometheus: Reduce duplication of test code and imports

### DIFF
--- a/src/ocean/util/prometheus/collector/Collector.d
+++ b/src/ocean/util/prometheus/collector/Collector.d
@@ -59,6 +59,10 @@
 
 module ocean.util.prometheus.collector.Collector;
 
+version (unittest) import ocean.core.Test;
+import ocean.meta.types.Qualifiers;
+import ocean.util.prometheus.collector.StatFormatter;
+
 /*******************************************************************************
 
     This class provides methods to collect metrics with no label, one label, or
@@ -75,12 +79,6 @@ module ocean.util.prometheus.collector.Collector;
 
 public class Collector
 {
-    import core.stdc.time;
-    import ocean.math.IEEE;
-    import ocean.text.convert.Formatter;
-    import ocean.meta.types.Qualifiers;
-    import StatFormatter = ocean.util.prometheus.collector.StatFormatter;
-
     /// A buffer used for storing collected stats. Is cleared when the `reset`
     /// method is called.
     private mstring collect_buf;
@@ -126,7 +124,7 @@ public class Collector
         static assert (is(ValuesT == struct) || is(ValuesT == class),
             "'values' parameter must be a struct or a class.");
 
-        StatFormatter.formatStats(values, this.collect_buf);
+        formatStats(values, this.collect_buf);
     }
 
     /***************************************************************************
@@ -152,8 +150,7 @@ public class Collector
         static assert (is(ValuesT == struct) || is(ValuesT == class),
             "'values' parameter must be a struct or a class.");
 
-        StatFormatter.formatStats!(LabelName)(values, label_val,
-            this.collect_buf);
+        formatStats!(LabelName)(values, label_val, this.collect_buf);
     }
 
     /***************************************************************************
@@ -180,33 +177,7 @@ public class Collector
         static assert (is(LabelsT == struct) || is(LabelsT == class),
             "'labels' parameter must be a struct or a class.");
 
-        StatFormatter.formatStats(values, labels, this.collect_buf);
-    }
-}
-
-version (unittest)
-{
-    import ocean.core.Test;
-    import ocean.meta.types.Qualifiers;
-
-    struct Statistics
-    {
-        ulong up_time_s;
-        size_t count;
-        float ratio;
-        double fraction;
-        real very_real;
-
-        // The following should not be collected as stats
-        int delegate ( int ) a_delegate;
-        void function ( ) a_function;
-    }
-
-    struct Labels
-    {
-        hash_t id;
-        cstring job;
-        float perf;
+        formatStats(values, labels, this.collect_buf);
     }
 }
 

--- a/src/ocean/util/prometheus/collector/CollectorRegistry.d
+++ b/src/ocean/util/prometheus/collector/CollectorRegistry.d
@@ -15,12 +15,12 @@
 
 module ocean.util.prometheus.collector.CollectorRegistry;
 
+import ocean.meta.types.Qualifiers;
+import ocean.util.prometheus.collector.Collector : Collector;
+
 /// ditto
 public class CollectorRegistry
 {
-    import ocean.meta.types.Qualifiers;
-    import ocean.util.prometheus.collector.Collector : Collector;
-
     /// An alias for the type of delegates that are called for stat collection
     public alias void delegate ( Collector ) CollectionDg;
 
@@ -98,26 +98,8 @@ public class CollectorRegistry
 version (unittest)
 {
     import ocean.core.Test;
-    import ocean.meta.types.Qualifiers;
-    import ocean.util.prometheus.collector.Collector;
 
-    ///
-    public struct Statistics
-    {
-        ulong up_time_s;
-        size_t count;
-        float ratio;
-        double fraction;
-        real very_real;
-    }
-
-    ///
-    public struct Labels
-    {
-        hash_t id;
-        cstring job;
-        float perf;
-    }
+    import ocean.util.prometheus.collector.StatFormatter : Labels, Statistics;
 
     private class ExampleStats
     {

--- a/src/ocean/util/prometheus/collector/StatFormatter.d
+++ b/src/ocean/util/prometheus/collector/StatFormatter.d
@@ -14,12 +14,11 @@
 
 module ocean.util.prometheus.collector.StatFormatter;
 
-import core.stdc.time;
-import ocean.meta.traits.Basic;
-import ocean.meta.codegen.Identifier;
 import ocean.math.IEEE;
-import ocean.text.convert.Formatter;
+import ocean.meta.codegen.Identifier;
+import ocean.meta.traits.Basic;
 import ocean.meta.types.Qualifiers;
+import ocean.text.convert.Formatter;
 
 /*******************************************************************************
 
@@ -303,7 +302,7 @@ version (unittest)
     import ocean.core.Test;
     import ocean.meta.types.Qualifiers;
 
-    struct Statistics
+    package struct Statistics
     {
         ulong up_time_s;
         size_t count;
@@ -312,7 +311,7 @@ version (unittest)
         real very_real;
     }
 
-    struct Labels
+    package struct Labels
     {
         hash_t id;
         cstring job;


### PR DESCRIPTION
The structs definition used in the test code were duplicated three times:
use a single definition. Additionally, a lot of unnecessary imports were
present, most likely because the code was moved from a module to a new one,
and possibly because the code might not have used the Formatter, originally.
The IEEE and time imports can be outright removed, and the SttatFormatter
one was simplified so unittest code wouldn't have to change.