### PR TITLE
Remove the use of 'in' for extern(C) func params

### DIFF
--- a/src/ocean/io/compress/lzo/c/lzo1x.d
+++ b/src/ocean/io/compress/lzo/c/lzo1x.d
@@ -29,20 +29,18 @@ public import ocean.io.compress.lzo.c.lzoconf;
 
 extern (C)
 {
-
     /// See original documentation for details.
-    LzoStatus lzo1x_1_compress ( in ubyte* src, size_t src_len,
+    LzoStatus lzo1x_1_compress ( scope const(ubyte)* src, size_t src_len,
                                  ubyte* dst, size_t * dst_len,
                                  void* wrkmem );
 
     /// See original documentation for details.
-    LzoStatus lzo1x_decompress ( in ubyte* src, size_t src_len,
+    LzoStatus lzo1x_decompress ( scope const(ubyte)* src, size_t src_len,
                            ubyte* dst, size_t* dst_len,
                            void* wrkmem = null /* NOT USED */ );
 
     /// See original documentation for details.
-    LzoStatus lzo1x_decompress_safe ( in ubyte* src, size_t src_len,
+    LzoStatus lzo1x_decompress_safe ( scope const(ubyte)* src, size_t src_len,
                                 ubyte* dst, size_t* dst_len,
                                 void* wrkmem = null /* NOT USED */ );
-
 }

--- a/src/ocean/io/compress/lzo/c/lzoconf.d
+++ b/src/ocean/io/compress/lzo/c/lzoconf.d
@@ -174,7 +174,7 @@ extern (C)
 
     **************************************************************************/
 
-    uint lzo_crc32   ( uint _c, in ubyte* _buf, uint _len );
+    uint lzo_crc32 (uint _c, scope const(ubyte)* _buf, uint _len);
 
     /**************************************************************************
 
@@ -255,4 +255,3 @@ uint lzo_crc32_init ( )
 {
     return lzo_crc32(0, null, 0);
 }
-

--- a/src/ocean/stdc/gnu/string.d
+++ b/src/ocean/stdc/gnu/string.d
@@ -22,11 +22,11 @@ public import core.sys.linux.string : memmem;
 
 extern (C):
 
-size_t   wcsnlen(in wchar_t* ws, size_t maxlen);
+size_t   wcsnlen(scope const(wchar_t)* ws, size_t maxlen);
 void*    mempcpy(void* to, void *from, size_t size);
 wchar_t* wmempcpy(wchar_t* wto, wchar_t* wfrom, size_t size);
-wchar_t* wcsdup (in wchar_t* ws);
-int      strverscmp(in char* s1, in char* s2);
+wchar_t* wcsdup (scope const(wchar_t)* ws);
+int      strverscmp(scope const(char)* s1, scope const(char)* s2);
 inout(void)* rawmemchr(inout(void)* block, int c);
 inout(void)* memrchr(inout(void)* block, int c, size_t size);
 inout(char)* strchrnul(inout(char)* str, int c);

--- a/src/ocean/sys/HomeFolder.d
+++ b/src/ocean/sys/HomeFolder.d
@@ -30,11 +30,10 @@ import ocean.sys.Environment;
 version (unittest) import ocean.core.Test;
 
 import core.exception : onOutOfMemoryError;
-import core.stdc.stdlib;
-import core.sys.posix.pwd;
 import core.stdc.errno;
-
-private extern (C) size_t strlen (in char *);
+import core.stdc.stdlib;
+import core.stdc.string;
+import core.sys.posix.pwd;
 
 
 /******************************************************************************


### PR DESCRIPTION
It's forbidden by the D compiler in the presence of '-preview=in'.