### PR TITLE
Add support for OpenSSL 3

### DIFF
--- a/src/ocean/net/ssl/openssl/OpenSsl.d
+++ b/src/ocean/net/ssl/openssl/OpenSsl.d
@@ -526,8 +526,13 @@ public void X509_free (X509* a);
 
 *******************************************************************************/
 
-public X509* SSL_get_peer_certificate (const(SSL)* s);
-
+version (Ocean_OpenSSL3)
+{
+    public X509* SSL_get1_peer_certificate (const(SSL)* s);
+    public alias SSL_get_peer_certificate = SSL_get1_peer_certificate;
+}
+else
+    public X509* SSL_get_peer_certificate (const(SSL)* s);
 
 /*******************************************************************************
 


### PR DESCRIPTION
OpenSSL3 broke the ABI (again) and provided a macro for source-level compatibility. This is a quick fix allowing users on Ubuntu 22 and other OpenSSL3 users to use Ocean.