### PR TITLE
LogEvent: Remove 'set' and trivial wrapper, makes the function a POD

### DIFF
--- a/src/ocean/io/console/AppStatus.d
+++ b/src/ocean/io/console/AppStatus.d
@@ -67,6 +67,7 @@ import ocean.io.Stdout;
 import ocean.io.Terminal;
 import ocean.io.model.IConduit;
 import ocean.text.convert.Formatter;
+import ocean.time.Clock;
 import ocean.time.MicrosecondsClock;
 import ocean.transition;
 import ocean.util.container.AppendBuffer;
@@ -842,8 +843,10 @@ public class AppStatus
             return this;
         }
 
-        LogEvent event;
-        event.set(ILogger.Context.init, ILogger.Level.init, this.msg[], "");
+        LogEvent event = {
+            time: Clock.now,
+            msg: this.msg[],
+        };
 
         this.applyDisplayProps(this.current_display_props);
 

--- a/src/ocean/time/Time.d
+++ b/src/ocean/time/Time.d
@@ -152,7 +152,7 @@ struct TimeSpan
         /**
          * Determines whether two TimeSpan values are equal
          */
-        equals_t opEquals(TimeSpan t)
+        public bool opEquals (in TimeSpan t) const scope
         {
                 return this.duration_ == t.duration_;
         }
@@ -160,7 +160,7 @@ struct TimeSpan
         /**
          * Compares this object against another TimeSpan value.
          */
-        public int opCmp ( const typeof(this) rhs ) const
+        public int opCmp (const typeof(this) rhs) const scope
         {
             return this.duration_.opCmp(rhs.duration_);
         }
@@ -174,7 +174,8 @@ struct TimeSpan
          * Returns: A TimeSpan value that is the result of this instance, the
          *          operation, and t.
          */
-        TimeSpan opBinary (string op) (TimeSpan t) if (op == "+" || op == "-")
+        public TimeSpan opBinary (string op) (in TimeSpan t) const scope
+            if (op == "+" || op == "-")
         {
             mixin("return TimeSpan(this.duration_ " ~ op ~ " t.duration_);");
         }
@@ -239,7 +240,8 @@ struct TimeSpan
          *         v = A multiplier or divisor to use for scaling this time span.
          * Returns: A new TimeSpan that is scaled by v
          */
-        TimeSpan opBinary (string op) (long v) if (op == "*" || op == "/")
+        public TimeSpan opBinary (string op) (long v) const scope
+            if (op == "*" || op == "/")
         {
                 mixin("return TimeSpan(duration_ " ~ op ~ " v);");
         }
@@ -289,7 +291,7 @@ struct TimeSpan
          * Returns: The result of integer division between this instance and
          * t.
          */
-        long opBinary (string op) (TimeSpan t) if (op == "/")
+        long opBinary (string op) (in TimeSpan t) const scope if (op == "/")
         {
             return duration_ / t.duration_;
         }
@@ -592,9 +594,9 @@ struct Time
 
         **********************************************************************/
 
-        int opEquals (Time t)
+        public bool opEquals (in Time t) const scope
         {
-                return ticks_ is t.ticks_;
+            return this.ticks_ is t.ticks_;
         }
 
         /**********************************************************************
@@ -603,15 +605,15 @@ struct Time
 
         **********************************************************************/
 
-        int opCmp (Time t)
+        public int opCmp (Time t) const scope
         {
-                if (ticks_ < t.ticks_)
-                    return -1;
+            if (this.ticks_ < t.ticks_)
+                return -1;
 
-                if (ticks_ > t.ticks_)
-                    return 1;
+            if (this.ticks_ > t.ticks_)
+                return 1;
 
-                return 0;
+            return 0;
         }
 
         /**********************************************************************
@@ -626,7 +628,8 @@ struct Time
 
         **********************************************************************/
 
-        Time opBinary (string op) (TimeSpan t) if (op == "+" || op == "-")
+        Time opBinary (string op) (in TimeSpan t) const scope
+            if (op == "+" || op == "-")
         {
             mixin("return Time(ticks_ " ~ op ~ " t.duration_.total!`hnsecs`);");
         }
@@ -695,9 +698,10 @@ struct Time
 
         **********************************************************************/
 
-        TimeSpan opBinary (string op) (Time t) if (op == "-")
+        public TimeSpan opBinary (string op) (in Time t) const scope
+            if (op == "-")
         {
-            return TimeSpan((ticks - t.ticks_).dur!"hnsecs");
+            return TimeSpan((ticks_ - t.ticks_).dur!"hnsecs");
         }
 
         unittest

--- a/src/ocean/util/log/AppendSysLog.d
+++ b/src/ocean/util/log/AppendSysLog.d
@@ -68,7 +68,7 @@ public class AppendSysLog : Appender
             dg("[");
             dg(event.name);
             dg("] - ");
-            dg(event.toString);
+            dg(event.msg);
         }
     }
 

