### PR TITLE
Make SignalFD.registered_signals const

### DIFF
--- a/integrationtest/signalfd/main.d
+++ b/integrationtest/signalfd/main.d
@@ -131,7 +131,7 @@ private class SignalFDTest
 
     ***************************************************************************/
 
-    private int[] handled_signals ( )
+    private const(int)[] handled_signals () const
     {
         return this.signal_fd.registered_signals;
     }

--- a/src/ocean/sys/SignalFD.d
+++ b/src/ocean/sys/SignalFD.d
@@ -332,15 +332,14 @@ public class SignalFD : ISelectable
 
     /***************************************************************************
 
-        Getter for the list of registered signals. Changing the contents of the
-        returned array may lead to undefined behaviour.
+        Getter for the list of registered signals.
 
         Returns:
             list of signals which are registered to be handled by this fd
 
     ***************************************************************************/
 
-    public int[] registered_signals ( )
+    public const(int)[] registered_signals () const
     {
         return this.signals;
     }


### PR DESCRIPTION
There is no reason to allow undefined behavior.