--- a/src/ocean/util/log/Appender.d
+++ b/src/ocean/util/log/Appender.d
@@ -296,8 +296,9 @@ public class LayoutTimer : Appender.Layout
 
     public override void format (LogEvent event, scope FormatterSink dg)
     {
-        sformat(dg, "{} {} [{}] {}- {}", event.span.millis(), event.levelName,
-            event.name, event.host.label, event);
+        sformat(dg, "{} {} [{}] {}- {}", event.span.millis(),
+            ILogger.convert(event.level),
+            event.name, event.host.label, event.msg);
     }
 }
 
@@ -310,11 +311,11 @@ unittest
        scope dg = (in cstring v) { result ~= v; };
        scope layout = new LayoutTimer();
        LogEvent event = {
-           msg_: "Have you met Ted?",
-           name_: "Barney",
-           time_: Clock.startTime() + TimeSpan.fromMillis(420),
-           level_: ILogger.Level.Warn,
-           host_: new HierarchyT!(Logger)("test"),
+           msg: "Have you met Ted?",
+           name: "Barney",
+           time: Clock.startTime() + TimeSpan.fromMillis(420),
+           level: ILogger.Level.Warn,
+           host: new HierarchyT!(Logger)("test"),
        };
 
        testNoAlloc(layout.format(event, dg));

--- a/src/ocean/util/log/Config.d
+++ b/src/ocean/util/log/Config.d
@@ -546,7 +546,7 @@ unittest
 
         final override public void append (LogEvent event)
         {
-            copy(this.latest_log_msg, event.toString());
+            copy(this.latest_log_msg, event.msg);
         }
 
         final override public Mask mask () { return this.mask_; }

--- a/src/ocean/util/log/Event.d
+++ b/src/ocean/util/log/Event.d
@@ -23,69 +23,30 @@
 
 module ocean.util.log.Event;
 
-import ocean.meta.types.Qualifiers;
-import ocean.core.Verify;
 import ocean.time.Clock;
 import ocean.util.log.ILogger;
 
 ///
 public struct LogEvent
 {
-    private cstring         msg_, name_;
-    private Time            time_;
-    private ILogger.Level   level_;
-    private ILogger.Context host_;
+    /// Level at which this even happened
+    public ILogger.Level   level;
 
-    /// Set the various attributes of this event.
-    void set (ILogger.Context host, ILogger.Level level, cstring msg, cstring name)
-    {
-        time_ = Clock.now;
-        level_ = level;
-        host_ = host;
-        name_ = name;
-        msg_ = msg;
-    }
+    /// Name of the logger emitting this event
+    public const(char)[]   name;
 
-    /// Return the message attached to this event.
-    cstring toString ()
-    {
-        return msg_;
-    }
+    /// Host of the Logger emitting this event
+    public ILogger.Context host;
 
-    /// Return the name of the logger which produced this event
-    cstring name ()
-    {
-        return name_;
-    }
+    /// Time at which this event was recorded
+    public Time            time;
 
-    /// Return the logger level of this event.
-    ILogger.Level level ()
-    {
-        return level_;
-    }
+    /// Message emitted
+    public const(char)[]   msg;
 
-    /// Return the hierarchy where the event was produced from
-    ILogger.Context host ()
+    /// Returns: The difference between the program start time and the event time
+    public TimeSpan span () const scope
     {
-        return host_;
-    }
-
-    /// Return the time this event was produced,
-    /// relative to the start of this executable
-    TimeSpan span ()
-    {
-        return time_ - Clock.startTime();
-    }
-
-    /// Return the time this event was produced relative to Epoch
-    Time time ()
-    {
-        return time_;
-    }
-
-    /// Return the logger level name of this event.
-    cstring levelName ()
-    {
-        return ILogger.convert(this.level_);
+        return this.time - Clock.startTime();
     }
 }

--- a/src/ocean/util/log/Logger.d
+++ b/src/ocean/util/log/Logger.d
@@ -826,10 +826,13 @@ public final class Logger : ILogger
     {
         if (host_.context.enabled (level_, level))
         {
-            LogEvent event;
-
-            // set the event attributes and append it
-            event.set(host_, level, exp, name.length ? name_[0..$-1] : "root");
+            LogEvent event = {
+                level: level,
+                name: name.length ? name_[0..$-1] : "root",
+                host: host_,
+                time: Clock.now,
+                msg: exp,
+            };
             this.append(event);
         }
         return this;
@@ -1010,7 +1013,7 @@ unittest
         public override string name () { return "BufferAppender"; }
         public override void append (LogEvent e)
         {
-            this.result ~= Event(e.level, e.toString());
+            this.result ~= Event(e.level, e.msg);
         }
     }
 
@@ -1046,7 +1049,7 @@ unittest
         public override void append (LogEvent e)
         {
             assert(this.index < this.buffers.length);
-            auto str =snformat(this.buffers[this.index].buffer, "{}", e.toString());
+            auto str = snformat(this.buffers[this.index].buffer, "{}", e.msg);
             this.buffers[this.index].message = str;
             this.buffers[this.index++].level = e.level;
         }

--- a/src/ocean/util/log/layout/Date.d
+++ b/src/ocean/util/log/layout/Date.d
@@ -23,11 +23,11 @@ import ocean.time.Clock;
 import ocean.time.WallClock;
 import ocean.util.log.Appender;
 import ocean.util.log.Event;
+import ocean.util.log.ILogger;
 
 version (unittest)
 {
     import ocean.core.Test;
-    import ocean.util.log.ILogger;
 }
 
 /*******************************************************************************
@@ -68,7 +68,7 @@ public class LayoutDate : Appender.Layout
         sformat(dg, "{u4}-{u2}-{u2} {u2}:{u2}:{u2},{u2} {} [{}] - {}",
             dt.date.year, dt.date.month, dt.date.day,
             dt.time.hours, dt.time.minutes, dt.time.seconds, dt.time.millis,
-            event.levelName, event.name, event);
+            ILogger.convert(event.level), event.name, event.msg);
     }
 }
 
@@ -81,11 +81,11 @@ unittest
        scope dg = (in cstring v) { result ~= v; };
        scope layout = new LayoutDate(false);
        LogEvent event = {
-           msg_: "Have you met Ted?",
-               name_: "Barney",
-               time_: Time.fromUnixTime(1525048962) + TimeSpan.fromMillis(420),
-               level_: ILogger.Level.Warn,
-               host_: null,
+           msg: "Have you met Ted?",
+           name: "Barney",
+           time: Time.fromUnixTime(1525048962) + TimeSpan.fromMillis(420),
+           level: ILogger.Level.Warn,
+           host: null,
        };
 
        testNoAlloc(layout.format(event, dg));

--- a/src/ocean/util/log/layout/LayoutMessageOnly.d
+++ b/src/ocean/util/log/layout/LayoutMessageOnly.d
@@ -33,6 +33,6 @@ public class LayoutMessageOnly : Appender.Layout
 
     public override void format (LogEvent event, scope FormatterSink dg)
     {
-        dg(event.toString);
+        dg(event.msg);
     }
 }

--- a/src/ocean/util/log/layout/LayoutSimple.d
+++ b/src/ocean/util/log/layout/LayoutSimple.d
@@ -19,11 +19,11 @@ import ocean.text.convert.Formatter;
 import ocean.meta.types.Qualifiers;
 import ocean.util.log.Appender;
 import ocean.util.log.Event;
+import ocean.util.log.ILogger;
 
 version (unittest)
 {
     import ocean.core.Test;
-    import ocean.util.log.ILogger;
 }
 
 /*******************************************************************************
@@ -68,7 +68,7 @@ public class LayoutSimple : Appender.Layout
 
     public override void format (LogEvent event, scope FormatterSink dg)
     {
-        sformat(dg, "{} [{}] - {}", event.levelName, event.name, event);
+        sformat(dg, "{} [{}] - {}", ILogger.convert(event.level), event.name, event.msg);
     }
 }
 
@@ -81,9 +81,9 @@ unittest
     scope dg = (cstring v) { result ~= v; };
     scope layout = new LayoutSimple();
     LogEvent event = {
-        msg_: "Have you met Ted?",
-        name_: "Barney",
-        level_: ILogger.Level.Warn,
+        msg: "Have you met Ted?",
+        name: "Barney",
+        level: ILogger.Level.Warn,
     };
 
     testNoAlloc(layout.format(event, dg));

--- a/src/ocean/util/log/layout/LayoutStatsLog.d
+++ b/src/ocean/util/log/layout/LayoutStatsLog.d
@@ -71,7 +71,7 @@ public class LayoutStatsLog : Appender.Layout
         sformat(dg, "{u4}-{u2}-{u2} {u2}:{u2}:{u2},{u3} {}",
             dt.date.year, dt.date.month, dt.date.day,
             dt.time.hours, dt.time.minutes, dt.time.seconds, dt.time.millis,
-            event);
+            event.msg);
     }
 }
 
@@ -84,11 +84,11 @@ unittest
     scope dg = (cstring v) { result ~= v; };
     scope layout = new LayoutStatsLog(false);
     LogEvent event = {
-        msg_: "Baguette: 420, Radler: +Inf",
-        name_: "Irrelevant",
-        time_: Time.fromUnixTime(1525048962) + TimeSpan.fromMillis(42),
-        level_: ILogger.Level.Warn,
-        host_: null,
+        msg: "Baguette: 420, Radler: +Inf",
+        name: "Irrelevant",
+        time: Time.fromUnixTime(1525048962) + TimeSpan.fromMillis(42),
+        level: ILogger.Level.Warn,
+        host: null,
     };
 
     testNoAlloc(layout.format(event, dg));


### PR DESCRIPTION
The functions were trivial wrapper with little benefit,
as they were unattributed, they prevented usage in safe/nothrow/etc contexts.
The only advantage they had was to make the structure read-only,
but that can be achieved by making it const.